### PR TITLE
[WIP] Bug 1951812: Remove AI namespace from target cluster after installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
-build
-reports
+.idea/
+.vscode/
+.venv/
+venv/
+build/
+kubevirtci/
 **/RCS/**
+.*.swp
+
+/vendor
+reports

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -552,6 +552,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
+				// Deletion of NS
+				mockk8sclient.EXPECT().DeleteNamespace(defaultTestControllerConf.Namespace).Return(nil)
+
 				wg.Add(1)
 				go assistedController.PostInstallConfigs(context.TODO(), &wg, status)
 				wg.Wait()
@@ -590,6 +593,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any()).Return([]models.MonitoredOperator{}, nil).AnyTimes()
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
+				mockk8sclient.EXPECT().DeleteNamespace(defaultTestControllerConf.Namespace).Return(nil)
 
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)
@@ -636,6 +640,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
+				mockk8sclient.EXPECT().DeleteNamespace(defaultTestControllerConf.Namespace).Return(nil)
 
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -80,6 +80,7 @@ type K8SClient interface {
 	CreateEvent(namespace, name, message, component string) (*v1.Event, error)
 	DeleteService(namespace, name string) error
 	DeletePods(namespace string) error
+	DeleteNamespace(namespace string) error
 }
 
 type K8SClientBuilder func(configPath string, logger *logrus.Logger) (K8SClient, error)
@@ -180,6 +181,10 @@ func (c *k8sClient) DeleteService(name, namespace string) error {
 
 func (c *k8sClient) DeletePods(namespace string) error {
 	return c.client.CoreV1().Pods(namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+}
+
+func (c *k8sClient) DeleteNamespace(namespace string) error {
+	return c.client.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
 }
 
 func (c *k8sClient) ListMachines() (*machinev1beta1.MachineList, error) {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -525,3 +525,17 @@ func (mr *MockK8SClientMockRecorder) DeletePods(namespace interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePods", reflect.TypeOf((*MockK8SClient)(nil).DeletePods), namespace)
 }
+
+// DeleteNamespace mocks base method
+func (m *MockK8SClient) DeleteNamespace(namespace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNamespace", namespace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNamespace indicates an expected call of DeleteNamespace
+func (mr *MockK8SClientMockRecorder) DeleteNamespace(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockK8SClient)(nil).DeleteNamespace), namespace)
+}


### PR DESCRIPTION
# Description

Currently the `assisted-installer` namespace on the cluster installed
using Assisted Installer is labeled with run-level what causes any
workload running there to bypass security constrains. In a scenario when
an operator tries to reuse this namespace to deploy Assisted Service on
such a cluster, the installation will fail because services expect to be
run using the safe UID/GID ranges.

In order to overcome the issue, after successful installation of the
cluster we will remove `assisted-installer` namespace so that if an
operator wants to deploy Assisted Service, it will be necessary to
recreate the namespace (this time without setting a run-level).

Long-term solution is to remove run-level label from the initially
created namespace. Those efforts are tracked in bug 1966621.

Closes: [OCPBUGSM-28041](https://issues.redhat.com/browse/OCPBUGSM-28041)

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

# Assignees

/assign 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
