### PR TITLE
MGMT-2409: Added request id to each InventoryClient request

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -82,16 +82,16 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	getInventoryNodes := func(numOfFullListReturn int) map[string]inventory_client.HostData {
 		for i := 0; i < numOfFullListReturn; i++ {
-			mockbmclient.EXPECT().GetHosts([]string{models.HostStatusDisabled,
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
 				models.HostStatusError, models.HostStatusInstalled}).Return(inventoryNamesIds, nil).Times(1)
 		}
-		mockbmclient.EXPECT().GetHosts([]string{models.HostStatusDisabled,
+		mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
 			models.HostStatusError, models.HostStatusInstalled}).Return(map[string]inventory_client.HostData{}, nil).Times(1)
 		return inventoryNamesIds
 	}
 	configuringSuccess := func() {
 		mockk8sclient.EXPECT().GetPods(gomock.Any(), gomock.Any(), "").Return([]v1.Pod{}, nil).AnyTimes()
-		mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	}
 
 	updateProgressSuccess := func(stages []models.HostStage, inventoryNamesIds map[string]inventory_client.HostData) {
@@ -101,7 +101,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 
 		for i, stage := range stages {
-			mockbmclient.EXPECT().UpdateHostInstallProgress(hostIds[i], stage, "").Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostIds[i], stage, "").Return(nil).Times(1)
 		}
 	}
 
@@ -130,7 +130,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			configuringSuccess()
 			listNodes()
 
-			mockbmclient.EXPECT().GetHosts([]string{models.HostStatusDisabled,
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
 				models.HostStatusError, models.HostStatusInstalled}).Return(map[string]inventory_client.HostData{}, fmt.Errorf("dummy")).Times(1)
 			getInventoryNodes(1)
 
@@ -151,7 +151,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					hostIds = append(hostIds, host.Host.ID.String())
 				}
 				for i, stage := range stages {
-					mockbmclient.EXPECT().UpdateHostInstallProgress(hostIds[i], stage, "").Return(nil).Times(1)
+					mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostIds[i], stage, "").Return(nil).Times(1)
 				}
 			}
 			kubeNamesIds = map[string]string{"node0": "6d6f00e8-70dd-48a5-859a-0f1459485ad9",
@@ -169,11 +169,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					for key, value := range inventoryNamesIds {
 						targetMap[key] = value
 					}
-					mockbmclient.EXPECT().GetHosts([]string{models.HostStatusDisabled,
+					mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
 						models.HostStatusError, models.HostStatusInstalled}).Return(targetMap, nil).Times(1)
 					delete(inventoryNamesIds, name)
 				}
-				mockbmclient.EXPECT().GetHosts([]string{models.HostStatusDisabled,
+				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
 					models.HostStatusError, models.HostStatusInstalled}).Return(inventoryNamesIds, nil).Times(1)
 			}
 
@@ -199,8 +199,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					hostIds = append(hostIds, host.Host.ID.String())
 				}
 				for i, stage := range stages {
-					mockbmclient.EXPECT().UpdateHostInstallProgress(hostIds[i], stage, "").Return(fmt.Errorf("dummy")).Times(1)
-					mockbmclient.EXPECT().UpdateHostInstallProgress(hostIds[i], stage, "").Return(nil).Times(1)
+					mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostIds[i], stage, "").Return(fmt.Errorf("dummy")).Times(1)
+					mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostIds[i], stage, "").Return(nil).Times(1)
 				}
 			}
 			mockk8sclient.EXPECT().ListNodes().Return(GetKubeNodes(kubeNamesIds), nil).Times(2)
@@ -304,7 +304,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			data["ca-bundle.crt"] = "CA"
 			cm := v1.ConfigMap{Data: data}
 			mockk8sclient.EXPECT().GetConfigMap(cmNamespace, cmName).Return(&cm, nil).Times(1)
