### PR TITLE
MGMT-2678: Adding bootstrap public SSH key to masters ignition. (#80)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,11 +21,13 @@ require (
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.10.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/thoas/go-funk v0.6.0
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	golang.org/x/net v0.0.0-20201002202402-0a1ea396d57c
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,7 @@ github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083/go.mod h1:otnto4
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 h1:4SPQljF/GJ8Q+QlCWMWxRBepub4DresnOm4eI2ebFGc=
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -1681,6 +1682,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -176,6 +176,16 @@ func (i *installer) startBootstrap() error {
 		return err
 	}
 
+	err = i.generateSshKeyPair()
+	if err != nil {
+		return err
+	}
+
+	err = i.ops.CreateOpenshiftSshManifest(assistedInstallerSshManifest, sshManifestTmpl, sshPubKeyPath)
+	if err != nil {
+		return err
+	}
+
 	// reload systemd configurations from filesystem and regenerate dependency trees
 	err = i.ops.SystemctlAction("daemon-reload")
 	if err != nil {
@@ -229,6 +239,19 @@ func (i *installer) extractIgnitionToFS(ignitionPath string) (err error) {
 	}
 	i.log.Errorf("Failed to extract ignition to disk, giving up")
 	return err
+}
+
+func (i *installer) generateSshKeyPair() error {
+	i.log.Info("Generating new SSH key pair")
+	if err := i.ops.Mkdir(sshDir); err != nil {
+		i.log.WithError(err).Error("Failed to create SSH dir")
+		return err
+	}
+	if _, err := i.ops.ExecPrivilegeCommand(utils.NewLogWriter(i.log), "ssh-keygen", "-q", "-f", sshKeyPath, "-N", ""); err != nil {
+		i.log.WithError(err).Error("Failed to generate SSH key pair")
+		return err
+	}
+	return nil
 }
 
 func (i *installer) getFileFromService(filename string) (string, error) {

--- a/src/installer/ssh_consts.go
+++ b/src/installer/ssh_consts.go
@@ -1,0 +1,25 @@
+package installer
+
+const (
+	sshDir                       = "/root/.ssh"
+	sshKeyPath                   = sshDir + "/id_rsa"
+	sshPubKeyPath                = sshKeyPath + ".pub"
+	assistedInstallerSshManifest = "/opt/openshift/openshift/99_openshift-machineconfig_99-assisted-installer-master-ssh.yaml"
+	sshManifestTmpl              = `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-assisted-installer-master-ssh
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    passwd:
+      users:
+      - name: core
+        sshAuthorizedKeys:
+        - {{.SshPubKey}}
+`
+)

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -278,3 +278,17 @@ func (mr *MockOpsMockRecorder) ReloadHostFile(filepath interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadHostFile", reflect.TypeOf((*MockOps)(nil).ReloadHostFile), filepath)
 }
+
+// CreateOpenshiftSshManifest mocks base method
+func (m *MockOps) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOpenshiftSshManifest", filePath, template, sshPubKeyPath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOpenshiftSshManifest indicates an expected call of CreateOpenshiftSshManifest
+func (mr *MockOpsMockRecorder) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenshiftSshManifest", reflect.TypeOf((*MockOps)(nil).CreateOpenshiftSshManifest), filePath, template, sshPubKeyPath)
+}


### PR DESCRIPTION
It will allows bootstrap SSH to masters in order to collect
`installer-gather.sh` logs in case of cluster installation failure.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>