### PR TITLE
NO-ISSUE: Uploading logs before changing state to REBOOT.

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -122,11 +122,11 @@ func (i *installer) InstallNode() error {
 			return err
 		}
 	}
-	i.UpdateHostInstallProgress(models.HostStageRebooting, "")
 	_, err = i.ops.UploadInstallationLogs(isBootstrap)
 	if err != nil {
 		i.log.Errorf("upload installation logs %s", err)
 	}
+	i.UpdateHostInstallProgress(models.HostStageRebooting, "")
 	if err = i.ops.Reboot(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Nothing should be done before changing state to REBOOT and actual
reboot.

This is causing timing issues on logs collection that may take few
seconds/minutes to finish.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>