-			mockbmclient.EXPECT().UploadIngressCa(data["ca-bundle.crt"], c.ClusterID).Return(nil).Times(1)
+			mockbmclient.EXPECT().UploadIngressCa(gomock.Any(), data["ca-bundle.crt"], c.ClusterID).Return(nil).Times(1)
 			res := c.addRouterCAToClusterCA()
 			Expect(res).Should(Equal(true))
 		})
@@ -324,7 +324,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			data["ca-bundle.crt"] = "CA"
 			cm := v1.ConfigMap{Data: data}
 			mockk8sclient.EXPECT().GetConfigMap(cmNamespace, cmName).Return(&cm, nil).Times(1)
-			mockbmclient.EXPECT().UploadIngressCa(data["ca-bundle.crt"], c.ClusterID).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().UploadIngressCa(gomock.Any(), data["ca-bundle.crt"], c.ClusterID).Return(fmt.Errorf("dummy")).Times(1)
 			res := c.addRouterCAToClusterCA()
 			Expect(res).Should(Equal(false))
 		})
@@ -344,19 +344,19 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			goodClusterVersion.Status.Conditions = []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorAvailable,
 				Status: configv1.ConditionTrue}}
 			cluster := models.Cluster{Status: &finalizing}
-			mockbmclient.EXPECT().GetCluster().Return(nil, fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().GetCluster().Return(&models.Cluster{Status: &installing}, nil).Times(1)
-			mockbmclient.EXPECT().GetCluster().Return(&cluster, nil).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&cluster, nil).Times(1)
 			mockk8sclient.EXPECT().GetConfigMap(cmNamespace, cmName).Return(&cm, nil).Times(1)
-			mockbmclient.EXPECT().UploadIngressCa(data["ca-bundle.crt"], c.ClusterID).Return(nil).Times(1)
+			mockbmclient.EXPECT().UploadIngressCa(gomock.Any(), data["ca-bundle.crt"], c.ClusterID).Return(nil).Times(1)
 			mockk8sclient.EXPECT().UnPatchEtcd().Return(fmt.Errorf("dummy")).Times(1)
 			mockk8sclient.EXPECT().UnPatchEtcd().Return(nil).Times(1)
 			mockk8sclient.EXPECT().GetPods(consoleNamespace, gomock.Any(), "").Return(nil, fmt.Errorf("dummy")).Times(1)
 			mockk8sclient.EXPECT().GetPods(consoleNamespace, gomock.Any(), "").Return([]v1.Pod{{Status: v1.PodStatus{Phase: "Pending"}}}, nil).Times(1)
 			mockk8sclient.EXPECT().GetPods(consoleNamespace, gomock.Any(), "").Return([]v1.Pod{{Status: v1.PodStatus{Phase: "Running"}}}, nil).Times(1)
 
-			mockbmclient.EXPECT().CompleteInstallation("cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().CompleteInstallation("cluster-id", true, "").Return(nil).Times(1)
+			mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
 			wg.Add(1)
 			go c.PostInstallConfigs(&wg)
@@ -369,10 +369,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			badClusterVersion.Status.Conditions = []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorAvailable,
 				Status: configv1.ConditionFalse}}
 			cluster := models.Cluster{Status: &finalizing}
-			mockbmclient.EXPECT().GetCluster().Return(&cluster, nil).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&cluster, nil).Times(1)
 
 			mockk8sclient.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("aaa")).MinTimes(1)
-			mockbmclient.EXPECT().CompleteInstallation("cluster-id", false,
+			mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", false,
 				"Timeout while waiting router ca data").Return(nil).Times(1)
 
 			wg.Add(1)
