### PR TITLE
NO-ISSUE: Fix bug in the date for ocm image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
   agent { label 'centos_worker' }
   triggers { cron(cronScheduleString(env.BRANCH_NAME)) }
   environment {
-        CURRENT_DATE = now.format("Ymd")
+        CURRENT_DATE = now.format("YMMdd")
         PUBLISH_TAG = releaseBranchPublishTag(env.BRANCH_NAME)
 
         // Credentials


### PR DESCRIPTION
Fixes a small bug where the wrong format date string was used. 😅 

I've been using the Jenkins replay functionality to test Jenkins changes:
Here is the manual replay log:
http://assisted-jenkins.usersys.redhat.com/job/assisted-service/job/ocm-2.3/36/console
![image](https://user-images.githubusercontent.com/7851712/121231598-6ce24980-c845-11eb-9000-6c641434a40d.png)

First one is YMMdd (new), second is Ymd (current) third is H for the current hour.

Signed-off-by: Lisa Rashidi-Ranjbar <lranjbar@redhat.com>