### PR TITLE
MGMT-2411: Fixed error format returned from assisted client

### DIFF
--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -176,7 +176,7 @@ func (c *inventoryClient) DownloadFile(ctx context.Context, filename string, des
 		fo.Close()
 	}()
 	_, err = c.ai.Installer.DownloadClusterFiles(ctx, c.createDownloadParams(filename), fo)
-	return err
+	return utils.GetAssistedError(err)
 }
 
 func (c *inventoryClient) DownloadHostIgnition(ctx context.Context, hostID string, dest string) error {
@@ -195,24 +195,24 @@ func (c *inventoryClient) DownloadHostIgnition(ctx context.Context, hostID strin
 		HostID:    strfmt.UUID(hostID),
 	}
 	_, err = c.ai.Installer.DownloadHostIgnition(ctx, &params, fo)
-	return err
+	return utils.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UpdateHostInstallProgress(ctx context.Context, hostId string, newStage models.HostStage, info string) error {
 	_, err := c.ai.Installer.UpdateHostInstallProgress(ctx, c.createUpdateHostInstallProgressParams(hostId, newStage, info))
-	return err
+	return utils.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UploadIngressCa(ctx context.Context, ingressCA string, clusterId string) error {
 	_, err := c.ai.Installer.UploadClusterIngressCert(ctx,
 		&installer.UploadClusterIngressCertParams{ClusterID: strfmt.UUID(clusterId), IngressCertParams: models.IngressCertParams(ingressCA)})
-	return err
+	return utils.GetAssistedError(err)
 }
 
 func (c *inventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
 	cluster, err := c.ai.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: c.clusterId})
 	if err != nil {
-		return nil, err
+		return nil, utils.GetAssistedError(err)
 	}
 
 	return cluster.Payload, nil
@@ -269,7 +269,7 @@ func (c *inventoryClient) getHostsWithInventoryInfo(ctx context.Context, log log
 	hostsWithHwInfo := make(map[string]HostData)
 	hosts, err := c.ai.Installer.ListHosts(ctx, &installer.ListHostsParams{ClusterID: c.clusterId})
 	if err != nil {
-		return nil, err
+		return nil, utils.GetAssistedError(err)
 	}
 	for _, host := range hosts.Payload {
 		if funk.IndexOf(skippedStatuses, *host.Status) > -1 {
@@ -290,7 +290,7 @@ func (c *inventoryClient) CompleteInstallation(ctx context.Context, clusterId st
 	_, err := c.ai.Installer.CompleteInstallation(ctx,
 		&installer.CompleteInstallationParams{ClusterID: strfmt.UUID(clusterId),
 			CompletionParams: &models.CompletionParams{IsSuccess: &isSuccess, ErrorInfo: errorInfo}})
-	return err
+	return utils.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
@@ -298,5 +298,5 @@ func (c *inventoryClient) UploadLogs(ctx context.Context, clusterId string, logs
 	_, err := c.ai.Installer.UploadLogs(ctx,
 		&installer.UploadLogsParams{ClusterID: strfmt.UUID(clusterId), LogsType: string(logsType),
 			Upfile: runtime.NamedReader(fileName, upfile)})
-	return err
+	return utils.GetAssistedError(err)
 }

--- a/src/utils/error_utils.go
+++ b/src/utils/error_utils.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+)
+
+type AssistedServiceErrorAPI interface {
+	Error() string
+	GetPayload() *models.Error
+}
+
+type AssistedServiceError struct {
+	Payload *models.Error
+}
+
+func (err AssistedServiceError) Error() string {
+	return fmt.Sprintf(
+		"AssistedServiceError Code: %s Href: %s ID: %d Kind: %s Reason: %s",
+		swag.StringValue(err.Payload.Code),
+		swag.StringValue(err.Payload.Href),
+		swag.Int32Value(err.Payload.ID),
+		swag.StringValue(err.Payload.Kind),
+		swag.StringValue(err.Payload.Reason))
+}
+
+func (err AssistedServiceError) GetPayload() *models.Error {
+	return err.Payload
+}
+
+type AssistedServiceInfraErrorAPI interface {
+	Error() string
+	GetPayload() *models.InfraError
+}
+
+type AssistedServiceInfraError struct {
+	Payload *models.InfraError
+}
+
+func (err AssistedServiceInfraError) Error() string {
+	return fmt.Sprintf(
+		"AssistedServiceInfraError Code: %d Message: %s",
+		swag.Int32Value(err.Payload.Code),
+		swag.StringValue(err.Payload.Message))
+}
+
+func (err AssistedServiceInfraError) GetPayload() *models.InfraError {
+	return err.Payload
+}
+
+func GetAssistedError(err error) error {
+	switch err := err.(type) {
+	case AssistedServiceErrorAPI:
+		return AssistedServiceError{err.GetPayload()}
+	case AssistedServiceInfraErrorAPI:
+		return AssistedServiceInfraError{err.GetPayload()}
+	default:
+		return err
+	}
+}


### PR DESCRIPTION
Currently due to a bug in assisted-service API, the Error() function
prints memory addresses instead of values.
Fixing the bug in assisted-service side will break backward
compatibility, therefore the fix should be made here.

Before logging the error, try to convert it to one of assisted
service Error or InfraError errors, and build the message from
the payload.

See an example of the bad error format:
Oct 09 04:43:36 localhost installer[182675]: time="2020-10-09T04:43:36Z" level=error msg="Failed to fetch file (worker.ign) from server. err: [GET /clusters/{cluster_id}/downloads/files][409] downloadClusterFilesConflict  &{Code:0xc00038aa70 Href:0xc00038aa80 ID:0xc000541e04 Kind:0xc00038aa90 Reason:0xc00038aaa0}"

Oct 09 04:43:36 localhost installer[182675]: time="2020-10-09T04:43:36Z" level=info msg="Updating node installation stage: Failed - [GET /clusters/{cluster_id}/downloads/files][409] downloadClusterFilesConflict  &{Code:0xc00038aa70 Href:0xc00038aa80 ID:0xc000541e04 Kind:0xc00038aa90 Reason:0xc00038aaa0}"