@@ -415,14 +415,14 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("Validate upload logs, Upload failed", func() {
 			r := bytes.NewBuffer([]byte("test"))
 			mockk8sclient.EXPECT().GetPodLogsAsBuffer(conf.Namespace, "test", gomock.Any()).Return(r, nil).Times(1)
-			mockbmclient.EXPECT().UploadLogs(conf.ClusterID, models.LogsTypeController, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().UploadLogs(gomock.Any(), conf.ClusterID, models.LogsTypeController, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
 			err := c.uploadPodLogs("test", conf.Namespace, controllerLogsSecondsAgo)
 			Expect(err).To(HaveOccurred())
 		})
 		It("Validate upload logs happy flow", func() {
 			r := bytes.NewBuffer([]byte("test"))
 			mockk8sclient.EXPECT().GetPodLogsAsBuffer(conf.Namespace, "test", gomock.Any()).Return(r, nil).Times(1)
-			mockbmclient.EXPECT().UploadLogs(conf.ClusterID, models.LogsTypeController, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UploadLogs(gomock.Any(), conf.ClusterID, models.LogsTypeController, gomock.Any()).Return(nil).Times(1)
 			err := c.uploadPodLogs("test", conf.Namespace, controllerLogsSecondsAgo)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/src/common/common_test.go
+++ b/src/common/common_test.go
@@ -40,15 +40,15 @@ var _ = Describe("verify common", func() {
 				"node1": {Host: &models.Host{ID: &node1Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}, Role: models.HostRoleMaster}, IPs: []string{"192.168.126.11", "192.168.11.123", "fe80::5054:ff:fe9a:4739"}},
 				"node2": {Host: &models.Host{ID: &node2Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}, Role: models.HostRoleWorker}, IPs: []string{"192.168.126.12", "192.168.11.124", "fe80::5054:ff:fe9a:4740"}}}
 
-			mockbmclient.EXPECT().UpdateHostInstallProgress(node1Id.String(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress(node2Id.String(), models.HostStageWaitingForIgnition, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), node1Id.String(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), node2Id.String(), models.HostStageWaitingForIgnition, gomock.Any()).Return(nil).Times(1)
 			SetConfiguringStatusForHosts(mockbmclient, testInventoryIdsIps, logs, true, l)
 			Expect(testInventoryIdsIps["node0"].Host.Progress.CurrentStage).Should(Equal(models.HostStageRebooting))
 			Expect(testInventoryIdsIps["node1"].Host.Progress.CurrentStage).Should(Equal(models.HostStageRebooting))
 			Expect(testInventoryIdsIps["node2"].Host.Progress.CurrentStage).Should(Equal(models.HostStageWaitingForIgnition))
 
-			mockbmclient.EXPECT().UpdateHostInstallProgress(node1Id.String(), models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress(node2Id.String(), models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), node1Id.String(), models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), node2Id.String(), models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
 			SetConfiguringStatusForHosts(mockbmclient, testInventoryIdsIps, logs, false, l)
 			Expect(testInventoryIdsIps["node1"].Host.Progress.CurrentStage).Should(Equal(models.HostStageConfiguring))
 			Expect(testInventoryIdsIps["node2"].Host.Progress.CurrentStage).Should(Equal(models.HostStageConfiguring))

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -57,10 +57,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		mockops.EXPECT().Mkdir(InstallDir).Return(nil).Times(1)
 	}
 	downloadFileSuccess := func(fileName string) {
-		mockbmclient.EXPECT().DownloadFile(fileName, filepath.Join(InstallDir, fileName)).Return(nil).Times(1)
+		mockbmclient.EXPECT().DownloadFile(gomock.Any(), fileName, filepath.Join(InstallDir, fileName)).Return(nil).Times(1)
 	}
 	downloadHostIgnitionSuccess := func(hostID string, fileName string) {
-		mockbmclient.EXPECT().DownloadHostIgnition(hostID, filepath.Join(InstallDir, fileName)).Return(nil).Times(1)
+		mockbmclient.EXPECT().DownloadHostIgnition(gomock.Any(), hostID, filepath.Join(InstallDir, fileName)).Return(nil).Times(1)
 	}
 
 	cleanInstallDevice := func() {
@@ -70,9 +70,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	updateProgressSuccess := func(stages [][]string) {
 		for _, stage := range stages {
 			if len(stage) == 2 {
-				mockbmclient.EXPECT().UpdateHostInstallProgress(hostId, models.HostStage(stage[0]), stage[1]).Return(nil).Times(1)
+				mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostId, models.HostStage(stage[0]), stage[1]).Return(nil).Times(1)
 			} else {
-				mockbmclient.EXPECT().UpdateHostInstallProgress(hostId, models.HostStage(stage[0]), "").Return(nil).Times(1)
+				mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), hostId, models.HostStage(stage[0]), "").Return(nil).Times(1)
 			}
 		}
 	}
@@ -91,7 +91,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			Status:     v1.PodStatus{Phase: "Running"}}}, nil).Times(1)
 		r := bytes.NewBuffer([]byte("test"))
 		mockk8sclient.EXPECT().GetPodLogsAsBuffer(assistedControllerNamespace, assistedControllerPrefix+"aasdasd", gomock.Any()).Return(r, nil).Times(1)
