### PR TITLE
MGMT-4992 - stop controller after 10 errors of 401/404.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/ignition/v2 v2.10.1
 	github.com/go-openapi/runtime v0.19.28
 	github.com/go-openapi/strfmt v0.20.1
+	github.com/go-openapi/swag v0.19.9
 	github.com/golang/mock v1.5.0
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-version v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,7 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
@@ -1113,6 +1114,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.3.0+incompatible h1:CZzRn4Ut9GbUkHlQ7jqBXeZQV41ZSKWFc302ZU6lUTk=
 github.com/pierrec/lz4 v2.3.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pin/tftp v2.1.0+incompatible/go.mod h1:xVpZOMCXTy+A5QMjEVN0Glwa1sUvaJhFXbr/aAxuxGY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1122,6 +1124,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/xattr v0.4.1 h1:dhclzL6EqOXNaPDWqoeb9tIxATfBSmjqL0b4DpSjwRw=
 github.com/pkg/xattr v0.4.1/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnFs=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -1309,6 +1312,7 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -1854,6 +1858,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
+gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=
 gopkg.in/djherbis/times.v1 v1.2.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -51,8 +51,10 @@ var (
 	GeneralProgressUpdateInt = 60 * time.Second
 	LogsUploadPeriod         = 5 * time.Minute
 	WaitTimeout              = 70 * time.Minute
+	CompleteTimeout          = 30 * time.Minute
 	DNSAddressRetryInterval  = 20 * time.Second
 	DeletionRetryInterval    = 10 * time.Second
+	LongWaitTimeout          = 10 * time.Hour
 )
 
 // assisted installer controller is added to control installation process after  bootstrap pivot
@@ -116,79 +118,96 @@ func logHostsStatus(log logrus.FieldLogger, hosts map[string]inventory_client.Ho
 	log.Infof("Hosts status: %v", hostsStatus)
 }
 
