### PR TITLE
MGMT-4836 Enhance unknown host logs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1129,6 +1129,7 @@ github.com/operator-framework/api v0.6.1 h1:bTOj1GseGV5oZc5iNQL5ZMqzP430sefNMkPb
 github.com/operator-framework/api v0.6.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.7.0 h1:uND/8x4J44eVEsGHeNMIQUYlduggG61CNPXlO8eXf3k=
 github.com/operator-framework/api v0.7.0/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
+github.com/operator-framework/api v0.7.1 h1:L1KKlfvEVp9qP1KnkQApb7xuOnrWG3Ds9XkY6BxDXOc=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88 h1:ByKBik0i2aTEr7iKdSCmUGULydHwr6hA0h4INv9LkSA=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88/go.mod h1:7Ut8p9jJ8C6RZyyhZfZypmlibCIJwK5Wcc+WZDgLkOA=

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -116,11 +116,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	getInventoryNodes := func(numOfFullListReturn int) map[string]inventory_client.HostData {
 		for i := 0; i < numOfFullListReturn; i++ {
-			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-				models.HostStatusInstalled}).Return(inventoryNamesIds, nil).Times(1)
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+				Return(inventoryNamesIds, nil).Times(1)
 		}
-		mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-			models.HostStatusInstalled}).Return(map[string]inventory_client.HostData{}, nil).Times(1)
+		mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+			Return(map[string]inventory_client.HostData{}, nil).Times(1)
 		return inventoryNamesIds
 	}
 	configuringSuccess := func() {
@@ -212,8 +212,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			configuringSuccess()
 			listNodes()
 
-			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-				models.HostStatusInstalled}).Return(map[string]inventory_client.HostData{}, fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+				Return(map[string]inventory_client.HostData{}, fmt.Errorf("dummy")).Times(1)
 			getInventoryNodes(1)
 
 			assistedController.WaitAndUpdateNodesStatus(status)
@@ -226,8 +226,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				for _, host := range inventoryNamesIds {
 					host.Host.Status = &errorStatus
 				}
-				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-					models.HostStatusInstalled}).Return(inventoryNamesIds, nil).Times(1)
+				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+					Return(inventoryNamesIds, nil).Times(1)
 			}
 			getInventoryNodesInError()
 			assistedController.WaitAndUpdateNodesStatus(status)
@@ -260,12 +260,12 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					for key, value := range inventoryNamesIds {
 						targetMap[key] = value
 					}
-					mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-						models.HostStatusInstalled}).Return(targetMap, nil).Times(1)
+					mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+						Return(targetMap, nil).Times(1)
 					delete(inventoryNamesIds, name)
 				}
-				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled,
-					models.HostStatusInstalled}).Return(inventoryNamesIds, nil).Times(1)
+				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+					Return(inventoryNamesIds, nil).Times(1)
 			}
 
 			updateProgressSuccess(defaultStages, inventoryNamesIds)


### PR DESCRIPTION
The controller doesn't inform in case there's an unknown hostname
in the k8s nodes. It will just get a timeout for not finding the wanted hosts.
    
In addition, the bootstrap does inform about it (warning logs) while it should fail.