### PR TITLE
MGMT-1263: allow overriding the rhcos image url

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	URL                  string
 	Verbose              bool
 	OpenshiftVersion     string
+	RhcosOverrideImage   string
 	Hostname             string
 	ControllerImage      string
 	AgentImage           string
@@ -45,6 +46,7 @@ func ProcessArgs() {
 	flag.StringVar(&ret.Device, "boot-device", "", "The boot device")
 	flag.StringVar(&ret.URL, "url", "", "The BM inventory URL, including a scheme and optionally a port (overrides the host and port arguments")
 	flag.StringVar(&ret.OpenshiftVersion, "openshift-version", "4.4", "Openshift version to install")
+	flag.StringVar(&ret.RhcosOverrideImage, "rhcos-override-image", "", "Override the built-in RHCOS image with this url")
 	flag.StringVar(&ret.Hostname, "host-name", "", "hostname to be set for this node")
 	flag.BoolVar(&ret.Verbose, "verbose", false, "Increase verbosity, set log level to debug")
 	flag.StringVar(&ret.ControllerImage, "controller-image", "quay.io/ocpmetal/assisted-installer-controller:latest",

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -107,7 +107,7 @@ func (i *installer) InstallNode() error {
 	i.UpdateHostInstallProgress(models.HostStageWritingImageToDisk, "")
 
 	err = utils.Retry(3, time.Second, i.log, func() error {
-		return i.ops.WriteImageToDisk(ignitionPath, i.Device, i.inventoryClient)
+		return i.ops.WriteImageToDisk(ignitionPath, i.Device, i.RhcosOverrideImage, i.inventoryClient)
 	})
 	if err != nil {
 		i.log.Errorf("Failed to write image to disk %s", err)

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -47,6 +47,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		hostId             = "host-id"
 		bootstrapIgn       = "bootstrap.ign"
 		openShiftVersion   = "4.4"
+		image              string
 		inventoryNamesHost map[string]inventory_client.HostData
 		kubeNamesIds       map[string]string
 	)
@@ -78,7 +79,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	}
 
 	writeToDiskSuccess := func() {
-		mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient).Return(nil).Times(1)
+		mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, image, mockbmclient).Return(nil).Times(1)
 	}
 
 	uploadLogsSuccess := func(bootstrap bool) {
@@ -439,7 +440,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mkdirSuccess()
 			downloadHostIgnitionSuccess(hostId, "master-host-id.ign")
 			err := fmt.Errorf("failed to write image to disk")
-			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, mockbmclient).Return(err).Times(3)
+			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "master-host-id.ign"), device, image, mockbmclient).Return(err).Times(3)
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(fmt.Errorf("failed after 3 attempts, last error: failed to write image to disk")))
 		})
@@ -480,7 +481,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDevice()
 			mkdirSuccess()
 			downloadHostIgnitionSuccess(hostId, "worker-host-id.ign")
-			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "worker-host-id.ign"), device, mockbmclient).Return(nil).Times(1)
+			mockops.EXPECT().WriteImageToDisk(filepath.Join(InstallDir, "worker-host-id.ign"), device, image, mockbmclient).Return(nil).Times(1)
 			// failure must do nothing
 			mockops.EXPECT().UploadInstallationLogs(false).Return("", errors.Errorf("Dummy")).Times(1)
 			rebootSuccess()

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -90,17 +90,17 @@ func (mr *MockOpsMockRecorder) Mkdir(dirName interface{}) *gomock.Call {
 }
 
 // WriteImageToDisk mocks base method
-func (m *MockOps) WriteImageToDisk(ignitionPath, device string, progressReporter inventory_client.InventoryClient) error {
+func (m *MockOps) WriteImageToDisk(ignitionPath, device, image string, progressReporter inventory_client.InventoryClient) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, progressReporter)
+	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, image, progressReporter)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteImageToDisk indicates an expected call of WriteImageToDisk
-func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, progressReporter interface{}) *gomock.Call {
+func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, image, progressReporter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, progressReporter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, image, progressReporter)
 }
 
 // Reboot mocks base method


### PR DESCRIPTION
This add RhcosOverrideImage to the global config so that a user can override the built-in rhcos image.

Note: [this PR](https://github.com/openshift/assisted-installer/pull/78) could also be used for this purpose