### PR TITLE
MGMT-2694 Add additional args to coreos-installer command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v12.0.0+incompatible

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"os"
 
@@ -28,6 +29,7 @@ type Config struct {
 	HTTPSProxy           string
 	NoProxy              string
 	ServiceIPs           string
+	InstallerArgs        []string
 }
 
 var GlobalConfig Config
@@ -59,6 +61,10 @@ func ProcessArgs() {
 	flag.StringVar(&ret.HTTPSProxy, "https-proxy", "", "A proxy URL to use for creating HTTPS connections outside the cluster")
 	flag.StringVar(&ret.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")
 	flag.StringVar(&ret.ServiceIPs, "service-ips", "", "All IPs of assisted service node")
+
+	var installerArgs string
+	flag.StringVar(&installerArgs, "installer-args", "", "JSON array of additional coreos-installer arguments")
+
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if ret.NoProxy != "" {
@@ -66,5 +72,13 @@ func ProcessArgs() {
 	}
 	if h != nil && *h {
 		printHelpAndExit()
+	}
+
+	if installerArgs != "" {
+		err := json.Unmarshal([]byte(installerArgs), &ret.InstallerArgs)
+		if err != nil {
+			println(err.Error())
+			printHelpAndExit()
+		}
 	}
 }

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -107,7 +107,7 @@ func (i *installer) InstallNode() error {
 	i.UpdateHostInstallProgress(models.HostStageWritingImageToDisk, "")
 
 	err = utils.Retry(3, time.Second, i.log, func() error {
-		return i.ops.WriteImageToDisk(ignitionPath, i.Device, i.inventoryClient)
+		return i.ops.WriteImageToDisk(ignitionPath, i.Device, i.inventoryClient, i.Config.InstallerArgs)
 	})
 	if err != nil {
 		i.log.Errorf("Failed to write image to disk %s", err)

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -78,7 +78,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	}
 
 	writeToDiskSuccess := func() {
-		mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient).Return(nil).Times(1)
+		mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient, nil).Return(nil).Times(1)
 	}
 
 	uploadLogsSuccess := func(bootstrap bool) {
@@ -439,7 +439,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mkdirSuccess()
 			downloadHostIgnitionSuccess(hostId, "master-host-id.ign")
 			err := fmt.Errorf("failed to write image to disk")
-			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient).Return(err).Times(3)
+			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient, nil).Return(err).Times(3)
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(fmt.Errorf("failed after 3 attempts, last error: failed to write image to disk")))
 		})
@@ -480,7 +480,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDevice()
 			mkdirSuccess()
 			downloadHostIgnitionSuccess(hostId, "worker-host-id.ign")
-			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "worker-host-id.ign"), device, mockbmclient).Return(nil).Times(1)
+			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "worker-host-id.ign"), device, mockbmclient, nil).Return(nil).Times(1)
 			// failure must do nothing
 			mockops.EXPECT().UploadInstallationLogs(false).Return("", errors.Errorf("Dummy")).Times(1)
 			rebootSuccess()

--- a/src/ops/coreos_installer_log_writer_test.go
+++ b/src/ops/coreos_installer_log_writer_test.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"io/ioutil"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/openshift/assisted-installer/src/inventory_client"
@@ -14,11 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
-
-func TestCoreosInstallerLogger(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "installer_test")
-}
 
 var _ = Describe("Verify CoreosInstallerLogger", func() {
 	var (

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -90,17 +90,17 @@ func (mr *MockOpsMockRecorder) Mkdir(dirName interface{}) *gomock.Call {
 }
 
 // WriteImageToDisk mocks base method
-func (m *MockOps) WriteImageToDisk(ignitionPath, device string, progressReporter inventory_client.InventoryClient) error {
+func (m *MockOps) WriteImageToDisk(ignitionPath, device string, progressReporter inventory_client.InventoryClient, extra []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, progressReporter)
+	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, progressReporter, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteImageToDisk indicates an expected call of WriteImageToDisk
-func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, progressReporter interface{}) *gomock.Call {
+func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, progressReporter, extra interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, progressReporter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, progressReporter, extra)
 }
 
 // Reboot mocks base method

--- a/src/ops/ops_suite_test.go
+++ b/src/ops/ops_suite_test.go
@@ -1,0 +1,13 @@
+package ops_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOps(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ops_test")
+}

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -64,3 +64,31 @@ F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: er
 		})
 	}
 }
