### PR TITLE
Bug 1966621: Do not use run-level label for assisted-installer namespace

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-nm.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-nm.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: assisted-installer
-  labels:
-    openshift.io/run-level: "0"

--- a/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
@@ -154,3 +154,17 @@ rules:
       - pods
     verbs:
       - deletecollection
+  - apiGroups:
+      - "security.openshift.io"
+    resourceNames:
+      - "anyuid"
+      - "nonroot"
+      - "hostmount-anyuid"
+      - "machine-api-termination-handler"
+      - "hostnetwork"
+      - "hostaccess"
+      - "node-exporter"
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -434,19 +434,6 @@ func (c controller) postInstallConfigs(ctx context.Context) error {
 		}
 	}
 
-	// Unlabel run-level from assisted-installer namespace after the installation.
-	// Keeping the `run-level` label represents a security risk as it overwrites the SecurityContext configurations
-	// used for applications deployed in this namespace.
-	data := []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
-	c.log.Infof("Removing run-level label from %s namespace", c.ControllerConfig.Namespace)
-	err = c.kc.PatchNamespace(c.ControllerConfig.Namespace, data)
-	if err != nil {
-		// It is a conscious decision not to fail an installation if for any reason patching the namespace
-		// in order to remove the `run-level` label has failed. This will be redesigned in the next release
-		// so that the `run-level` label is not created in the first place.
-		c.log.Warn("Failed to unlabel AI namespace after the installation.")
-	}
-
 	err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.addRouterCAToClusterCA)
 	if err != nil {
 		return errors.Wrapf(err, "Timeout while waiting router ca data")

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -49,8 +49,6 @@ var (
 		MustGatherImage:       "quay.io/test-must-gather:latest",
 	}
 
-	aiNamespaceRunlevelPatch = []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
-
 	progressClusterVersionCondition = &configv1.ClusterVersion{
 		Status: configv1.ClusterVersionStatus{
 			Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorProgressing,
@@ -644,9 +642,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				setConsoleAsAvailable("cluster-id")
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				// CVO
 				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName).
 					Return(&models.MonitoredOperator{Status: "", StatusInfo: ""}, nil).Times(1)
@@ -703,9 +698,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg)
 				wg.Wait()
@@ -717,9 +709,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockk8sclient.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("aaa")).MinTimes(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", false,
 					"Timeout while waiting router ca data: timed out").Return(nil).Times(1)
-
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				go assistedController.PostInstallConfigs(context.TODO(), &wg)
@@ -776,9 +765,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg)
 				wg.Wait()
@@ -803,9 +789,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", models.OperatorStatusFailed, "Waiting for operator timed out").Return(nil).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
-
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg)


### PR DESCRIPTION
Namespaces using run-level label are considered to be highly privileged
and Security Context Constrains are not applied to the workload running
in them.

One of the deployment models for assisted-installer uses cluster
deployed by the AI service to deploy next clusters. In this scenario, if
the same `assisted-installer` namespace is used for deploying Assisted
Service Operator, the pods do not get any securityContext properties
applied. This, apart from the potential security violations, causes
functional errors as e.g. Postgres container is running using wrong UID.

This PR changes configuration of the `assisted-installer` namespace so
that it does not have run-level label applied and is treated like any
other customer namespace.

Closes: [OCPBUGSM-29833](https://issues.redhat.com/browse/OCPBUGSM-29833)