### PR TITLE
OCPBUGSM-27324 Some hosts may never publish "Writing image to disk: 100%" event

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -751,6 +751,7 @@ github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -1041,6 +1042,7 @@ github.com/onsi/ginkgo v1.15.1 h1:DsXNrKujDlkMS9Rsxmd+Fg7S6Kc5lhE+qX8tY6laOxc=
 github.com/onsi/ginkgo v1.15.1/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
 github.com/onsi/ginkgo v1.15.2 h1:l77YT15o814C2qVL47NOyjV/6RbaP7kKdrvZnxQ3Org=
 github.com/onsi/ginkgo v1.15.2/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
+github.com/onsi/ginkgo v1.16.0 h1:NBrNLB37exjJLxXtFOktx6CISBdS1aF8+7MwKlTV8U4=
 github.com/onsi/ginkgo v1.16.0/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/src/ops/coreos_installer_log_writer.go
+++ b/src/ops/coreos_installer_log_writer.go
@@ -14,6 +14,7 @@ import (
 )
 
 const MinProgressDelta = 5
+const completed = 100
 
 type CoreosInstallerLogWriter struct {
 	log              *logrus.Logger
@@ -56,7 +57,7 @@ func (l *CoreosInstallerLogWriter) reportProgress() {
 	if err != nil {
 		return
 	}
-	if currentPercent >= l.lastProgress+MinProgressDelta {
+	if currentPercent >= l.lastProgress+MinProgressDelta || (currentPercent == completed && l.lastProgress != completed) {
 		// If the progress is more than 5% report it
 		ctx := utils.GenerateRequestContext()
 		if err := l.progressReporter.UpdateHostInstallProgress(ctx, l.hostID, models.HostStageWritingImageToDisk, match[2]); err == nil {

--- a/src/ops/coreos_installer_log_writer_test.go
+++ b/src/ops/coreos_installer_log_writer_test.go
@@ -123,7 +123,51 @@ var _ = Describe("Verify CoreosInstallerLogger", func() {
 				Expect(err).Should(BeNil())
 			}
 			Expect(len(hook.Entries)).Should(Equal(10))
+		})
 
+		It("test multiple lines with 100%", func() {
+			updateProgressSuccess([][]string{{string(models.HostStageWritingImageToDisk), "55%"},
+				{string(models.HostStageWritingImageToDisk), "60%"},
+				{string(models.HostStageWritingImageToDisk), "98%"},
+				{string(models.HostStageWritingImageToDisk), "100%"},
+			})
+			testLogs := []string{"> Read disk 471.2 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.6 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.8 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.9 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 473.0 MiB/844.7 MiB (60%)   \r",
+				"> Read disk 473.3 MiB/844.7 MiB (62%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (98%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (100%)   \r"}
+			for i := range testLogs {
+				_, err := cilogger.Write([]byte(testLogs[i]))
+				Expect(err).Should(BeNil())
+			}
+			Expect(len(hook.Entries)).Should(Equal(8))
+
+		})
+		It("test multiple lines with multiple 100%", func() {
+			updateProgressSuccess([][]string{{string(models.HostStageWritingImageToDisk), "55%"},
+				{string(models.HostStageWritingImageToDisk), "60%"},
+				{string(models.HostStageWritingImageToDisk), "66%"},
+				{string(models.HostStageWritingImageToDisk), "98%"},
+				{string(models.HostStageWritingImageToDisk), "100%"},
+			})
+			testLogs := []string{"> Read disk 471.2 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.6 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.8 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 472.9 MiB/844.7 MiB (55%)   \r",
+				"> Read disk 473.0 MiB/844.7 MiB (60%)   \r",
+				"> Read disk 473.3 MiB/844.7 MiB (62%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (98%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (99%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (100%)   \r",
+				"> Read disk 473.8 MiB/844.7 MiB (100%)   \r"}
+			for i := range testLogs {
+				_, err := cilogger.Write([]byte(testLogs[i]))
+				Expect(err).Should(BeNil())
+			}
+			Expect(len(hook.Entries)).Should(Equal(10))
 		})
 	})
 })


### PR DESCRIPTION
Report progress if the progress percentage is 100 regardless of the progress delta
Make sure we don't spam and only report it once by verifying that the lastProgress isn't 100%