### PR TITLE
MGMT-2411: fixed bad error format log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971
 	github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a
-	github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8
+	github.com/openshift/assisted-service v1.0.10-0.20201124085636-632752de76c4
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,11 @@ github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971/go.mod h1:M3xexPhgM8
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a h1:mk+JGnFSuRTTWzODLs1gclp5om0+k4lH8btJSJxQA80=
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a/go.mod h1:q1jXr/OgGA7bOBu1uzlZXOjExPHIoAXxzQlifXBmXLY=
 github.com/openshift/assisted-service v0.0.0-20200811075806-62dcbcd62c0b/go.mod h1:H96z5QdPNv7PZ+/p+VafuHyAUqlVcpOFTnfMl8QYzQ4=
+github.com/openshift/assisted-service v1.0.9 h1:dE7h81GFbJC4PC/5XGRP8qOM9tmh64KFHyI1cjTWQsA=
 github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8 h1:CN4m36+mD0SRUk/qE7Dr9tIxSD6XXx5XSoPRlqFm0K0=
 github.com/openshift/assisted-service v1.0.10-0.20201109152238-bb2f4a5dbbd8/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
+github.com/openshift/assisted-service v1.0.10-0.20201124085636-632752de76c4 h1:OB8QlqHKtgBAK516IWcRC0CYlmIPXQY4i2kvT2PfGYI=
+github.com/openshift/assisted-service v1.0.10-0.20201124085636-632752de76c4/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
+	aserror "github.com/openshift/assisted-service/pkg/error"
 	"github.com/openshift/assisted-service/pkg/requestid"
 	"github.com/sirupsen/logrus"
 )
@@ -176,7 +177,7 @@ func (c *inventoryClient) DownloadFile(ctx context.Context, filename string, des
 		fo.Close()
 	}()
 	_, err = c.ai.Installer.DownloadClusterFiles(ctx, c.createDownloadParams(filename), fo)
-	return err
+	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) DownloadHostIgnition(ctx context.Context, hostID string, dest string) error {
@@ -195,24 +196,24 @@ func (c *inventoryClient) DownloadHostIgnition(ctx context.Context, hostID strin
 		HostID:    strfmt.UUID(hostID),
 	}
 	_, err = c.ai.Installer.DownloadHostIgnition(ctx, &params, fo)
-	return err
+	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UpdateHostInstallProgress(ctx context.Context, hostId string, newStage models.HostStage, info string) error {
 	_, err := c.ai.Installer.UpdateHostInstallProgress(ctx, c.createUpdateHostInstallProgressParams(hostId, newStage, info))
-	return err
+	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UploadIngressCa(ctx context.Context, ingressCA string, clusterId string) error {
 	_, err := c.ai.Installer.UploadClusterIngressCert(ctx,
 		&installer.UploadClusterIngressCertParams{ClusterID: strfmt.UUID(clusterId), IngressCertParams: models.IngressCertParams(ingressCA)})
-	return err
+	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
 	cluster, err := c.ai.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: c.clusterId})
 	if err != nil {
-		return nil, err
+		return nil, aserror.GetAssistedError(err)
 	}
 
 	return cluster.Payload, nil
@@ -269,7 +270,7 @@ func (c *inventoryClient) getHostsWithInventoryInfo(ctx context.Context, log log
 	hostsWithHwInfo := make(map[string]HostData)
 	hosts, err := c.ai.Installer.ListHosts(ctx, &installer.ListHostsParams{ClusterID: c.clusterId})
 	if err != nil {
-		return nil, err
+		return nil, aserror.GetAssistedError(err)
 	}
 	for _, host := range hosts.Payload {
 		if funk.IndexOf(skippedStatuses, *host.Status) > -1 {
@@ -290,7 +291,7 @@ func (c *inventoryClient) CompleteInstallation(ctx context.Context, clusterId st
 	_, err := c.ai.Installer.CompleteInstallation(ctx,
 		&installer.CompleteInstallationParams{ClusterID: strfmt.UUID(clusterId),
 			CompletionParams: &models.CompletionParams{IsSuccess: &isSuccess, ErrorInfo: errorInfo}})
-	return err
+	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
@@ -298,5 +299,5 @@ func (c *inventoryClient) UploadLogs(ctx context.Context, clusterId string, logs
 	_, err := c.ai.Installer.UploadLogs(ctx,
 		&installer.UploadLogsParams{ClusterID: strfmt.UUID(clusterId), LogsType: string(logsType),
 			Upfile: runtime.NamedReader(fileName, upfile)})
-	return err
+	return aserror.GetAssistedError(err)
 }


### PR DESCRIPTION
Currently due to a bug in assisted-service API, the Error() function
prints memory addresses instead of values.
Fixing the bug in assisted-service side will break backward
compatibility, therefore the fix should be made here.

Before logging the error, try to convert it to one of assisted
service Error or InfraError errors, and build the message from
the payload.

See an example of the bad error format:
Oct 09 04:43:36 localhost installer[182675]: time="2020-10-09T04:43:36Z" level=error msg="Failed to fetch file (worker.ign) from server. err: [GET /clusters/{cluster_id}/downloads/files][409] downloadClusterFilesConflict &{Code:0xc00038aa70 Href:0xc00038aa80 ID:0xc000541e04 Kind:0xc00038aa90 Reason:0xc00038aaa0}"

Oct 09 04:43:36 localhost installer[182675]: time="2020-10-09T04:43:36Z" level=info msg="Updating node installation stage: Failed - [GET /clusters/{cluster_id}/downloads/files][409] downloadClusterFilesConflict &{Code:0xc00038aa70 Href:0xc00038aa80 ID:0xc000541e04 Kind:0xc00038aa90 Reason:0xc00038aaa0}"