### PR TITLE
MGMT-5188 Deprecate UpdateClusterInstallProgress API

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -719,12 +719,6 @@ func (c controller) waitingForClusterVersion() error {
 			if err := c.ic.UpdateClusterOperator(utils.GenerateRequestContext(), c.ClusterID, cvoOperatorName, operatorStatus, operatorMessage); err != nil {
 				c.log.WithError(err).Errorf("Failed to update cluster %s cvo status", c.ClusterID)
 			}
-
-			// TODO: MGMT-5188
-			// Old CVO progress API. Should be deprecated
-			if err := c.ic.UpdateClusterInstallProgress(utils.GenerateRequestContext(), c.ClusterID, status); err != nil {
-				c.log.WithError(err).Errorf("Failed to update cluster %s installation progress status", c.ClusterID)
-			}
 		}
 
 		return false

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -474,7 +474,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				// CVO
 				mockk8sclient.EXPECT().GetClusterVersion("version").Return(nil, fmt.Errorf("dummy")).Times(1)
-				mockbmclient.EXPECT().UpdateClusterInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1)
 
 				mockk8sclient.EXPECT().GetClusterVersion("version").Return(progressClusterVersionCondition, nil).Times(1)
 				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName).
@@ -973,7 +972,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				if t.shouldSendUpdate {
 					mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).Times(1)
-					mockbmclient.EXPECT().UpdateClusterInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				}
 
 				if t.currentCVOStatus.Status == models.OperatorStatusAvailable {

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -54,7 +54,6 @@ type InventoryClient interface {
 	UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error
 	ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState)
 	HostLogProgressReport(ctx context.Context, clusterId string, hostId string, progress models.LogsState)
-	UpdateClusterInstallProgress(ctx context.Context, clusterId string, progress string) error
 	UpdateClusterOperator(ctx context.Context, clusterId string, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error
 }
 
@@ -361,14 +360,6 @@ func (c *inventoryClient) HostLogProgressReport(ctx context.Context, clusterId s
 	if err != nil {
 		c.logger.WithError(err).Errorf("failed to report log progress %s on host %s", progress, hostId)
 	}
-}
-
-func (c *inventoryClient) UpdateClusterInstallProgress(ctx context.Context, clusterId string, progress string) error {
-	_, err := c.ai.Installer.UpdateClusterInstallProgress(ctx, &installer.UpdateClusterInstallProgressParams{
-		ClusterID:       strfmt.UUID(clusterId),
-		ClusterProgress: progress,
-	})
-	return aserror.GetAssistedError(err)
 }
 
 func (c *inventoryClient) UpdateClusterOperator(ctx context.Context, clusterId string, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -220,20 +220,6 @@ func (mr *MockInventoryClientMockRecorder) HostLogProgressReport(ctx, clusterId,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).HostLogProgressReport), ctx, clusterId, hostId, progress)
 }
 
-// UpdateClusterInstallProgress mocks base method
-func (m *MockInventoryClient) UpdateClusterInstallProgress(ctx context.Context, clusterId, progress string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterInstallProgress", ctx, clusterId, progress)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateClusterInstallProgress indicates an expected call of UpdateClusterInstallProgress
-func (mr *MockInventoryClientMockRecorder) UpdateClusterInstallProgress(ctx, clusterId, progress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterInstallProgress), ctx, clusterId, progress)
-}
-
 // UpdateClusterOperator mocks base method
 func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
CVO is being monitored using the generic cluster monitored operators
API. There's no need for the cluster progress field anymore.
All the relevant code was deleted.

/cc @nmagnezi 
Matches https://github.com/openshift/assisted-service/pull/1509