### PR TITLE
NO-ISSUE fix panic in controller startup

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -362,7 +362,7 @@ func (c controller) updateBMHs(bmhList metal3v1alpha1.BareMetalHostList, machine
 			}
 			delete(annotations, metal3v1alpha1.StatusAnnotation)
 		}
-		if bmh.Spec.ConsumerRef == nil {
+		if bmh.Spec.ConsumerRef == nil && len(machineList.Items) > 0 {
 			machine := machineList.Items[0]
 			machineList.Items = machineList.Items[1:]
 			bmh.Spec.ConsumerRef = &v1.ObjectReference{


### PR DESCRIPTION
Sometime the machineList is not ready at the time
of the controller startup, causing a panic in line 366.
The controller bounce back again but it's cleaner to
have a sanity check first