### PR TITLE
Fixed time.Duration lint failure

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,7 +1,7 @@
 FROM golang:1.14.3
 ENV GO111MODULE=on
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845
 RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.12.2  # installs the ginkgo CLI
 RUN go get -u github.com/golang/mock/mockgen@v1.4.3

--- a/src/inventory_client/retry_roundtripper.go
+++ b/src/inventory_client/retry_roundtripper.go
@@ -37,7 +37,7 @@ func (rrt RetryRoundTripper) retry(maxTries uint, backoff *backoff.Backoff, fn f
 			if i <= maxTries {
 				delay := backoff.Duration()
 				rrt.log.WithError(err).Warnf("Failed executing HTTP call: %s %s, attempt number %d, Going to retry in: %s",
-					req.Method, req.URL, i, delay.String())
+					req.Method, req.URL, i, delay)
 				time.Sleep(delay)
 			}
 		} else {


### PR DESCRIPTION
"/src/inventory_client/retry_roundtripper.go:23:11: cannot use rrt.delay (variable of type time.Duration) as time.Duration value in struct literal"


https://github.com/golangci/golangci-lint/issues/995