### PR TITLE
Bug 1951812: Remove label from AI namespace after cluster installation

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
@@ -23,6 +23,12 @@ rules:
     verbs:
       - create
   - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - patch
+  - apiGroups:
       - certificates.k8s.io
     resources:
       - certificatesigningrequests
@@ -148,4 +154,3 @@ rules:
       - pods
     verbs:
       - deletecollection
-

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -386,6 +386,19 @@ func (c controller) postInstallConfigs(ctx context.Context) error {
 		}
 	}
 
+	// Unlabel run-level from assisted-installer namespace after the installation.
+	// Keeping the `run-level` label represents a security risk as it overwrites the SecurityContext configurations
+	// used for applications deployed in this namespace.
+	data := []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
+	c.log.Infof("Removing run-level label from %s namespace", c.ControllerConfig.Namespace)
+	err = c.kc.PatchNamespace(c.ControllerConfig.Namespace, data)
+	if err != nil {
+		// It is a conscious decision not to fail an installation if for any reason patching the namespace
+		// in order to remove the `run-level` label has failed. This will be redesigned in the next release
+		// so that the `run-level` label is not created in the first place.
+		c.log.Warn("Failed to unlabel AI namespace after the installation.")
+	}
+
 	err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.addRouterCAToClusterCA)
 	if err != nil {
 		return errors.Errorf("Timeout while waiting router ca data")

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -48,6 +48,8 @@ var (
 		MustGatherImage:       "quay.io/test-must-gather:latest",
 	}
 
+	aiNamespaceRunlevelPatch = []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
+
 	progressClusterVersionCondition = &configv1.ClusterVersion{
 		Status: configv1.ClusterVersionStatus{
 			Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorProgressing,
@@ -529,6 +531,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					fmt.Errorf("bad-conditions-status")).Times(1)
 				setConsoleAsAvailable("cluster-id")
 
+				// Patching NS
+				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
+
 				// CVO
 				mockk8sclient.EXPECT().GetClusterVersion("version").Return(nil, fmt.Errorf("dummy")).Times(1)
 
@@ -591,6 +596,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
+				// Patching NS
+				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
+
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)
 				wg.Wait()
@@ -602,6 +610,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockk8sclient.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("aaa")).MinTimes(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", false,
 					"Timeout while waiting router ca data").Return(nil).Times(1)
+
+				// Patching NS
+				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				go assistedController.PostInstallConfigs(context.TODO(), &wg, status)
@@ -637,6 +648,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
+				// Patching NS
+				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
+
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)
 				wg.Wait()
@@ -656,6 +670,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", models.OperatorStatusProgressing, gomock.Any()).Return(nil).AnyTimes()
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", models.OperatorStatusFailed, "Waiting for operator timed out").Return(nil).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
+
+				// Patching NS
+				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -80,6 +80,7 @@ type K8SClient interface {
 	CreateEvent(namespace, name, message, component string) (*v1.Event, error)
 	DeleteService(namespace, name string) error
 	DeletePods(namespace string) error
+	PatchNamespace(namespace string, data []byte) error
 }
 
 type K8SClientBuilder func(configPath string, logger *logrus.Logger) (K8SClient, error)
@@ -180,6 +181,12 @@ func (c *k8sClient) DeleteService(name, namespace string) error {
 
 func (c *k8sClient) DeletePods(namespace string) error {
 	return c.client.CoreV1().Pods(namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+}
+
+// TODO: We should be passing the context to these functions
+func (c *k8sClient) PatchNamespace(namespace string, data []byte) error {
+	_, err := c.client.CoreV1().Namespaces().Patch(context.TODO(), namespace, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	return err
 }
 
 func (c *k8sClient) ListMachines() (*machinev1beta1.MachineList, error) {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -525,3 +525,17 @@ func (mr *MockK8SClientMockRecorder) DeletePods(namespace interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePods", reflect.TypeOf((*MockK8SClient)(nil).DeletePods), namespace)
 }
+
+// PatchNamespace mocks base method
+func (m *MockK8SClient) PatchNamespace(namespace string, data []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchNamespace", namespace, data)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchNamespace indicates an expected call of PatchNamespace
+func (mr *MockK8SClientMockRecorder) PatchNamespace(namespace, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNamespace", reflect.TypeOf((*MockK8SClient)(nil).PatchNamespace), namespace, data)
+}


### PR DESCRIPTION
# Description

Currently the `assisted-installer` namespace on the cluster installed
using Assisted Installer is labeled with run-level what causes any
workload running there to bypass security constrains. In a scenario when
an operator tries to reuse this namespace to deploy Assisted Service on
such a cluster, the installation will fail because services expect to be
run using the safe UID/GID ranges.

In order to overcome the issue, after the installation of the
cluster we will remove the label from the `assisted-installer` namespace
so that if an operator wants to deploy Assisted Service, it will be
necessary to recreate the namespace (this time without setting a run-level).

Please note that if for any reason removing the label fails, we will not
fail the installation of the cluster.

Long-term solution is to remove run-level label from the initially
created namespace and use another mechanism to ensure that the AI
controller starts as early as possible. Those efforts are tracked in bug
1966621.

Closes: [OCPBUGSM-28041](https://issues.redhat.com/browse/OCPBUGSM-28041)

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

I have deployed a SNO using code from this PR. After the installation I have the following state of the `assisted-installer` namespace

```
[root@edge-14 assisted-installer-manifests-bis]# oc1 get all
NAME                                      READY   STATUS      RESTARTS   AGE
pod/assisted-installer-controller-jjszz   0/1     Completed   2          127m

NAME                                      COMPLETIONS   DURATION   AGE
job.batch/assisted-installer-controller   1/1           126m       127m
[root@edge-14 assisted-installer-manifests-bis]# oc1 describe ns assisted-installer
Name:         assisted-installer
Labels:       kubernetes.io/metadata.name=assisted-installer
Annotations:  openshift.io/sa.scc.mcs: s0:c8,c2
              openshift.io/sa.scc.supplemental-groups: 1000060000/10000
              openshift.io/sa.scc.uid-range: 1000060000/10000
Status:       Active

No resource quota.

No LimitRange resource.
```

In the controller logs I can see that the code unlabeling the namespace has been executed

```
[root@edge-14 assisted-installer-manifests-bis]# oc1 logs pod/assisted-installer-controller-jjszz                                                                                                                                    
[...]
time="2021-06-04T08:52:59Z" level=info msg="Checking cluster version operator availability status"
time="2021-06-04T08:52:59Z" level=info msg="Service acknowledged CVO is available for cluster c18b34c0-11a2-4b5d-b54f-aada21ce403d"                                                                                                  
time="2021-06-04T08:52:59Z" level=info msg="Removing run-level label from assisted-installer namespace"
time="2021-06-04T08:53:29Z" level=info msg="Start adding ingress ca to cluster" request_id=1c9fb496-be5b-4bff-9e64-3ab06d131142                                                                                                      
[...]
```

Hub cluster reports installation as succeeded

```
[root@edge-14 dev-scripts]# oc describe -n assisted-installer agentclusterinstall bmac-test
[...]
    Last Probe Time:             2021-06-04T08:54:08Z
    Last Transition Time:        2021-06-04T08:54:08Z
    Message:                     The installation has completed: Cluster is installed
    Reason:                      InstallationCompleted
    Status:                      True
    Type:                        Completed
[...]
```

# Assignees

/assign 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
