### PR TITLE
MGMT-4668: Add support to create manifest in assisted-installer

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -545,6 +545,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					Return(&models.MonitoredOperator{Status: models.OperatorStatusAvailable, StatusInfo: availableClusterVersionCondition.Status.Conditions[0].Message}, nil).Times(1)
 
 				// Completion
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "custom_manifests.yaml", gomock.Any()).Return(nil).Times(1)
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "kubeconfig-noingress", gomock.Any()).Return(nil).Times(1)
+				mockops.EXPECT().CreateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any()).Return([]models.MonitoredOperator{}, nil).Times(2)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
@@ -576,6 +579,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			})
 			It("success", func() {
 				installing := models.ClusterStatusInstalling
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "custom_manifests.yaml", gomock.Any()).Return(nil).Times(1)
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "kubeconfig-noingress", gomock.Any()).Return(nil).Times(1)
+				mockops.EXPECT().CreateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(1)
 				setClusterAsFinalizing()
@@ -613,6 +619,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			It("waiting for single OLM operator", func() {
 				setControllerWaitForOLMOperators(assistedController.ClusterID)
 
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "custom_manifests.yaml", gomock.Any()).Return(nil).Times(1)
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "kubeconfig-noingress", gomock.Any()).Return(nil).Times(1)
+				mockops.EXPECT().CreateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any()).Return(
 					[]models.MonitoredOperator{{SubscriptionName: "local-storage-operator", Namespace: "openshift-local-storage", OperatorType: models.OperatorTypeOlm, Name: "lso", Status: "", TimeoutSeconds: 120 * 60}}, nil,
 				).Times(1)
@@ -636,6 +645,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			It("waiting for single OLM operator which timeouts", func() {
 				setControllerWaitForOLMOperators(assistedController.ClusterID)
 
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "custom_manifests.yaml", gomock.Any()).Return(nil).Times(1)
+				mockbmclient.EXPECT().DownloadFile(gomock.Any(), "kubeconfig-noingress", gomock.Any()).Return(nil).Times(1)
+				mockops.EXPECT().CreateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any()).Return(
 					[]models.MonitoredOperator{{SubscriptionName: "local-storage-operator", Namespace: "openshift-local-storage", OperatorType: models.OperatorTypeOlm, Name: "lso", Status: models.OperatorStatusProgressing, TimeoutSeconds: 1}}, nil,
 				).AnyTimes()

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -364,3 +364,17 @@ func (mr *MockOpsMockRecorder) EvaluateDiskSymlink(arg0 interface{}) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDiskSymlink", reflect.TypeOf((*MockOps)(nil).EvaluateDiskSymlink), arg0)
 }
+
+// CreateManifests mocks base method
+func (m *MockOps) CreateManifests(arg0 string, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateManifests", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateManifests indicates an expected call of CreateManifests
+func (mr *MockOpsMockRecorder) CreateManifests(arg0 interface{}, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManifests", reflect.TypeOf((*MockOps)(nil).CreateManifests), arg0, arg1)
+}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -47,6 +47,7 @@ type Ops interface {
 	CreateRandomHostname(hostname string) error
 	GetHostname() (string, error)
 	EvaluateDiskSymlink(string) string
+	CreateManifests(string, string) error
 }
 
 const (
@@ -565,4 +566,15 @@ func (o *ops) CreateRandomHostname(hostname string) error {
 
 func (o *ops) GetHostname() (string, error) {
 	return os.Hostname()
+}
+
+func (o *ops) CreateManifests(kubeconfig string, manifestFilePath string) error {
+	command := fmt.Sprintf("oc --kubeconfig=%s apply -f %s", kubeconfig, manifestFilePath)
+	output, err := o.ExecCommand(o.logWriter, "bash", "-c", command)
+	if err != nil {
+		return err
+	}
+	o.log.Info(output)
+
+	return nil
 }


### PR DESCRIPTION
This PR add a possibility to create manifests from assisted-installer.
In some cases it may be useful to create manifest from
assisted-isntaller instead of openshift-installer. For example when
installing CNV/LSO/OCS we need to have predefined CRDs for the
operators, because at the time of the operator is being created the CRDs
are not yet created by the OLM.

This PR add support to read the files from `custom_manifests.yaml` which is retrieved
from the assisted-service. The manifest are created via `oc create -f` command,
using the `kubeconfig-noingress` file.