### PR TITLE
MGMT-3179 OVNKubernetes Patch for IPv6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.4
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,6 @@ github.com/docker/docker v0.7.3-0.20190817195342-4760db040282/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce h1:KXS1Jg+ddGcWA8e1N7cupxaHHZhit5rB9tfDU+mfjyY=
 github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200505174321-1655290016ac+incompatible h1:ZxJX4ZSNg1LORBsStUojbrLfkrE3Ut122XhzyZnN110=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200505174321-1655290016ac+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
@@ -366,6 +364,7 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/getsentry/raven-go v0.0.0-20190513200303-c977f96e1095/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
@@ -982,10 +981,6 @@ github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971/go.mod h1:M3xexPhgM8
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a h1:mk+JGnFSuRTTWzODLs1gclp5om0+k4lH8btJSJxQA80=
 github.com/openshift/assisted-installer-agent v0.0.0-20200811180147-bc9c7b899b8a/go.mod h1:q1jXr/OgGA7bOBu1uzlZXOjExPHIoAXxzQlifXBmXLY=
 github.com/openshift/assisted-service v0.0.0-20200811075806-62dcbcd62c0b/go.mod h1:H96z5QdPNv7PZ+/p+VafuHyAUqlVcpOFTnfMl8QYzQ4=
-github.com/openshift/assisted-service v1.0.10-0.20201124085636-632752de76c4 h1:OB8QlqHKtgBAK516IWcRC0CYlmIPXQY4i2kvT2PfGYI=
-github.com/openshift/assisted-service v1.0.10-0.20201124085636-632752de76c4/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
-github.com/openshift/assisted-service v1.0.10-0.20201217084907-7fa60b0f3839 h1:8XudycGByjeUatdHVB3dyU/RW+kMO6Za+k4U4qmwPFE=
-github.com/openshift/assisted-service v1.0.10-0.20201217084907-7fa60b0f3839/go.mod h1:Go1XCefC2rE81z7Ou8nQKhVhnHO51wYnqWu6hFPfUKI=
 github.com/openshift/assisted-service v1.0.10-0.20201220135917-8ca5c20f9f90 h1:m5v0+MwDIAALIXpdyi+FVNA1Sw0B0vGzj4brRaYgdUw=
 github.com/openshift/assisted-service v1.0.10-0.20201220135917-8ca5c20f9f90/go.mod h1:Go1XCefC2rE81z7Ou8nQKhVhnHO51wYnqWu6hFPfUKI=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -83,6 +83,34 @@ func (mr *MockK8SClientMockRecorder) UnPatchEtcd() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnPatchEtcd", reflect.TypeOf((*MockK8SClient)(nil).UnPatchEtcd))
 }
 
+// PatchControlPlaneReplicas mocks base method
+func (m *MockK8SClient) PatchControlPlaneReplicas() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchControlPlaneReplicas")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchControlPlaneReplicas indicates an expected call of PatchControlPlaneReplicas
+func (mr *MockK8SClientMockRecorder) PatchControlPlaneReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchControlPlaneReplicas", reflect.TypeOf((*MockK8SClient)(nil).PatchControlPlaneReplicas))
+}
+
+// UnPatchControlPlaneReplicas mocks base method
+func (m *MockK8SClient) UnPatchControlPlaneReplicas() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnPatchControlPlaneReplicas")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnPatchControlPlaneReplicas indicates an expected call of UnPatchControlPlaneReplicas
+func (mr *MockK8SClientMockRecorder) UnPatchControlPlaneReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnPatchControlPlaneReplicas", reflect.TypeOf((*MockK8SClient)(nil).UnPatchControlPlaneReplicas))
+}
+
 // ListNodes mocks base method
 func (m *MockK8SClient) ListNodes() (*v10.NodeList, error) {
 	m.ctrl.T.Helper()
@@ -302,4 +330,19 @@ func (m *MockK8SClient) GetClusterVersion(name string) (*v1.ClusterVersion, erro
 func (mr *MockK8SClientMockRecorder) GetClusterVersion(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterVersion", reflect.TypeOf((*MockK8SClient)(nil).GetClusterVersion), name)
+}
+
+// GetNetworkType mocks base method
+func (m *MockK8SClient) GetNetworkType() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkType")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkType indicates an expected call of GetNetworkType
+func (mr *MockK8SClientMockRecorder) GetNetworkType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkType", reflect.TypeOf((*MockK8SClient)(nil).GetNetworkType))
 }


### PR DESCRIPTION
This change id for OVNKubernetes network type only
When starting network with OVNKubernetes netwkork type, the operator requires
that all replicas of controlPlane, which are actually the masters, will be up.
Since one of the Assisted Installer masters is actually the bootstrap when the network is started,
this network type cannot be started.
This patch changes temporarily the number of replicas to 2, to let the network start,
and then returns it to 3.

/cc @eranco74 
/cc @tsorya 