### PR TITLE
MGMT-2629 PullSecretToken marked secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0-20200326152221-912866ddb162
 	github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a
-	github.com/openshift/assisted-service v1.0.10-0.20201103185959-9fbcf52e8938
+	github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8
 	github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,11 @@ github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnlj
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a h1:mk+JGnFSuRTTWzODLs1gclp5om0+k4lH8btJSJxQA80=
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a/go.mod h1:q1jXr/OgGA7bOBu1uzlZXOjExPHIoAXxzQlifXBmXLY=
 github.com/openshift/assisted-service v0.0.0-20200811075806-62dcbcd62c0b/go.mod h1:H96z5QdPNv7PZ+/p+VafuHyAUqlVcpOFTnfMl8QYzQ4=
+github.com/openshift/assisted-service v1.0.9 h1:dE7h81GFbJC4PC/5XGRP8qOM9tmh64KFHyI1cjTWQsA=
 github.com/openshift/assisted-service v1.0.10-0.20201103185959-9fbcf52e8938 h1:sbhPFKrPUre8v89KBIf8xAfko0KS/r4CKB/xUkWPrLw=
 github.com/openshift/assisted-service v1.0.10-0.20201103185959-9fbcf52e8938/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
+github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8 h1:CN4m36+mD0SRUk/qE7Dr9tIxSD6XXx5XSoPRlqFm0K0=
+github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	ControllerImage      string
 	AgentImage           string
 	InstallationTimeout  uint
-	PullSecretToken      string
+	PullSecretToken      string `secret:"true"`
 	SkipCertVerification bool
 	CACertPath           string
 	HTTPProxy            string

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/secretdump"
 )
 
 func main() {
@@ -21,7 +22,7 @@ func main() {
 		logger.Warnf("Missing Pull Secret Token environment variable")
 	}
 
-	logger.Infof("Assisted installer started. Configuration is:\n %+v", config.GlobalConfig)
+	logger.Infof("Assisted installer started. Configuration is:\n %s", secretdump.DumpSecretStruct(config.GlobalConfig))
 	client, err := inventory_client.CreateInventoryClient(config.GlobalConfig.ClusterID, config.GlobalConfig.URL,
 		config.GlobalConfig.PullSecretToken, config.GlobalConfig.SkipCertVerification, config.GlobalConfig.CACertPath, logger, http.ProxyFromEnvironment)
 	if err != nil {


### PR DESCRIPTION
Recreated https://github.com/openshift/assisted-installer/pull/86 because it wouldn't let me reopen

Same as before, but the dump function moved to assisted-service

Had to run 

```go get github.com/openshift/assisted-service@bb2f4a5dbbd8357716edeacc0ffbc540fa1e1757```

to get the relevant version of assisted-service, I hope it's alright.