### PR TITLE
OCPBUGSM-27526 Sync operator status with the service

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1044,6 +1044,7 @@ github.com/onsi/ginkgo v1.15.2 h1:l77YT15o814C2qVL47NOyjV/6RbaP7kKdrvZnxQ3Org=
 github.com/onsi/ginkgo v1.15.2/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
 github.com/onsi/ginkgo v1.16.0 h1:NBrNLB37exjJLxXtFOktx6CISBdS1aF8+7MwKlTV8U4=
 github.com/onsi/ginkgo v1.16.0/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
+github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
 github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1140,6 +1141,7 @@ github.com/operator-framework/api v0.7.0 h1:uND/8x4J44eVEsGHeNMIQUYlduggG61CNPXl
 github.com/operator-framework/api v0.7.0/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.7.1 h1:L1KKlfvEVp9qP1KnkQApb7xuOnrWG3Ds9XkY6BxDXOc=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
+github.com/operator-framework/api v0.8.0 h1:S1R5BaPKeZoACbu0913mPnG33s7GOA2VrT9gvOeBjbU=
 github.com/operator-framework/api v0.8.0/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88 h1:ByKBik0i2aTEr7iKdSCmUGULydHwr6hA0h4INv9LkSA=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88/go.mod h1:7Ut8p9jJ8C6RZyyhZfZypmlibCIJwK5Wcc+WZDgLkOA=

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -123,6 +123,36 @@ func (mr *MockInventoryClientMockRecorder) GetCluster(ctx interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx)
 }
 
+// GetClusterMonitoredOperator mocks base method
+func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName string) (*models.MonitoredOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName)
+	ret0, _ := ret[0].(*models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName)
+}
+
+// GetClusterMonitoredOLMOperators mocks base method
+func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId string) ([]models.MonitoredOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId)
+	ret0, _ := ret[0].([]models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId)
+}
+
 // CompleteInstallation mocks base method
 func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
 	m.ctrl.T.Helper()
@@ -205,7 +235,7 @@ func (mr *MockInventoryClientMockRecorder) UpdateClusterInstallProgress(ctx, clu
 }
 
 // UpdateClusterOperator mocks base method
-func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId string, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
+func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterOperator", ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
 	ret0, _ := ret[0].(error)
@@ -216,19 +246,4 @@ func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, cluster
 func (mr *MockInventoryClientMockRecorder) UpdateClusterOperator(ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterOperator", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterOperator), ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
-}
-
-// GetClusterMonitoredOLMOperators mocks base method
-func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId string) ([]models.MonitoredOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId)
-	ret0, _ := ret[0].([]models.MonitoredOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId)
 }

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -13,7 +13,7 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	ops "github.com/openshift/assisted-installer/src/ops"
 	v1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1alpha10 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v10 "k8s.io/api/certificates/v1"
 	v11 "k8s.io/api/core/v1"
 )
@@ -246,11 +246,11 @@ func (mr *MockK8SClientMockRecorder) GetPods(namespace, labelMatch, fieldSelecto
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockK8SClient)(nil).GetPods), namespace, labelMatch, fieldSelector)
 }
 
-// GetCSV indicates an expected call of GetCSV
-func (m *MockK8SClient) GetCSV(namespace string, name string) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+// GetCSV mocks base method
+func (m *MockK8SClient) GetCSV(namespace, name string) (*v1alpha10.ClusterServiceVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCSV", namespace, name)
-	ret0, _ := ret[0].(*operatorsv1alpha1.ClusterServiceVersion)
+	ret0, _ := ret[0].(*v1alpha10.ClusterServiceVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -261,8 +261,8 @@ func (mr *MockK8SClientMockRecorder) GetCSV(namespace, name interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSV", reflect.TypeOf((*MockK8SClient)(nil).GetCSV), namespace, name)
 }
 
-// GetCSVFromSubscription indicates an expected call of GetCSVFromSubscription
-func (m *MockK8SClient) GetCSVFromSubscription(namespace string, name string) (string, error) {
+// GetCSVFromSubscription mocks base method
+func (m *MockK8SClient) GetCSVFromSubscription(namespace, name string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCSVFromSubscription", namespace, name)
 	ret0, _ := ret[0].(string)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -272,5 +272,6 @@ func ClusterOperatorConditionsToMonitoredOperatorStatus(conditions []configv1.Cl
 			return models.OperatorStatusFailed, condition.Message
 		}
 	}
+
 	return models.OperatorStatusProgressing, ""
 }


### PR DESCRIPTION
Without the sync, a network issue could occur and an operator update could be
missed. Hence, it is mandatory to verify that the service is aligned
with the operators' statuses before existing.

In addition, a lot of organization in the assisted_installer_controller
UTs.

The OLM implementation already takes care of going over the progressing
monitored operator.

/cc @nmagnezi @tsorya 