### PR TITLE
MGMT-4078 Monitor console operator

### DIFF
--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -70,6 +70,7 @@ type K8SClient interface {
 	GetControlPlaneReplicas() (int, error)
 	ListEvents(namespace string) (*v1.EventList, error)
 	ListClusterOperators() (*configv1.ClusterOperatorList, error)
+	GetClusterOperator(name string) (*configv1.ClusterOperator, error)
 	CreateEvent(namespace, name, message, component string) (*v1.Event, error)
 }
 
@@ -487,6 +488,10 @@ func (c *k8sClient) GetClusterVersion(name string) (*configv1.ClusterVersion, er
 
 func (c *k8sClient) ListClusterOperators() (*configv1.ClusterOperatorList, error) {
 	return c.configClient.ClusterOperators().List(context.TODO(), metav1.ListOptions{})
+}
+
+func (c *k8sClient) GetClusterOperator(name string) (*configv1.ClusterOperator, error) {
+	return c.configClient.ClusterOperators().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 func (c *k8sClient) CreateEvent(namespace, name, message, component string) (*v1.Event, error) {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -407,6 +407,21 @@ func (mr *MockK8SClientMockRecorder) ListClusterOperators() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterOperators", reflect.TypeOf((*MockK8SClient)(nil).ListClusterOperators))
 }
 
+// GetClusterOperator mocks base method
+func (m *MockK8SClient) GetClusterOperator(name string) (*v1.ClusterOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterOperator", name)
+	ret0, _ := ret[0].(*v1.ClusterOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterOperator indicates an expected call of GetClusterOperator
+func (mr *MockK8SClientMockRecorder) GetClusterOperator(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterOperator", reflect.TypeOf((*MockK8SClient)(nil).GetClusterOperator), name)
+}
+
 // CreateEvent mocks base method
 func (m *MockK8SClient) CreateEvent(namespace, name, message, component string) (*v10.Event, error) {
 	m.ctrl.T.Helper()

--- a/src/utils/tarutil_test.go
+++ b/src/utils/tarutil_test.go
@@ -34,12 +34,14 @@ var _ = Describe("tar_utils", func() {
 			var content bytes.Buffer
 			var tarcontent bytes.Buffer
 			zr, _ := gzip.NewReader(&outbuf)
+			// #nosec
 			_, _ = io.Copy(&tarcontent, zr)
 			tr := tar.NewReader(&tarcontent)
 
 			hdr, err := tr.Next()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hdr.Name).To(Equal("f1.log"))
+			// #nosec
 			_, _ = io.Copy(&content, tr)
 			Expect(content.String()).To(Equal("This is a test string"))
 
@@ -49,11 +51,14 @@ var _ = Describe("tar_utils", func() {
 			hdr, err = tr.Next()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hdr.Name).To(Equal("tartest.tar.gz"))
+			// #nosec
 			_, _ = io.Copy(&filezipcontent, tr)
 			filezr, _ := gzip.NewReader(&filezipcontent)
+			// #nosec
 			_, _ = io.Copy(&filetarcontent, filezr)
 			filetr := tar.NewReader(&filetarcontent)
 			_, _ = filetr.Next()
+			// #nosec
 			_, _ = io.Copy(&filecontent, filetr)
 			Expect(filecontent.String()).To(Equal("This is an example file for tar tests\n"))
 		})


### PR DESCRIPTION
In order to verify the availability of the console operator, the assisted
controller needs to monitor the console operator availability.

```
time="2021-02-15T23:51:34Z" level=info msg="Checking if console is available"
time="2021-02-15T23:51:34Z" level=warning msg="Operator console condition 'Available' is not met due to 'Deployment_FailedUpdate': DeploymentAvailable: 2 replicas ready at version 4.6.16"
time="2021-02-15T23:52:03Z" level=info msg="Start uploading controller logs (intermediate snapshot)"
time="2021-02-15T23:52:03Z" level=info msg="Uploading logs for assisted-installer-controller-g5vcx in assisted-installer"
W0215 23:52:03.346958       1 warnings.go:67] certificates.k8s.io/v1beta1 CertificateSigningRequest is deprecated in v1.19+, unavailable in v1.22+; use certificates.k8s.io/v1 CertificateSigningRequest
time="2021-02-15T23:52:03Z" level=info msg="Done uploading controller logs to the service"
time="2021-02-15T23:52:04Z" level=info msg="Checking if console is available"
time="2021-02-15T23:52:04Z" level=info msg="Console operator is available"
time="2021-02-15T23:52:04Z" level=info msg="Start complete installation step, with params success:true, error info "
time="2021-02-15T23:52:05Z" level=info msg="Done complete installation step"

```
Signed-off-by: Moti Asayag <masayag@redhat.com>