### PR TITLE
MGMT-3298: enable MCD to use 'systemd start rpm-ostreed' while running as a container

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -3,26 +3,23 @@ package installer
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/openshift/assisted-installer/src/common"
-
 	"path/filepath"
+	"strings"
 	"time"
 
-	"github.com/openshift/assisted-service/models"
-	"github.com/thoas/go-funk"
-
-	"github.com/openshift/assisted-installer/src/k8s_client"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/assisted-installer/src/common"
 	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/inventory_client"
+	"github.com/openshift/assisted-installer/src/k8s_client"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
-	"github.com/sirupsen/logrus"
+	"github.com/openshift/assisted-service/models"
 )
 
 const (
@@ -225,6 +222,7 @@ func (i *installer) extractIgnitionToFS(ignitionPath string) (err error) {
 	i.log.Infof("Extracting ignition to disk using %s mcoImage", mcoImage)
 	for j := 0; j < extractRetryCount; j++ {
 		_, err = i.ops.ExecPrivilegeCommand(utils.NewLogWriter(i.log), "podman", "run", "--net", "host",
+			"--pid=host",
 			"--volume", "/:/rootfs:rw",
 			"--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree",
 			"--privileged",

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -10,24 +10,20 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/pkg/errors"
-
 	"github.com/go-openapi/strfmt"
-
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/openshift/assisted-installer/src/k8s_client"
-	"github.com/openshift/assisted-service/models"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/inventory_client"
+	"github.com/openshift/assisted-installer/src/k8s_client"
 	"github.com/openshift/assisted-installer/src/ops"
-	"github.com/sirupsen/logrus"
+	"github.com/openshift/assisted-service/models"
 )
 
 func TestValidator(t *testing.T) {
@@ -134,6 +130,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		extractIgnitionToFS := func(out string, err error) {
 			mockops.EXPECT().ExecPrivilegeCommand(
 				gomock.Any(), "podman", "run", "--net", "host",
+				"--pid=host",
 				"--volume", "/:/rootfs:rw",
 				"--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree",
 				"--privileged",


### PR DESCRIPTION
Combination of ``--pid=host`` and ``--privilege`` should be enough for it to work