### PR TITLE
WIP/On-Hold: Set etc/hosts file to resolve dnsname

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -8,7 +8,11 @@ spec:
     metadata:
       labels:
         app: assisted-installer-controller
-    spec:
+    spec:{{if .AssistedServiceIPs}}
+      hostAliases:{{range .AssistedServiceIPs}} 
+        - ip: "{{.}}"
+          hostnames:
+            - "assisted-api.local.openshift.io"{{end}}{{end}}
       containers:
         - name: assisted-installer-controller
           image: {{.ControllerImage}}

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tT
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
+github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
@@ -249,9 +250,11 @@ github.com/docker/docker v0.7.3-0.20190817195342-4760db040282/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce h1:KXS1Jg+ddGcWA8e1N7cupxaHHZhit5rB9tfDU+mfjyY=
 github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	HTTPProxy            string
 	HTTPSProxy           string
 	NoProxy              string
+	ServiceIPs           string
 }
 
 var GlobalConfig Config
@@ -54,6 +55,7 @@ func ProcessArgs() {
 	flag.StringVar(&ret.HTTPProxy, "http-proxy", "", "A proxy URL to use for creating HTTP connections outside the cluster")
 	flag.StringVar(&ret.HTTPSProxy, "https-proxy", "", "A proxy URL to use for creating HTTPS connections outside the cluster")
 	flag.StringVar(&ret.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")
+	flag.StringVar(&ret.ServiceIPs, "assisted-service-ips", "", "All IPs of assisted service node")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if h != nil && *h {

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/openshift/assisted-installer/src/common"
 
@@ -426,5 +427,10 @@ func (i *installer) setEtcHostInIgnition(ignitionPath string) error {
 		i.log.Infof("No IPs to set, continuing")
 		return nil
 	}
-	return i.ops.SetFileInIgnition(ignitionPath, "/etc/hosts", fmt.Sprintf("data:,%s", dataurl.EncodeBytes([]byte(serviceIPs))), 420)
+	ips := strings.Split(serviceIPs, " ")
+	content := ""
+	for _, ip := range ips {
+		content = content + fmt.Sprintf(ip+" assisted-api.local.openshift.io\n")
+	}
+	return i.ops.SetFileInIgnition(ignitionPath, "/etc/hosts", dataurl.EncodeBytes([]byte(content)), 420)
 }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/openshift/assisted-installer-agent/pkg/journalLogger"
+	"github.com/openshift/assisted-installer/src/config"
 
 	ignition "github.com/coreos/ignition/v2/config/v3_1"
 	"github.com/coreos/ignition/v2/config/v3_1/types"
@@ -93,6 +94,14 @@ func SetFileInIgnition(ignitionData []byte, filePath, fileContents string, mode 
 			},
 			Mode: &mode,
 		},
+	}
+	if config.GlobalConfig.ServiceIPs != "" && filePath == "/etc/hosts" {
+		file.FileEmbedded1.Append = []types.Resource{
+			{
+				Source: &fileContents,
+			},
+		}
+		file.FileEmbedded1.Contents = types.Resource{}
 	}
 	bm.Storage.Files = append(bm.Storage.Files, file)
 	return json.Marshal(bm)


### PR DESCRIPTION
Assisted service sets a custom dns name for service base url for onprem use by adding all the ips of the assisted service node's into /etc/hosts file of the agent machines. Once the agent machine reboots during the cluster installation, the entries in etc/hosts file on agent nodes are lost. This fix adds the required entries back into the agent's etc/host file via ignition config.