### PR TITLE
MGMT-2403 retry mechanism for oc must-gather logs

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -110,6 +110,7 @@ func UploadPodLogs(kc k8s_client.K8SClient, ic inventory_client.InventoryClient,
 	//it will close writer and upload will fail
 	ctx := utils.GenerateRequestContext()
 	err = ic.UploadLogs(ctx, clusterId, models.LogsTypeController, pr)
+	log.Infof("Done uploading controller logs to the service")
 	if err != nil {
 		utils.RequestIDLogger(ctx, log).WithError(err).Error("Failed to upload logs")
 		return errors.Wrapf(err, "Failed to upload logs")

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -80,8 +80,9 @@ func main() {
 
 	logger.Infof("Waiting for all go routines to finish")
 	wg.Wait()
-	logger.Infof("closing logs...")
-	if !status.HasError() { //with error the logs are canceled within UploadLogs
+	if !status.HasError() {
+		//with error the logs are canceled within UploadLogs
+		logger.Infof("closing logs...")
 		cancelLogs()
 	}
 	wgLogs.Wait()


### PR DESCRIPTION
Report back if oc-must gater command has failed and retry
for an hour to fetch the logs before aborting completely

This will give an opportunity for the newly formed cluster
to stabilize and evetually serve the gather pod