### PR TITLE
MGMT-4479 Specify must-gather image

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
@@ -12,3 +12,4 @@ data:
   ca-cert-path: '{{.CACertPath}}'
   check-cluster-version: '{{.CheckCVO}}'
   high-availability-mode: {{.HaMode}}
+  must-gather-image: {{.MustGatherImage}}

--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -61,6 +61,12 @@ spec:
                   name: assisted-installer-controller-config
                   key: check-cluster-version
                   optional: true
+            - name: MUST_GATHER_IMAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: assisted-installer-controller-config
+                  key: must-gather-image
+                  optional: true
           {{if .CACertPath}}
           volumeMounts:
           - name: service-ca-cert-config

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -55,6 +55,7 @@ type ControllerConfig struct {
 	OpenshiftVersion      string `envconfig:"OPENSHIFT_VERSION" required:"true"`
 	HighAvailabilityMode  string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`
 	WaitForClusterVersion bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
+	MustGatherImage       string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
 }
 type Controller interface {
 	WaitAndUpdateNodesStatus(status *ControllerStatus)
@@ -637,7 +638,7 @@ func (c controller) logClusterOperatorsStatus() {
  * - controller logs
  * - oc must-gather logs
  **/
-func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSeconds int64, isMustGatherEnabled bool) error {
+func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSeconds int64, isMustGatherEnabled bool, mustGatherImg string) error {
 	var tarentries = make([]utils.TarEntry, 0)
 	var ok bool = true
 	ctx := utils.GenerateRequestContext()
@@ -646,7 +647,7 @@ func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSec
 
 	if isMustGatherEnabled {
 		c.log.Infof("Uploading oc must-gather logs")
-		if tarfile, err := c.collectMustGatherLogs(ctx); err == nil {
+		if tarfile, err := c.collectMustGatherLogs(ctx, mustGatherImg); err == nil {
 			if entry, tarerr := utils.NewTarEntryFromFile(tarfile); tarerr == nil {
 				tarentries = append(tarentries, *entry)
 			}
@@ -696,7 +697,7 @@ func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSec
 	return nil
 }
 
-func (c controller) collectMustGatherLogs(ctx context.Context) (string, error) {
+func (c controller) collectMustGatherLogs(ctx context.Context, mustGatherImg string) (string, error) {
 	tempDir, ferr := ioutil.TempDir("", "controller-must-gather-logs-")
 	if ferr != nil {
 		c.log.Errorf("Failed to create temp directory for must-gather-logs %v\n", ferr)
@@ -713,7 +714,7 @@ func (c controller) collectMustGatherLogs(ctx context.Context) (string, error) {
 	}
 
 	//collect must gather logs
-	logtar, err := c.ops.GetMustGatherLogs(tempDir, kubeconfigPath)
+	logtar, err := c.ops.GetMustGatherLogs(tempDir, kubeconfigPath, mustGatherImg)
 	if err != nil {
 		c.log.Errorf("Failed to collect must-gather logs %v\n", err)
 		return "", err
@@ -738,7 +739,7 @@ func (c *controller) UploadLogs(ctx context.Context, cancellog context.CancelFun
 				c.log.Infof("Upload final controller and cluster logs before exit")
 				c.ic.ClusterLogProgressReport(progress_ctx, c.ClusterID, models.LogsStateRequested)
 				_ = utils.WaitForPredicate(WaitTimeout, LogsUploadPeriod, func() bool {
-					err := c.uploadSummaryLogs(podName, c.Namespace, controllerLogsSecondsAgo, status.HasError())
+					err := c.uploadSummaryLogs(podName, c.Namespace, controllerLogsSecondsAgo, status.HasError(), c.MustGatherImage)
 					if err != nil {
 						c.log.Infof("retry uploading logs in 5 minutes...")
 					}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	InstallerArgs        []string
 	HighAvailabilityMode string
 	CheckClusterVersion  bool
+	MustGatherImage      string
 }
 
 var GlobalConfig Config
@@ -67,6 +68,7 @@ func ProcessArgs() {
 	flag.StringVar(&ret.ServiceIPs, "service-ips", "", "All IPs of assisted service node")
 	flag.StringVar(&ret.HighAvailabilityMode, "high-availability-mode", "Full", "high-availability expectations. default is 'Full', which represents the behavior in a \"normal\" cluster. Use 'None' for single-node deployment")
 	flag.BoolVar(&ret.CheckClusterVersion, "check-cluster-version", false, "Do not monitor CVO")
+	flag.StringVar(&ret.MustGatherImage, "must-gather-image", "", "Custom must-gather image")
 
 	var installerArgs string
 	flag.StringVar(&installerArgs, "installer-args", "", "JSON array of additional coreos-installer arguments")

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -294,18 +294,18 @@ func (mr *MockOpsMockRecorder) CreateOpenshiftSshManifest(filePath, template, ss
 }
 
 // GetMustGatherLogs mocks base method
-func (m *MockOps) GetMustGatherLogs(workDir, kubeconfigPath string) (string, error) {
+func (m *MockOps) GetMustGatherLogs(workDir, kubeconfigPath, mustGatherImg string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMustGatherLogs", workDir, kubeconfigPath)
+	ret := m.ctrl.Call(m, "GetMustGatherLogs", workDir, kubeconfigPath, mustGatherImg)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMustGatherLogs indicates an expected call of GetMustGatherLogs
-func (mr *MockOpsMockRecorder) GetMustGatherLogs(workDir, kubeconfigPath interface{}) *gomock.Call {
+func (mr *MockOpsMockRecorder) GetMustGatherLogs(workDir, kubeconfigPath, mustGatherImg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherLogs", reflect.TypeOf((*MockOps)(nil).GetMustGatherLogs), workDir, kubeconfigPath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherLogs", reflect.TypeOf((*MockOps)(nil).GetMustGatherLogs), workDir, kubeconfigPath, mustGatherImg)
 }
 
 // CreateRandomHostname mocks base method


### PR DESCRIPTION
Tell must-gather command which image to use. This should enable
to run must-gather with an available and working image instead of
the default latest in cases when it's not possible to get an image
ID from OCP stream (e.g. the API fails).