### PR TITLE
MGMT-2634 Remove host-name flag

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	URL                  string
 	Verbose              bool
 	OpenshiftVersion     string
-	Hostname             string
 	ControllerImage      string
 	AgentImage           string
 	InstallationTimeout  uint
@@ -45,7 +44,6 @@ func ProcessArgs() {
 	flag.StringVar(&ret.Device, "boot-device", "", "The boot device")
 	flag.StringVar(&ret.URL, "url", "", "The BM inventory URL, including a scheme and optionally a port (overrides the host and port arguments")
 	flag.StringVar(&ret.OpenshiftVersion, "openshift-version", "4.4", "Openshift version to install")
-	flag.StringVar(&ret.Hostname, "host-name", "", "hostname to be set for this node")
 	flag.BoolVar(&ret.Verbose, "verbose", false, "Increase verbosity, set log level to debug")
 	flag.StringVar(&ret.ControllerImage, "controller-image", "quay.io/ocpmetal/assisted-installer-controller:latest",
 		"Assisted Installer Controller image URL")


### PR DESCRIPTION
This is not used as of 93495e81245278863102d155b15b4d0782641ff4 and is no longer being sent from the service as of openshift/assisted-service#670