### PR TITLE
MGMT-2662 Handle the case when MetalProvisioning exists

### DIFF
--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -60,6 +60,7 @@ type K8SClient interface {
 	GetPods(namespace string, labelMatch map[string]string, fieldSelector string) ([]v1.Pod, error)
 	IsMetalProvisioningExists() (bool, error)
 	ListBMHs() (metal3v1alpha1.BareMetalHostList, error)
+	GetBMH(name string) (*metal3v1alpha1.BareMetalHost, error)
 	UpdateBMHStatus(bmh *metal3v1alpha1.BareMetalHost) error
 	UpdateBMH(bmh *metal3v1alpha1.BareMetalHost) error
 	SetProxyEnvVars() error
@@ -442,6 +443,18 @@ func (c *k8sClient) ListBMHs() (metal3v1alpha1.BareMetalHostList, error) {
 		return metal3v1alpha1.BareMetalHostList{}, err
 	}
 	return hosts, nil
+}
+
+func (c *k8sClient) GetBMH(name string) (*metal3v1alpha1.BareMetalHost, error) {
+	host := metal3v1alpha1.BareMetalHost{}
+	nn := types.NamespacedName{Namespace: "openshift-machine-api", Name: name}
+	err := c.runtimeClient.Get(context.Background(), nn, &host)
+	if err != nil {
+		c.log.Errorf("failed to Get BMH %s, error %s", name, err)
+		return &metal3v1alpha1.BareMetalHost{}, err
+	}
+	return &host, nil
+
 }
 
 func (c *k8sClient) UpdateBMHStatus(bmh *metal3v1alpha1.BareMetalHost) error {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -275,6 +275,21 @@ func (mr *MockK8SClientMockRecorder) ListBMHs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBMHs", reflect.TypeOf((*MockK8SClient)(nil).ListBMHs))
 }
 
+// GetBMH mocks base method
+func (m *MockK8SClient) GetBMH(name string) (*v1alpha1.BareMetalHost, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBMH", name)
+	ret0, _ := ret[0].(*v1alpha1.BareMetalHost)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBMH indicates an expected call of GetBMH
+func (mr *MockK8SClientMockRecorder) GetBMH(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBMH", reflect.TypeOf((*MockK8SClient)(nil).GetBMH), name)
+}
+
 // UpdateBMHStatus mocks base method
 func (m *MockK8SClient) UpdateBMHStatus(bmh *v1alpha1.BareMetalHost) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
In the current situation (no provisioning resource)
- don't change anything

In the new situation of having a provisioning resource
- set host.Spec.ExternallyProvisioned=true
- don't move the metal3v1alpha1.StatusAnnotation
- remove the metal3v1alpha1.PausedAnnotation (set on masters by the installer)
- continue setting the controllerRef

Provisioning is enabled by https://github.com/openshift/assisted-service/pull/709 when we have 4.7 and above.
This can be merged now as it is only used when the PR above is merged.