### PR TITLE
OCPBUGSM-29397 decrease waiting time in case of cluster was not found or not authorized

### DIFF
--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -29,7 +29,7 @@ var Options struct {
 	ControllerConfig assistedinstallercontroller.ControllerConfig
 }
 
-const maximumErrorsBeforeExit = 10
+const maximumErrorsBeforeExit = 3
 
 func main() {
 	logger := logrus.New()
@@ -114,9 +114,10 @@ func waitForInstallation(client inventory_client.InventoryClient, log logrus.Fie
 		if err != nil {
 			// In case cluster was deleted or controller is not authorised
 			// we should exit controller after maximumErrorsBeforeExit errors
+			// in case cluster was deleted we should exit immediately
 			switch err.(type) {
 			case *installer.GetClusterNotFound:
-				errCounter++
+				errCounter = errCounter + maximumErrorsBeforeExit
 				log.WithError(err).Errorf("Cluster was not found in inventory or user is not authorized")
 			case *installer.GetClusterUnauthorized:
 				errCounter++

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -94,13 +94,26 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		Expect(exitCode).Should(Equal(0))
 	})
 
-	It("Waiting for cluster Not found/Unauthorized  - should exit 0 ", func() {
+	It("Waiting for cluster Not found  - should exit 0 ", func() {
 		exitCode := 1
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(maximumErrorsBeforeExit - 2)
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterUnauthorized()).Times(2)
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(1)
+		// added to make waitForInstallation exit
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+
+		waitForInstallation(mockbmclient, l, status)
+		Expect(status.HasError()).Should(Equal(false))
+		Expect(exitCode).Should(Equal(0))
+	})
+
+	It("Waiting for cluster Unauthorized  - should exit 0 ", func() {
+		exitCode := 1
+		exit = func(code int) {
+			exitCode = code
+		}
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
 		// added to make waitForInstallation exit
 		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
@@ -114,7 +127,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterNotFound()).Times(maximumErrorsBeforeExit - 2)
+		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewGetClusterUnauthorized()).Times(maximumErrorsBeforeExit - 2)
 		// added to make waitForInstallation exit
 		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 


### PR DESCRIPTION
 In case of 404 controller will exit immediately(up to one minute) in case of 401 controller will exit after 3 minutes
