### PR TITLE
MGMT-3256 pvdisplay fails to run

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -402,7 +402,7 @@ func (o *ops) GetMCSLogs() (string, error) {
 
 func (o *ops) UploadInstallationLogs(isBootstrap bool) (string, error) {
 	command := "podman"
-	args := []string{"run", "--rm", "--privileged", "--net=host", "-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+	args := []string{"run", "--rm", "--privileged", "--net=host", "--pid=host", "-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
 		"-v", "/var/log:/var/log", config.GlobalConfig.AgentImage, "logs_sender",
 		"-cluster-id", config.GlobalConfig.ClusterID, "-url", config.GlobalConfig.URL,
 		"-host-id", config.GlobalConfig.HostID,


### PR DESCRIPTION
Fix logs-sender command when run from installer and align it with the command
as recieved from assisted-service and executed by the next-step-runner