### PR TITLE
MGMT-4185 Add other minor and pre versions to tests

### DIFF
--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -232,7 +232,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			createOpenshiftSshManifestSuccess()
 			daemonReload(nil)
 		}
-		for _, version := range []string{"4.6", "4.7", "4.7.1", "4.8"} {
+		for _, version := range []string{"4.6", "4.6.16", "4.7", "4.7.1", "4.7-pre-release", "4.8"} {
 			Context(version, func() {
 				BeforeEach(func() {
 					conf.OpenshiftVersion = version


### PR DESCRIPTION
This extends the unit tests run for the AI installer to verify that both
minor and pre release versions are managed. Just one more unit test

Signed-off-by: Flavio Percoco <flavio@redhat.com>