+
+// TODO: reconcile testing frameworks
+/*
+var _ = Describe("installerArgs", func() {
+	var (
+		device       = "/dev/sda"
+		ignitionPath = "/tmp/ignition.ign"
+	)
+
+	It("Returns the correct list with no extra args", func() {
+		args := installerArgs(ignitionPath, device, nil)
+		expected := []string{"install", "--insecure", "-i", "/tmp/ignition.ign", "/dev/sda"}
+		Expect(args).To(Equal(expected))
+	})
+
+	It("Returns the correct list with empty extra args", func() {
+		args := installerArgs(ignitionPath, device, []string{})
+		expected := []string{"install", "--insecure", "-i", "/tmp/ignition.ign", "/dev/sda"}
+		Expect(args).To(Equal(expected))
+	})
+
+	It("Returns the correct list with extra args", func() {
+		args := installerArgs(ignitionPath, device, []string{"-n", "--append-karg", "nameserver=8.8.8.8"})
+		expected := []string{"install", "--insecure", "-i", "/tmp/ignition.ign", "-n", "--append-karg", "nameserver=8.8.8.8", "/dev/sda"}
+		Expect(args).To(Equal(expected))
+	})
+})
+*/

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -2,41 +2,39 @@ package ops
 
 import (
 	"fmt"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-func TestExecCommandError(t *testing.T) {
-	tests := []struct {
-		name              string
-		err               *ExecCommandError
-		wantError         string
-		wantDetailedError string
-	}{
-		{
-			name: "mkdir -p",
-			err: &ExecCommandError{
-				Command: "mkdir",
-				Args:    []string{"-p", "/somedir"},
-				Env:     []string{"HOME=/home/userZ"},
-				ExitErr: fmt.Errorf("Permission denied"),
-				Output:  "mkdir: cannot create directory ‘/somedir’: Permission denied",
-			},
-			wantError:         "failed executing mkdir [-p /somedir], Error Permission denied, LastOutput \"mkdir: cannot create directory ‘/somedir’: Permission denied\"",
-			wantDetailedError: "failed executing mkdir [-p /somedir], env vars [HOME=/home/userZ], error Permission denied, waitStatus 0, Output \"mkdir: cannot create directory ‘/somedir’: Permission denied\"",
-		},
-		{
-			name: "extract ignition to disk",
-			err: &ExecCommandError{
-				Command:    "nsenter",
-				Args:       []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot"},
-				Env:        []string{"HOME=/home/userZ"},
-				ExitErr:    fmt.Errorf("exit status 255"),
-				WaitStatus: 255,
-				Output:     "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
-			},
-			wantError: `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], Error exit status 255, LastOutput "... or: Timeout was reached
-F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`,
-			wantDetailedError: `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], env vars [HOME=/home/userZ], error exit status 255, waitStatus 255, Output "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...
+var _ = Describe("ExecCommandError", func() {
+	It("Creates the correct error for mkdir", func() {
+		err := &ExecCommandError{
+			Command: "mkdir",
+			Args:    []string{"-p", "/somedir"},
+			Env:     []string{"HOME=/home/userZ"},
+			ExitErr: fmt.Errorf("Permission denied"),
+			Output:  "mkdir: cannot create directory ‘/somedir’: Permission denied",
+		}
+		wantError := "failed executing mkdir [-p /somedir], Error Permission denied, LastOutput \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
+		wantDetailedError := "failed executing mkdir [-p /somedir], env vars [HOME=/home/userZ], error Permission denied, waitStatus 0, Output \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
+
+		Expect(err.Error()).To(Equal(wantError))
+		Expect(err.DetailedError()).To(Equal(wantDetailedError))
+	})
+
+	It("Creates the correct error for ignition extract", func() {
+		err := &ExecCommandError{
+			Command:    "nsenter",
+			Args:       []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot"},
+			Env:        []string{"HOME=/home/userZ"},
+			ExitErr:    fmt.Errorf("exit status 255"),
+			WaitStatus: 255,
+			Output:     "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
+		}
+		wantError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], Error exit status 255, LastOutput "... or: Timeout was reached
+F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`
+		wantDetailedError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], env vars [HOME=/home/userZ], error exit status 255, waitStatus 255, Output "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...
 Getting image source signatures
 Copying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14
 Copying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457
@@ -50,23 +48,13 @@ I1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d
 I1019 19:03:28.797227 1 start.go:118] Calling chroot("/rootfs")
 I1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json
 error: Timeout was reached
-F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.err.Error(); got != tt.wantError {
-				t.Errorf("Error() got = \n%v\n, want \n%v", got, tt.wantError)
-			}
-			if got := tt.err.DetailedError(); got != tt.wantDetailedError {
-				t.Errorf("DetailedError() got = \n%v\n, want \n%v", got, tt.wantDetailedError)
-			}
-		})
-	}
-}
+F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`
 
-// TODO: reconcile testing frameworks
-/*
+		Expect(err.Error()).To(Equal(wantError))
+		Expect(err.DetailedError()).To(Equal(wantDetailedError))
+	})
+})
+
 var _ = Describe("installerArgs", func() {
 	var (
 		device       = "/dev/sda"
@@ -91,4 +79,3 @@ var _ = Describe("installerArgs", func() {
 		Expect(args).To(Equal(expected))
 	})
 })
-*/


### PR DESCRIPTION
This allows for customizing things like kernel args as well as bringing networking files forward from the previous stage.

[MGMT-2694](https://issues.redhat.com/browse/MGMT-2694)