### PR TITLE
MGMT-4839 Reduce spam logs from ops.ExecCommand

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -148,7 +148,10 @@ func (o *ops) ExecCommand(liveLogger io.Writer, command string, args ...string) 
 				execErr.WaitStatus = status.ExitStatus()
 			}
 		}
-		o.log.Info(execErr.DetailedError())
+		if liveLogger != nil {
+			//If the caller didn't provide liveLogger the log isn't interesting and might spam
+			o.log.Info(execErr.DetailedError())
+		}
 		return output, execErr
 	}
 	o.log.Debug("Command executed:", " command", command, " arguments", args, "env vars", cmd.Env, "output", output)


### PR DESCRIPTION
This function get called in loops while waiting for marker files, logging every command that failed sapm the log
When the command output matters the caller pass liveLogger, in such case it should log the detailed command error