### PR TITLE
OCPBUGSM-30942: ACM/ZTP with Wan emulation, SNO cluster installs do not show as installed although they are

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -73,6 +73,7 @@ spec:
             mountPath: {{.CACertPath}}
           {{end}}
       restartPolicy: OnFailure
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       serviceAccountName: assisted-installer-controller
@@ -86,5 +87,3 @@ spec:
         hostPath:
           path: {{.CACertPath}}
       {{end}}
-
-


### PR DESCRIPTION
In case it takes long time fopr dns operator to start we can get timeout
in assisted-service cause assisted-controller can't reach the service.
Another issue is that we are workarounding dns pod issue in
assisted-controller and that's why this part should run before
controller tries to reach the service.
From now controller will use host network and will not be dependent on
dns pod.