### PR TITLE
MGMT-6283 Remove EFI partition mount

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -226,11 +226,7 @@ func (o *ops) SetBootOrder(device string) error {
 	}
 
 	o.log.Info("Setting efibootmgr to boot from disk")
-	_, err = o.ExecPrivilegeCommand(o.logWriter, "mount", device+"2", "/mnt")
-	if err != nil {
-		o.log.Errorf("Failed to mount device %s, err: %s", device+"2", err)
-		return err
-	}
+
 	// efi-system is installed onto partition 2
 	_, err = o.ExecPrivilegeCommand(o.logWriter, "efibootmgr", "-d", device, "-p", "2", "-c", "-L", "RHCOS", "-l", "\\EFI\\BOOT\\BOOTX64.EFI")
 	if err != nil {


### PR DESCRIPTION
The EFI partition is not necesarily ready to be mounted right after coreos-installer is called. There
is a race which causes the SetBootOrder call to fail.

This commit removes the mount step as it doens't seem to be really needed for the efibootmgr call. This commit
once tested in one of the faulty environments where the issue could be replicated constantly and it resulted
in the expected behavior. Boot order is set correctly and node starts

/cc @eranco74 git-blame says you added this code https://github.com/openshift/assisted-installer/commit/9c5698f078e07fd4d00b1f982228c0e600279640 Would love your review here :) 

Signed-off-by: Flavio Percoco <flavio@redhat.com>