-		mockbmclient.EXPECT().UploadLogs(clusterId, models.LogsTypeController, gomock.Any()).Return(nil).Times(1)
+		mockbmclient.EXPECT().UploadLogs(gomock.Any(), clusterId, models.LogsTypeController, gomock.Any()).Return(nil).Times(1)
 	}
 
 	resolvConfSuccess := func() {
@@ -153,15 +153,15 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			}
 		}
 		WaitMasterNodesSucccess := func() {
-			mockbmclient.EXPECT().GetEnabledHostsNamesHosts().Return(inventoryNamesHost, nil).AnyTimes()
+			mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(inventoryNamesHost, nil).AnyTimes()
 			mockk8sclient.EXPECT().ListMasterNodes().Return(GetKubeNodes(map[string]string{}), nil).Times(1)
 			kubeNamesIds = map[string]string{"node0": "7916fa89-ea7a-443e-a862-b3e930309f65"}
 			mockk8sclient.EXPECT().ListMasterNodes().Return(GetKubeNodes(kubeNamesIds), nil).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress(inventoryNamesHost["node0"].Host.ID.String(), models.HostStageJoined, "").Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), inventoryNamesHost["node0"].Host.ID.String(), models.HostStageJoined, "").Times(1)
 			kubeNamesIds = map[string]string{"node0": "7916fa89-ea7a-443e-a862-b3e930309f65",
 				"node1": "eb82821f-bf21-4614-9a3b-ecb07929f238"}
 			mockk8sclient.EXPECT().ListMasterNodes().Return(GetKubeNodes(kubeNamesIds), nil).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress(inventoryNamesHost["node1"].Host.ID.String(), models.HostStageJoined, "").Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), inventoryNamesHost["node1"].Host.ID.String(), models.HostStageJoined, "").Times(1)
 		}
 		patchEtcdSuccess := func() {
 			mockk8sclient.EXPECT().PatchEtcd().Return(nil).Times(1)
@@ -318,16 +318,16 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				IPs: []string{"192.168.126.10", "192.168.11.122", "fe80::5054:ff:fe9a:4738"}},
 				"node1": {Host: &models.Host{ID: &node1Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}}, IPs: []string{"192.168.126.11", "192.168.11.123", "fe80::5054:ff:fe9a:4739"}},
 				"node2": {Host: &models.Host{ID: &node2Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}}, IPs: []string{"192.168.126.12", "192.168.11.124", "fe80::5054:ff:fe9a:4740"}}}
