### PR TITLE
Accept proxy settings in install command

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -142,7 +142,8 @@ func (c *controller) ApproveCsrs(done <-chan bool, wg *sync.WaitGroup) {
 }
 
 func (c controller) approveCsrs(csrs *v1beta1.CertificateSigningRequestList) {
-	for _, csr := range csrs.Items {
+	for i := range csrs.Items {
+		csr := csrs.Items[i]
 		if !isCsrApproved(&csr) {
 			c.log.Infof("Approving csr %s", csr.Name)
 			// We can fail and it is ok, we will retry on the next time
@@ -210,7 +211,8 @@ func (c controller) UpdateBMHs(wg *sync.WaitGroup) {
 
 func (c controller) updateBMHStatus(bmhList metal3v1alpha1.BareMetalHostList) bool {
 	allUpdated := true
-	for _, bmh := range bmhList.Items {
+	for i := range bmhList.Items {
+		bmh := bmhList.Items[i]
 		c.log.Infof("Checking bmh %s", bmh.Name)
 		annotations := bmh.GetAnnotations()
 		content := []byte(annotations[metal3v1alpha1.StatusAnnotation])

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	PullSecretToken      string
 	SkipCertVerification bool
 	CACertPath           string
+	HTTPProxy            string
+	HTTPSProxy           string
+	NoProxy              string
 }
 
 var GlobalConfig Config
@@ -48,6 +51,9 @@ func ProcessArgs() {
 	flag.UintVar(&ret.InstallationTimeout, "installation-timeout", 120, "Installation timeout in minutes")
 	flag.BoolVar(&ret.SkipCertVerification, "insecure", false, "Do not validate TLS certificate")
 	flag.StringVar(&ret.CACertPath, "cacert", "", "Path to custom CA certificate in PEM format")
+	flag.StringVar(&ret.HTTPProxy, "http-proxy", "", "A proxy URL to use for creating HTTP connections outside the cluster")
+	flag.StringVar(&ret.HTTPSProxy, "https-proxy", "", "A proxy URL to use for creating HTTPS connections outside the cluster")
+	flag.StringVar(&ret.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if h != nil && *h {

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -153,6 +153,7 @@ func (o *ops) ExtractFromIgnition(ignitionPath string, fileToExtract string) err
 
 	tmpFile := "/opt/extracted_from_ignition.json"
 	o.log.Infof("Writing extracted content to tmp file %s", tmpFile)
+	// #nosec
 	err = ioutil.WriteFile(tmpFile, extractedContent, 0644)
 	if err != nil {
 		o.log.Errorf("Error occurred while writing extracted content to %s", tmpFile)
@@ -278,6 +279,7 @@ func (o *ops) renderDeploymentFiles(srcTemplate string, params map[string]string
 
 	renderedControllerYaml := filepath.Join(manifestsFolder, dest)
 	o.log.Infof("Writing rendered data to %s", renderedControllerYaml)
+	// #nosec
 	if err = ioutil.WriteFile(renderedControllerYaml, buf.Bytes(), 0644); err != nil {
 		o.log.Errorf("Error occurred while trying to write rendered data to %s : %e", renderedControllerYaml, err)
 		return err


### PR DESCRIPTION
On D/S image, nsenter is being executed without environment variables,
therefore no proxy configuration are enabled to 'coreos-installer'
command which attempt to download a resource.
    
While the issue isn't happened to commands running on 'bash' image used
for U/S assisted-installer image, D/S image uses ubi8-minimal which
behaves differently and requires the env-vars to be provided explicitly
(assuming we'd like to avoid hacking the process id of the agent in
order to inherit the already-provided env-vars for proxy from it).
    
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1877757
Signed-off-by: Moti Asayag <masayag@redhat.com>