### PR TITLE
OCPBUGSM-17295 Implement Proxy function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/thoas/go-funk v0.6.0
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -55,7 +55,8 @@ type HostData struct {
 	Host      *models.Host
 }
 
-func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string, logger *logrus.Logger) (*inventoryClient, error) {
+func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,
+	logger *logrus.Logger, proxyFunc func(*http.Request) (*url.URL, error)) (*inventoryClient, error) {
 	clientConfig := client.Config{}
 	var err error
 	clientConfig.URL, err = url.ParseRequestURI(createUrl(inventoryURL))
@@ -74,7 +75,7 @@ func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret str
 	}
 
 	transport := requestid.Transport(&http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxyFunc,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/src/inventory_client/retry_roundtripper.go
+++ b/src/inventory_client/retry_roundtripper.go
@@ -2,6 +2,7 @@ package inventory_client
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -36,8 +37,8 @@ func (rrt RetryRoundTripper) retry(maxTries uint, backoff *backoff.Backoff, fn f
 		if err != nil {
 			if i <= maxTries {
 				delay := backoff.Duration()
-				rrt.log.WithError(err).Warnf("Failed executing HTTP call: %s %s, attempt number %d, Going to retry in: %s",
-					req.Method, req.URL, i, delay)
+				rrt.log.WithError(err).Warnf("Failed executing HTTP call: %s %s, attempt number %d, Going to retry in: %s, request sent with: HTTP_PROXY: %s, http_proxy: %s, HTTPS_PROXY: %s, https_proxy: %s, NO_PROXY: %s, no_proxy: %s",
+					req.Method, req.URL, i, delay, os.Getenv("HTTP_PROXY"), os.Getenv("http_proxy"), os.Getenv("HTTPS_PROXY"), os.Getenv("https_proxy"), os.Getenv("NO_PROXY"), os.Getenv("no_proxy"))
 				time.Sleep(delay)
 			}
 		} else {

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"log"
+	"net/http"
+	"net/url"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/openshift/assisted-installer/src/k8s_client"
+	"golang.org/x/net/http/httpproxy"
 
 	"github.com/kelseyhightower/envconfig"
 	assistedinstallercontroller "github.com/openshift/assisted-installer/src/assisted_installer_controller"
@@ -17,6 +21,11 @@ import (
 var Options struct {
 	ControllerConfig assistedinstallercontroller.ControllerConfig
 }
+
+var (
+	envProxyOnce          sync.Once
+	envVarsProxyFuncValue func(*url.URL) (*url.URL, error)
+)
 
 func main() {
 	logger := logrus.New()
@@ -39,7 +48,9 @@ func main() {
 		log.Fatalf("Failed to set env vars for installer-controller pod %v", err)
 	}
 
-	client, err := inventory_client.CreateInventoryClient(Options.ControllerConfig.ClusterID, Options.ControllerConfig.URL, Options.ControllerConfig.PullSecretToken, Options.ControllerConfig.SkipCertVerification, Options.ControllerConfig.CACertPath, logger)
+	client, err := inventory_client.CreateInventoryClient(Options.ControllerConfig.ClusterID,
+		Options.ControllerConfig.URL, Options.ControllerConfig.PullSecretToken, Options.ControllerConfig.SkipCertVerification,
+		Options.ControllerConfig.CACertPath, logger, ProxyFromEnvVars)
 	if err != nil {
 		log.Fatalf("Failed to create inventory client %v", err)
 	}
@@ -68,4 +79,27 @@ func main() {
 	done <- true
 	logger.Infof("Waiting fo all go routines to finish")
 	wg.Wait()
+}
+
+// ProxyFromEnvVars provides an alternative to http.ProxyFromEnvironment since it is being initialized only
+// once and that happens by k8s before proxy settings was obtained. While this is no issue for k8s, it prevents
+// any out-of-cluster traffic from using the proxy
+func ProxyFromEnvVars(req *http.Request) (*url.URL, error) {
+	return envVarsProxyFunc()(req.URL)
+}
+
+func envVarsProxyFunc() func(*url.URL) (*url.URL, error) {
+	envProxyOnce.Do(func() {
+		envVarsProxyFuncValue = FromEnvVars().ProxyFunc()
+	})
+	return envVarsProxyFuncValue
+}
+
+func FromEnvVars() *httpproxy.Config {
+	return &httpproxy.Config{
+		HTTPProxy:  os.Getenv("HTTP_PROXY"),
+		HTTPSProxy: os.Getenv("HTTPS_PROXY"),
+		NoProxy:    os.Getenv("NO_PROXY"),
+		CGI:        os.Getenv("REQUEST_METHOD") != "",
+	}
 }

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/openshift/assisted-installer/src/config"
@@ -21,7 +22,8 @@ func main() {
 	}
 
 	logger.Infof("Assisted installer started. Configuration is:\n %+v", config.GlobalConfig)
-	client, err := inventory_client.CreateInventoryClient(config.GlobalConfig.ClusterID, config.GlobalConfig.URL, config.GlobalConfig.PullSecretToken, config.GlobalConfig.SkipCertVerification, config.GlobalConfig.CACertPath, logger)
+	client, err := inventory_client.CreateInventoryClient(config.GlobalConfig.ClusterID, config.GlobalConfig.URL,
+		config.GlobalConfig.PullSecretToken, config.GlobalConfig.SkipCertVerification, config.GlobalConfig.CACertPath, logger, http.ProxyFromEnvironment)
 	if err != nil {
 		logger.Fatalf("Failed to create inventory client %e", err)
 	}


### PR DESCRIPTION
ProxyFromEnvVars provides an alternative to http.ProxyFromEnvironment
since it is being initialized only once and that happens by k8s before
proxy settings was obtained from the cluster.
While this is no issue for k8s client, it prevents any out-of-cluster
traffic from using the proxy.

By providing implementation of that method, we allow to use env-vars
set for the pod based on the cluster-wide-proxy.

Signed-off-by: Moti Asayag <masayag@redhat.com>