-func (c *controller) WaitAndUpdateNodesStatus(status *ControllerStatus) {
+// WaitAndUpdateNodesStatus waits till all nodes joins the cluster and become ready
+// it will update joined/done status
+// approve csr will run as routine and cancelled whenever all nodes are ready and joined
+// this will allow to run it and end only when it is needed
+func (c *controller) WaitAndUpdateNodesStatus(ctx context.Context, wg *sync.WaitGroup) {
+	approveCtx, approveCancel := context.WithCancel(ctx)
+	defer func() {
+		approveCancel()
+		c.log.Infof("WaitAndUpdateNodesStatus finished")
+		wg.Done()
+	}()
+	// starting approve csrs
+	go c.ApproveCsrs(approveCtx)
 
 	c.log.Infof("Waiting till all nodes will join and update status to assisted installer")
+	_ = utils.WaitForPredicateWithContext(ctx, LongWaitTimeout, GeneralWaitInterval, c.waitAndUpdateNodesStatus)
+}
+
+func (c *controller) waitAndUpdateNodesStatus() bool {
 	ignoreStatuses := []string{models.HostStatusDisabled}
 	var hostsInError int
-	for {
-		time.Sleep(GeneralWaitInterval)
-		ctx := utils.GenerateRequestContext()
-		log := utils.RequestIDLogger(ctx, c.log)
+	ctxReq := utils.GenerateRequestContext()
+	log := utils.RequestIDLogger(ctxReq, c.log)
 
-		assistedNodesMap, err := c.ic.GetHosts(ctx, log, ignoreStatuses)
-		if err != nil {
-			log.WithError(err).Error("Failed to get node map from the assisted service")
+	assistedNodesMap, err := c.ic.GetHosts(ctxReq, log, ignoreStatuses)
+	if err != nil {
+		log.WithError(err).Error("Failed to get node map from the assisted service")
+		return false
+	}
+
+	logHostsStatus(log, assistedNodesMap)
+
+	hostsInProgressMap := common.GetHostsInStatus(assistedNodesMap, []string{models.HostStatusInstalled}, false)
+	errNodesMap := common.GetHostsInStatus(hostsInProgressMap, []string{models.HostStatusError}, true)
+	hostsInError = len(errNodesMap)
+
+	//if all hosts are in error, mark the failure and finish
+	if hostsInError > 0 && hostsInError == len(hostsInProgressMap) {
+		c.log.Infof("Done waiting for all the nodes. Nodes in error status: %d\n", hostsInError)
+		return true
+	}
+	//if all hosts are successfully installed, finish
+	if len(hostsInProgressMap) == 0 {
+		c.log.Infof("All nodes were successfully installed")
+		return true
+	}
+	//otherwise, update the progress status and keep waiting
+	log.Infof("Checking if cluster nodes are ready. %d nodes remaining", len(hostsInProgressMap))
+	nodes, err := c.kc.ListNodes()
+	if err != nil {
+		log.WithError(err).Error("Failed to get list of nodes from k8s client")
+		return false
+	}
+	for _, node := range nodes.Items {
+		host, ok := hostsInProgressMap[strings.ToLower(node.Name)]
+		if !ok {
+			if _, ok := assistedNodesMap[strings.ToLower(node.Name)]; !ok {
+				log.Warnf("Node %s is not in inventory hosts", strings.ToLower(node.Name))
+			}
+
 			continue
 		}
-
-		logHostsStatus(log, assistedNodesMap)
-
-		hostsInProgressMap := common.GetHostsInStatus(assistedNodesMap, []string{models.ClusterStatusInstalled}, false)
-		errNodesMap := common.GetHostsInStatus(hostsInProgressMap, []string{models.HostStatusError}, true)
-		hostsInError = len(errNodesMap)
-
-		//if all hosts are in error, mark the failure and finish
-		if hostsInError > 0 && hostsInError == len(hostsInProgressMap) {
-			status.Error()
-			break
-		}
-		//if all hosts are successfully installed, finish
-		if len(hostsInProgressMap) == 0 {
-			break
-		}
-		//otherwise, update the progress status and keep waiting
-		log.Infof("Checking if cluster nodes are ready. %d nodes remaining", len(hostsInProgressMap))
-		nodes, err := c.kc.ListNodes()
-		if err != nil {
-			log.WithError(err).Error("Failed to get list of nodes from k8s client")
-			continue
-		}
-		for _, node := range nodes.Items {
-			host, ok := hostsInProgressMap[strings.ToLower(node.Name)]
-			if !ok {
-				if _, ok := assistedNodesMap[strings.ToLower(node.Name)]; !ok {
-					log.Warnf("Node %s is not in inventory hosts", strings.ToLower(node.Name))
-				}
-
+		if common.IsK8sNodeIsReady(node) {
+			log.Infof("Found new ready node %s with inventory id %s, kubernetes id %s, updating its status to %s",
+				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageDone)
+			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.ID.String(), models.HostStageDone, ""); err != nil {
+				log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
 				continue
 			}
-			if common.IsK8sNodeIsReady(node) {
-				log.Infof("Found new ready node %s with inventory id %s, kubernetes id %s, updating its status to %s",
-					node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageDone)
-				if err := c.ic.UpdateHostInstallProgress(ctx, host.Host.ID.String(), models.HostStageDone, ""); err != nil {
-					log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
-					continue
-				}
-			} else if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
-				log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
-					node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
-				if err := c.ic.UpdateHostInstallProgress(ctx, host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
-					log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
-					continue
-				}
+		} else if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
+			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
+				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
+			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
+				log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
+				continue
 			}
 		}
-		c.updateConfiguringStatusIfNeeded(assistedNodesMap)
 	}
-	c.log.Infof("Done waiting for all the nodes. Nodes in error status: %d\n", hostsInError)
+	c.updateConfiguringStatusIfNeeded(assistedNodesMap)
+	return false
 }
 
 func (c *controller) HackDNSAddressConflict(wg *sync.WaitGroup) {
 
 	c.log.Infof("Making sure service %s can reserve the .10 address", dnsServiceName)
 
-	defer wg.Done()
+	defer func() {
+		c.log.Infof("HackDNSAddressConflict finished")
+		wg.Done()
+	}()
 	networks, err := c.kc.GetServiceNetworks()
 	if err != nil || len(networks) == 0 {
 		c.log.Errorf("Failed to get service networks: %s", err)
@@ -279,8 +298,7 @@ func (c *controller) updateConfiguringStatusIfNeeded(hosts map[string]inventory_
 	common.SetConfiguringStatusForHosts(c.ic, hosts, logs, false, c.log)
 }
 
-func (c *controller) ApproveCsrs(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (c *controller) ApproveCsrs(ctx context.Context) {
 	c.log.Infof("Start approving CSRs")
 	ticker := time.NewTicker(GeneralWaitInterval)
 	for {
@@ -318,46 +336,56 @@ func isCsrApproved(csr *certificatesv1.CertificateSigningRequest) bool {
 	return false
 }
 
-func (c controller) PostInstallConfigs(wg *sync.WaitGroup, status *ControllerStatus) {
-	defer wg.Done()
-	for {
-		time.Sleep(GeneralWaitInterval)
-		ctx := utils.GenerateRequestContext()
+func (c controller) PostInstallConfigs(ctx context.Context, wg *sync.WaitGroup, status *ControllerStatus) {
+	defer func() {
+		c.log.Infof("Finished PostInstallConfigs")
+		wg.Done()
+	}()
+	err := utils.WaitForPredicateWithContext(ctx, LongWaitTimeout, GeneralWaitInterval, func() bool {
+		ctxReq := utils.GenerateRequestContext()
 		cluster, err := c.ic.GetCluster(ctx)
 		if err != nil {
-			utils.RequestIDLogger(ctx, c.log).WithError(err).Errorf("Failed to get cluster %s from assisted-service", c.ClusterID)
-			continue
+			utils.RequestIDLogger(ctxReq, c.log).WithError(err).Errorf("Failed to get cluster %s from assisted-service", c.ClusterID)
+			return false
 		}
 		// waiting till cluster will be installed(3 masters must be installed)
 		if *cluster.Status != models.ClusterStatusFinalizing {
-			continue
+			return false
 		}
-		break
+		return true
+	})
+	if err != nil {
+		return
 	}
 
 	errMessage := ""
-	err := c.postInstallConfigs()
+	err = c.postInstallConfigs(ctx)
+	// context was cancelled, requires usage of WaitForPredicateWithContext
+	// no reason to set error
+	if ctx.Err() != nil {
+		return
+	}
 	if err != nil {
 		errMessage = err.Error()
 		status.Error()
 	}
 	success := err == nil
-	c.sendCompleteInstallation(success, errMessage)
+	c.sendCompleteInstallation(ctx, success, errMessage)
 }
 
-func (c controller) postInstallConfigs() error {
+func (c controller) postInstallConfigs(ctx context.Context) error {
 	var err error
 
 	c.log.Infof("Waiting for cluster version operator: %t", c.WaitForClusterVersion)
 
 	if c.WaitForClusterVersion {
-		err = c.waitingForClusterVersion()
+		err = c.waitingForClusterVersion(ctx)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = utils.WaitForPredicate(WaitTimeout, GeneralWaitInterval, c.addRouterCAToClusterCA)
+	err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.addRouterCAToClusterCA)
 	if err != nil {
 		return errors.Errorf("Timeout while waiting router ca data")
 	}
@@ -367,7 +395,7 @@ func (c controller) postInstallConfigs() error {
 		return err
 	}
 	if unpatch && c.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone {
-		err = utils.WaitForPredicate(WaitTimeout, GeneralWaitInterval, c.unpatchEtcd)
+		err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.unpatchEtcd)
 		if err != nil {
 			return errors.Errorf("Timeout while trying to unpatch etcd")
 		}
@@ -375,13 +403,13 @@ func (c controller) postInstallConfigs() error {
 		c.log.Infof("Skipping etcd unpatch for cluster version %s", c.ControllerConfig.OpenshiftVersion)
 	}
 
-	err = utils.WaitForPredicate(WaitTimeout, GeneralWaitInterval, c.validateConsoleAvailability)
+	err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.validateConsoleAvailability)
 	if err != nil {
 		return errors.Errorf("Timeout while waiting for console to become available")
 	}
 
 	waitTimeout := c.getMaximumOLMTimeout()
-	err = utils.WaitForPredicate(waitTimeout, GeneralWaitInterval, c.waitForOLMOperators)
+	err = utils.WaitForPredicateWithContext(ctx, waitTimeout, GeneralWaitInterval, c.waitForOLMOperators)
 	if err != nil {
 		// In case the timeout occur, we have to update the pending OLM operators to failed state,
 		// so the assisted-service can update the cluster state to completed.
@@ -394,14 +422,16 @@ func (c controller) postInstallConfigs() error {
 	return nil
 }
 
-func (c controller) UpdateBMHs(wg *sync.WaitGroup) {
-	defer wg.Done()
-	for {
-		time.Sleep(GeneralWaitInterval)
+func (c controller) UpdateBMHs(ctx context.Context, wg *sync.WaitGroup) {
+	defer func() {
+		c.log.Infof("Finished UpdateBMHs")
+		wg.Done()
+	}()
+	_ = utils.WaitForPredicateWithContext(ctx, time.Duration(1<<63-1), GeneralWaitInterval, func() bool {
 		bmhs, err := c.kc.ListBMHs()
 		if err != nil {
 			c.log.WithError(err).Errorf("Failed to list BMH hosts")
-			continue
+			return false
 		}
 
 		c.log.Infof("Number of BMHs is %d", len(bmhs.Items))
@@ -409,7 +439,7 @@ func (c controller) UpdateBMHs(wg *sync.WaitGroup) {
 		machines, err := c.unallocatedMachines(bmhs)
 		if err != nil {
 			c.log.WithError(err).Errorf("Failed to find unallocated machines")
-			continue
+			return false
 		}
 
 		c.log.Infof("Number of unallocated Machines is %d", len(machines.Items))
@@ -417,9 +447,10 @@ func (c controller) UpdateBMHs(wg *sync.WaitGroup) {
 		allUpdated := c.updateBMHs(&bmhs, machines)
 		if allUpdated {
 			c.log.Infof("Updated all the BMH CRs, finished successfully")
-			return
+			return true
 		}
-	}
+		return false
+	})
 }
 
 func (c controller) unallocatedMachines(bmhList metal3v1alpha1.BareMetalHostList) (*mapiv1beta1.MachineList, error) {
@@ -766,7 +797,7 @@ func (c controller) validateConsoleAvailability() bool {
 //
 // This function would be aligned with the console operator reporting workflow
 // as part of the deprecation of the old API in MGMT-5188.
-func (c controller) waitingForClusterVersion() error {
+func (c controller) waitingForClusterVersion(ctx context.Context) error {
 	isClusterVersionAvailable := func() bool {
 		c.log.Infof("Checking cluster version operator availability status")
 		co, err := c.kc.GetClusterVersion("version")
@@ -801,23 +832,23 @@ func (c controller) waitingForClusterVersion() error {
 		return false
 	}
 
-	err := utils.WaitForPredicate(WaitTimeout, GeneralProgressUpdateInt, isClusterVersionAvailable)
+	err := utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralProgressUpdateInt, isClusterVersionAvailable)
 	if err != nil {
 		return errors.Errorf("Timeout while waiting for cluster version to be available")
 	}
 	return nil
 }
 
-func (c controller) sendCompleteInstallation(isSuccess bool, errorInfo string) {
+func (c controller) sendCompleteInstallation(ctx context.Context, isSuccess bool, errorInfo string) {
 	c.log.Infof("Start complete installation step, with params success:%t, error info %s", isSuccess, errorInfo)
-	for {
-		ctx := utils.GenerateRequestContext()
-		if err := c.ic.CompleteInstallation(ctx, c.ClusterID, isSuccess, errorInfo); err != nil {
-			utils.RequestIDLogger(ctx, c.log).Error(err)
-			continue
+	_ = utils.WaitForPredicateWithContext(ctx, CompleteTimeout, GeneralProgressUpdateInt, func() bool {
+		ctxReq := utils.GenerateRequestContext()
+		if err := c.ic.CompleteInstallation(ctxReq, c.ClusterID, isSuccess, errorInfo); err != nil {
+			utils.RequestIDLogger(ctxReq, c.log).Error(err)
+			return false
 		}
-		break
-	}
+		return true
+	})
 	c.log.Infof("Done complete installation step")
 }
 
@@ -847,7 +878,6 @@ func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSec
 	ctx := utils.GenerateRequestContext()
 
 	c.logClusterOperatorsStatus()
-
 	if isMustGatherEnabled {
 		c.log.Infof("Uploading oc must-gather logs")
 		if tarfile, err := c.collectMustGatherLogs(ctx, mustGatherImg); err == nil {
@@ -929,18 +959,22 @@ func (c controller) collectMustGatherLogs(ctx context.Context, mustGatherImg str
 // Uploading logs every 5 minutes
 // We will take logs of assisted controller and upload them to assisted-service
 // by creating tar gz of them.
-func (c *controller) UploadLogs(ctx context.Context, cancellog context.CancelFunc, wg *sync.WaitGroup, status *ControllerStatus) {
-	defer wg.Done()
+func (c *controller) UploadLogs(ctx context.Context, wg *sync.WaitGroup, status *ControllerStatus) {
 	podName := ""
 	ticker := time.NewTicker(LogsUploadPeriod)
-	progress_ctx := utils.GenerateRequestContext()
+	progressCtx := utils.GenerateRequestContext()
+
+	defer func() {
+		c.log.Infof("Finished UploadLogs")
+		wg.Done()
+	}()
 	c.log.Infof("Start sending logs")
 	for {
 		select {
 		case <-ctx.Done():
 			if podName != "" {
 				c.log.Infof("Upload final controller and cluster logs before exit")
-				c.ic.ClusterLogProgressReport(progress_ctx, c.ClusterID, models.LogsStateRequested)
+				c.ic.ClusterLogProgressReport(progressCtx, c.ClusterID, models.LogsStateRequested)
 				_ = utils.WaitForPredicate(WaitTimeout, LogsUploadPeriod, func() bool {
 					err := c.uploadSummaryLogs(podName, c.Namespace, controllerLogsSecondsAgo, status.HasError(), c.MustGatherImage)
 					if err != nil {
@@ -949,7 +983,7 @@ func (c *controller) UploadLogs(ctx context.Context, cancellog context.CancelFun
 					return err == nil
 				})
 			}
-			c.ic.ClusterLogProgressReport(progress_ctx, c.ClusterID, models.LogsStateCompleted)
+			c.ic.ClusterLogProgressReport(progressCtx, c.ClusterID, models.LogsStateCompleted)
 			return
 		case <-ticker.C:
 			if podName == "" {
@@ -964,12 +998,6 @@ func (c *controller) UploadLogs(ctx context.Context, cancellog context.CancelFun
 					continue
 				}
 				podName = pods[0].Name
-			}
-
-			if status.HasError() {
-				c.log.Infof("Error detected. Closing logs and aborting...")
-				cancellog()
-				continue
 			}
 
 			//on normal flow, keep updating the controller log output every 5 minutes

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -220,7 +220,7 @@ func (c *inventoryClient) UploadIngressCa(ctx context.Context, ingressCA string,
 func (c *inventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
 	cluster, err := c.ai.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: c.clusterId})
 	if err != nil {
-		return nil, aserror.GetAssistedError(err)
+		return nil, err
 	}
 
 	return cluster.Payload, nil

--- a/src/main/assisted-installer-controller-ocp/main.go
+++ b/src/main/assisted-installer-controller-ocp/main.go
@@ -58,12 +58,9 @@ func main() {
 	logger.Infof("Controller deployed on OCP cluster")
 
 	var wg sync.WaitGroup
-	var status assistedinstallercontroller.ControllerStatus
 	var waitAndUpdateFunc = func() {
-		assistedController.WaitAndUpdateNodesStatus(&status)
+		assistedController.WaitAndUpdateNodesStatus(context.TODO(), &wg)
 	}
-	go approveCsrs(assistedController.ApproveCsrs, &wg)
-	wg.Add(1)
 	go waitAndUpdateNodesStatus(waitAndUpdateFunc)
 	wg.Add(1)
 	wg.Wait()
@@ -74,11 +71,4 @@ func waitAndUpdateNodesStatus(waitAndUpdateNodesStatusFunc func()) {
 		waitAndUpdateNodesStatusFunc()
 		time.Sleep(assistedinstallercontroller.GeneralWaitInterval)
 	}
-}
-
-// Note: BMHs for day2 are currently not provided. Once added, CSRs approval can be skipped.
-func approveCsrs(approveCsrsFunc func(context.Context, *sync.WaitGroup), wg *sync.WaitGroup) {
-	// not cancelling approve to keep routine alive
-	ctx := context.Background()
-	approveCsrsFunc(ctx, wg)
 }

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/client/installer"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	assistedinstallercontroller "github.com/openshift/assisted-installer/src/assisted_installer_controller"
+	"github.com/openshift/assisted-installer/src/inventory_client"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "controller_main_test")
+}
+
+var _ = Describe("installer HostRoleMaster role", func() {
+	var (
+		l            = logrus.New()
+		ctrl         *gomock.Controller
+		mockbmclient *inventory_client.MockInventoryClient
+		status       *assistedinstallercontroller.ControllerStatus
+	)
+
+	l.SetOutput(ioutil.Discard)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockbmclient = inventory_client.NewMockInventoryClient(ctrl)
+		waitForInstallationInterval = 10 * time.Millisecond
+		status = &assistedinstallercontroller.ControllerStatus{}
+	})
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("Waiting for cluster installed - first cluster error then installed", func() {
+		// fail to connect to assisted and then succeed
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)},
+			nil).Times(1)
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+	})
+
+	It("Waiting for cluster cancelled", func() {
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusCancelled)},
+			nil).Times(1)
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+	})
+
+	It("Waiting for cluster error - should set error status", func() {
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusError)},
+			nil).Times(1)
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(true))
+	})
+
+	It("Waiting for cluster Unauthorized - should exit 0 ", func() {
+		exitCode := 1
+		exit = func(code int) {
+			exitCode = code
+		}
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
+		// added to make waitForInstallation exit
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+		Expect(exitCode).Should(Equal(0))
+	})
+
+	It("Waiting for cluster Not found - should exit 0 ", func() {
+		exitCode := 1
+		exit = func(code int) {
+			exitCode = code
+		}
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(maximumErrorsBeforeExit)
+
+		// added to make waitForInstallation exit
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+		Expect(exitCode).Should(Equal(0))
+	})
+
+	It("Waiting for cluster Not found/Unauthorized  - should exit 0 ", func() {
+		exitCode := 1
+		exit = func(code int) {
+			exitCode = code
+		}
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(maximumErrorsBeforeExit - 2)
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterUnauthorized()).Times(2)
+		// added to make waitForInstallation exit
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+		Expect(exitCode).Should(Equal(0))
+	})
+
+	It("Waiting for cluster Unauthorized less then needed for exit and then installed", func() {
+		exitCode := 1
+		exit = func(code int) {
+			exitCode = code
+		}
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(maximumErrorsBeforeExit - 2)
+		// added to make waitForInstallation exit
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+		Expect(exitCode).Should(Equal(1))
+	})
+
+})

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -187,11 +187,17 @@ func GetHostIpsFromInventory(inventory *models.Inventory) ([]string, error) {
 }
 
 func WaitForPredicate(timeout time.Duration, interval time.Duration, predicate func() bool) error {
+	return WaitForPredicateWithContext(context.TODO(), timeout, interval, predicate)
+}
+
+func WaitForPredicateWithContext(ctx context.Context, timeout time.Duration, interval time.Duration, predicate func() bool) error {
 	timeoutAfter := time.After(timeout)
 	ticker := time.NewTicker(interval)
 	// Keep trying until we're time out or get true
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		// Got a timeout! fail with a timeout error
 		case <-timeoutAfter:
 			return errors.New("timed out")


### PR DESCRIPTION
MGMT-[OCPBUGSM-27367](https://issues.redhat.com/browse/OCPBUGSM-27367) Reset cluster mentioned 5/6 installation logs were collected  but when downloading there are 6

Controller will have monitoring loop that will monitor connection to
service. If cluster will be cancelled or installer monitor will not set
error and exit. On cluster error monitor will set error that will say to
upload logs to upload must gather.
If 10 401/404 errors will occured in a row, it will exit 0