-			mockbmclient.EXPECT().GetEnabledHostsNamesHosts().Return(nil, fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().GetEnabledHostsNamesHosts().Return(testInventoryIdsIps, nil).Times(1)
+			mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(testInventoryIdsIps, nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("", fmt.Errorf("dummy")).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("dummy logs", nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("dummy logs", nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return(logs, nil).AnyTimes()
 
-			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress("eb82821f-bf21-4614-9a3b-ecb07929f240", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress("eb82821f-bf21-4614-9a3b-ecb07929f239", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), gomock.Any(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "eb82821f-bf21-4614-9a3b-ecb07929f240", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "eb82821f-bf21-4614-9a3b-ecb07929f239", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
@@ -345,16 +345,16 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			testInventoryIdsIps := map[string]inventory_client.HostData{
 				"node1": {Host: &models.Host{ID: &node1Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}}, IPs: []string{"192.168.126.11", "192.168.11.123", "fe80::5054:ff:fe9a:4739"}},
 				"node2": {Host: &models.Host{ID: &node2Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}}, IPs: []string{"192.168.126.12", "192.168.11.124", "fe80::5054:ff:fe9a:4740"}}}
-			mockbmclient.EXPECT().GetEnabledHostsNamesHosts().Return(nil, fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().GetEnabledHostsNamesHosts().Return(testInventoryIdsIps, nil).Times(1)
+			mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(testInventoryIdsIps, nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("", fmt.Errorf("dummy")).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("dummy logs", nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return("dummy logs", nil).Times(1)
 			mockops.EXPECT().GetMCSLogs().Return(logs, nil).AnyTimes()
 
-			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress("eb82821f-bf21-4614-9a3b-ecb07929f240", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
-			mockbmclient.EXPECT().UpdateHostInstallProgress("eb82821f-bf21-4614-9a3b-ecb07929f239", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), gomock.Any(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "eb82821f-bf21-4614-9a3b-ecb07929f240", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "eb82821f-bf21-4614-9a3b-ecb07929f239", models.HostStageConfiguring, gomock.Any()).Return(nil).Times(1)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			installerObj.updateConfiguringStatus(ctx)
@@ -426,7 +426,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDevice()
 			mkdirSuccess()
 			err := fmt.Errorf("failed to fetch file")
-			mockbmclient.EXPECT().DownloadHostIgnition(hostId, filepath.Join(InstallDir, "master-host-id.ign")).Return(err).Times(1)
+			mockbmclient.EXPECT().DownloadHostIgnition(gomock.Any(), hostId, filepath.Join(InstallDir, "master-host-id.ign")).Return(err).Times(1)
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(err))
 		})

--- a/src/inventory_client/inventory_client_test.go
+++ b/src/inventory_client/inventory_client_test.go
@@ -1,6 +1,7 @@
 package inventory_client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -62,14 +63,14 @@ var _ = Describe("inventory_client_tests", func() {
 		It("positive_response", func() {
 			server.Start()
 			expectServerCall(server, fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts/%s/progress", clusterID, hostID), expectedJson, http.StatusOK)
-			Expect(client.UpdateHostInstallProgress(hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
+			Expect(client.UpdateHostInstallProgress(context.Background(), hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
 			Expect(server.ReceivedRequests()).Should(HaveLen(1))
 
 		})
 
 		It("negative_server_error_response", func() {
 			server.Start()
-			Expect(client.UpdateHostInstallProgress(hostID, models.HostStageInstalling, "")).Should(HaveOccurred())
+			Expect(client.UpdateHostInstallProgress(context.Background(), hostID, models.HostStageInstalling, "")).Should(HaveOccurred())
 			Expect(server.ReceivedRequests()).Should(HaveLen(testMaxRetries + 1))
 
 		})
@@ -80,7 +81,7 @@ var _ = Describe("inventory_client_tests", func() {
 			expectServerCall(server, fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts/%s/progress", clusterID, hostID), expectedJson, http.StatusForbidden)
 			expectServerCall(server, fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts/%s/progress", clusterID, hostID), expectedJson, http.StatusOK)
 
-			Expect(client.UpdateHostInstallProgress(hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
+			Expect(client.UpdateHostInstallProgress(context.Background(), hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
 			Expect(server.ReceivedRequests()).Should(HaveLen(3))
 		})
 
@@ -92,14 +93,14 @@ var _ = Describe("inventory_client_tests", func() {
 				server.Start()
 			}()
 
-			Expect(client.UpdateHostInstallProgress(hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
+			Expect(client.UpdateHostInstallProgress(context.Background(), hostID, models.HostStageInstalling, "")).ShouldNot(HaveOccurred())
 			Expect(server.ReceivedRequests()).Should(HaveLen(1))
 		})
 
 		It("server_down", func() {
 			server.Start()
 			server.Close()
-			Expect(client.UpdateHostInstallProgress(hostID, models.HostStageInstalling, "")).Should(HaveOccurred())
+			Expect(client.UpdateHostInstallProgress(context.Background(), hostID, models.HostStageInstalling, "")).Should(HaveOccurred())
 		})
 	})
 })

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -5,11 +5,13 @@
 package inventory_client
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockInventoryClient is a mock of InventoryClient interface
@@ -36,130 +38,130 @@ func (m *MockInventoryClient) EXPECT() *MockInventoryClientMockRecorder {
 }
 
 // DownloadFile mocks base method
-func (m *MockInventoryClient) DownloadFile(filename, dest string) error {
+func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadFile", filename, dest)
+	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DownloadFile indicates an expected call of DownloadFile
-func (mr *MockInventoryClientMockRecorder) DownloadFile(filename, dest interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), filename, dest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
 }
 
 // DownloadHostIgnition mocks base method
-func (m *MockInventoryClient) DownloadHostIgnition(hostID, dest string) error {
+func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, hostID, dest string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadHostIgnition", hostID, dest)
+	ret := m.ctrl.Call(m, "DownloadHostIgnition", ctx, hostID, dest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DownloadHostIgnition indicates an expected call of DownloadHostIgnition
-func (mr *MockInventoryClientMockRecorder) DownloadHostIgnition(hostID, dest interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) DownloadHostIgnition(ctx, hostID, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadHostIgnition", reflect.TypeOf((*MockInventoryClient)(nil).DownloadHostIgnition), hostID, dest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadHostIgnition", reflect.TypeOf((*MockInventoryClient)(nil).DownloadHostIgnition), ctx, hostID, dest)
 }
 
 // UpdateHostInstallProgress mocks base method
-func (m *MockInventoryClient) UpdateHostInstallProgress(hostId string, newStage models.HostStage, info string) error {
+func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, hostId string, newStage models.HostStage, info string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", hostId, newStage, info)
+	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, hostId, newStage, info)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress
-func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(hostId, newStage, info interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, hostId, newStage, info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), hostId, newStage, info)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, hostId, newStage, info)
 }
 
 // GetEnabledHostsNamesHosts mocks base method
-func (m *MockInventoryClient) GetEnabledHostsNamesHosts() (map[string]HostData, error) {
+func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts")
+	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
 	ret0, _ := ret[0].(map[string]HostData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts
-func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts() *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
 }
 
 // UploadIngressCa mocks base method
-func (m *MockInventoryClient) UploadIngressCa(ingressCA, clusterId string) error {
+func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadIngressCa", ingressCA, clusterId)
+	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadIngressCa indicates an expected call of UploadIngressCa
-func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ingressCA, clusterId interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ingressCA, clusterId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
 }
 
 // GetCluster mocks base method
-func (m *MockInventoryClient) GetCluster() (*models.Cluster, error) {
+func (m *MockInventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster")
+	ret := m.ctrl.Call(m, "GetCluster", ctx)
 	ret0, _ := ret[0].(*models.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCluster indicates an expected call of GetCluster
-func (mr *MockInventoryClientMockRecorder) GetCluster() *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) GetCluster(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx)
 }
 
 // CompleteInstallation mocks base method
-func (m *MockInventoryClient) CompleteInstallation(clusterId string, isSuccess bool, errorInfo string) error {
+func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteInstallation", clusterId, isSuccess, errorInfo)
+	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CompleteInstallation indicates an expected call of CompleteInstallation
-func (mr *MockInventoryClientMockRecorder) CompleteInstallation(clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), clusterId, isSuccess, errorInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
 }
 
 // GetHosts mocks base method
-func (m *MockInventoryClient) GetHosts(skippedStatuses []string) (map[string]HostData, error) {
+func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogger, skippedStatuses []string) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHosts", skippedStatuses)
+	ret := m.ctrl.Call(m, "GetHosts", ctx, log, skippedStatuses)
 	ret0, _ := ret[0].(map[string]HostData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHosts indicates an expected call of GetHosts
-func (mr *MockInventoryClientMockRecorder) GetHosts(skippedStatuses interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) GetHosts(ctx, log, skippedStatuses interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetHosts), skippedStatuses)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetHosts), ctx, log, skippedStatuses)
 }
 
 // UploadLogs mocks base method
-func (m *MockInventoryClient) UploadLogs(clusterId string, logsType models.LogsType, upfile io.Reader) error {
+func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadLogs", clusterId, logsType, upfile)
+	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadLogs indicates an expected call of UploadLogs
-func (mr *MockInventoryClientMockRecorder) UploadLogs(clusterId, logsType, upfile interface{}) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), clusterId, logsType, upfile)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
 }

--- a/src/ops/coreos_installer_log_writer.go
+++ b/src/ops/coreos_installer_log_writer.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/assisted-installer/src/utils"
+
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -56,7 +58,8 @@ func (l *CoreosInstallerLogWriter) reportProgress() {
 	}
 	if currentPercent >= l.lastProgress+MinProgressDelta {
 		// If the progress is more than 5% report it
-		if err := l.progressReporter.UpdateHostInstallProgress(l.hostID, models.HostStageWritingImageToDisk, match[2]); err == nil {
+		ctx := utils.GenerateRequestContext()
+		if err := l.progressReporter.UpdateHostInstallProgress(ctx, l.hostID, models.HostStageWritingImageToDisk, match[2]); err == nil {
 			l.lastProgress = currentPercent
 		}
 	}

--- a/src/ops/coreos_installer_log_writer_test.go
+++ b/src/ops/coreos_installer_log_writer_test.go
@@ -36,9 +36,9 @@ var _ = Describe("Verify CoreosInstallerLogger", func() {
 		updateProgressSuccess := func(stages [][]string) {
 			for _, stage := range stages {
 				if len(stage) == 2 {
-					mockbmclient.EXPECT().UpdateHostInstallProgress("hostID", models.HostStage(stage[0]), stage[1]).Return(nil).Times(1)
+					mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "hostID", models.HostStage(stage[0]), stage[1]).Return(nil).Times(1)
 				} else {
-					mockbmclient.EXPECT().UpdateHostInstallProgress("hostID", models.HostStage(stage[0]), "").Return(nil).Times(1)
+					mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), "hostID", models.HostStage(stage[0]), "").Return(nil).Times(1)
 				}
 			}
 		}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +13,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/openshift/assisted-service/pkg/requestid"
 
 	"github.com/pkg/errors"
 
@@ -224,4 +227,12 @@ func envVarsProxyFunc() func(*url.URL) (*url.URL, error) {
 func SetNoProxyEnv(noProxy string) {
 	os.Setenv("NO_PROXY", noProxy)
 	os.Setenv("no_proxy", noProxy)
+}
+
+func GenerateRequestContext() context.Context {
+	return requestid.ToContext(context.Background(), requestid.NewID())
+}
+
+func RequestIDLogger(ctx context.Context, log *logrus.Logger) logrus.FieldLogger {
+	return requestid.RequestIDLogger(log, requestid.FromContext(ctx))
 }


### PR DESCRIPTION
In order to be ease the debug process of requests and responses
sent from assisted-installer to assisted-service and backwards a
request id will be added to each request. Loggers will print any
errors returned from assisted-service with this request id (same
as it works in assisted-installer-agent).