### PR TITLE
OCPBUGSM-27762 Automatic boot order setting is done incorrectly when …

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,7 @@ github.com/go-openapi/runtime v0.19.26 h1:K/6PoVNj5WJXUnMk+VEbELeXjtBkCS1UxTDa04
 github.com/go-openapi/runtime v0.19.26/go.mod h1:BvrQtn6iVb2QmiVXRsFAm6ZCAZBpbVKFfN6QWCp582M=
 github.com/go-openapi/runtime v0.19.27 h1:4zrQCJoP7rqNCUaApDv1MdPkaa5TuPfO05Lq5WLhX9I=
 github.com/go-openapi/runtime v0.19.27/go.mod h1:BvrQtn6iVb2QmiVXRsFAm6ZCAZBpbVKFfN6QWCp582M=
+github.com/go-openapi/runtime v0.19.28 h1:9lYu6axek8LJrVkMVViVirRcpoaCxXX7+sSvmizGVnA=
 github.com/go-openapi/runtime v0.19.28/go.mod h1:BvrQtn6iVb2QmiVXRsFAm6ZCAZBpbVKFfN6QWCp582M=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -71,7 +71,7 @@ func (i *installer) InstallNode() error {
 	i.log.Infof("Installing node with role: %s", i.Config.Role)
 
 	i.UpdateHostInstallProgress(models.HostStageStartingInstallation, i.Config.Role)
-
+	i.Config.Device = i.ops.EvaluateDiskSymlink(i.Config.Device)
 	i.log.Infof("Start cleaning up device %s", i.Device)
 	err := i.cleanupInstallDevice()
 	if err != nil {

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -350,3 +350,17 @@ func (mr *MockOpsMockRecorder) GetHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockOps)(nil).GetHostname))
 }
+
+// EvaluateDiskSymlink mocks base method
+func (m *MockOps) EvaluateDiskSymlink(arg0 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvaluateDiskSymlink", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// EvaluateDiskSymlink indicates an expected call of EvaluateDiskSymlink
+func (mr *MockOpsMockRecorder) EvaluateDiskSymlink(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDiskSymlink", reflect.TypeOf((*MockOps)(nil).EvaluateDiskSymlink), arg0)
+}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -46,6 +46,7 @@ type Ops interface {
 	GetMustGatherLogs(workDir, kubeconfigPath, mustGatherImg string) (string, error)
 	CreateRandomHostname(hostname string) error
 	GetHostname() (string, error)
+	EvaluateDiskSymlink(string) string
 }
 
 const (
@@ -174,7 +175,6 @@ func (o *ops) SystemctlAction(action string, args ...string) error {
 }
 
 func (o *ops) WriteImageToDisk(ignitionPath string, device string, progressReporter inventory_client.InventoryClient, extraArgs []string) error {
-	device = o.getTargetDevice(device)
 	allArgs := installerArgs(ignitionPath, device, extraArgs)
 	o.log.Infof("Writing image and ignition to disk with arguments: %v", allArgs)
 	_, err := o.ExecPrivilegeCommand(NewCoreosInstallerLogWriter(o.log, progressReporter, config.GlobalConfig.HostID),
@@ -182,7 +182,7 @@ func (o *ops) WriteImageToDisk(ignitionPath string, device string, progressRepor
 	return err
 }
 
-func (o *ops) getTargetDevice(device string) string {
+func (o *ops) EvaluateDiskSymlink(device string) string {
 	// Overcome https://github.com/coreos/coreos-installer/issues/512 bug.
 	// coreos-installer has a bug where when a disk has busy partitions, it will
 	// print a confusing error message if that disk doesn't have a `/dev/*` style path.
@@ -194,7 +194,7 @@ func (o *ops) getTargetDevice(device string) string {
 		o.log.Warnf("Failed to filepath.EvalSymlinks(%s): %s. Continuing with %s anyway.",
 			device, err.Error(), device)
 	} else {
-		o.log.Infof("Resolving %s symlink to %s for coreos-installer", device, linkTarget)
+		o.log.Infof("Resolving installation device %s symlink to %s ", device, linkTarget)
 		device = linkTarget
 	}
 	return device


### PR DESCRIPTION
…using by-path style device names

Evaluate the installation device symlink to the actual disk path at the start of the installation