### PR TITLE
Bug 1966621: Clean up the code after run-level label removal

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -386,19 +386,6 @@ func (c controller) postInstallConfigs(ctx context.Context) error {
 		}
 	}
 
-	// Unlabel run-level from assisted-installer namespace after the installation.
-	// Keeping the `run-level` label represents a security risk as it overwrites the SecurityContext configurations
-	// used for applications deployed in this namespace.
-	data := []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
-	c.log.Infof("Removing run-level label from %s namespace", c.ControllerConfig.Namespace)
-	err = c.kc.PatchNamespace(c.ControllerConfig.Namespace, data)
-	if err != nil {
-		// It is a conscious decision not to fail an installation if for any reason patching the namespace
-		// in order to remove the `run-level` label has failed. This will be redesigned in the next release
-		// so that the `run-level` label is not created in the first place.
-		c.log.Warn("Failed to unlabel AI namespace after the installation.")
-	}
-
 	err = utils.WaitForPredicateWithContext(ctx, WaitTimeout, GeneralWaitInterval, c.addRouterCAToClusterCA)
 	if err != nil {
 		return errors.Errorf("Timeout while waiting router ca data")

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -48,8 +48,6 @@ var (
 		MustGatherImage:       "quay.io/test-must-gather:latest",
 	}
 
-	aiNamespaceRunlevelPatch = []byte(`{"metadata":{"labels":{"$patch": "delete", "openshift.io/run-level":"0"}}}`)
-
 	progressClusterVersionCondition = &configv1.ClusterVersion{
 		Status: configv1.ClusterVersionStatus{
 			Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorProgressing,
@@ -531,9 +529,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					fmt.Errorf("bad-conditions-status")).Times(1)
 				setConsoleAsAvailable("cluster-id")
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				// CVO
 				mockk8sclient.EXPECT().GetClusterVersion("version").Return(nil, fmt.Errorf("dummy")).Times(1)
 
@@ -596,9 +591,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)
 				wg.Wait()
@@ -610,9 +602,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockk8sclient.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("aaa")).MinTimes(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", false,
 					"Timeout while waiting router ca data").Return(nil).Times(1)
-
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				go assistedController.PostInstallConfigs(context.TODO(), &wg, status)
@@ -648,9 +637,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
 
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
-
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)
 				wg.Wait()
@@ -670,9 +656,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", models.OperatorStatusProgressing, gomock.Any()).Return(nil).AnyTimes()
 				mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", models.OperatorStatusFailed, "Waiting for operator timed out").Return(nil).Times(1)
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(nil).Times(1)
-
-				// Patching NS
-				mockk8sclient.EXPECT().PatchNamespace(defaultTestControllerConf.Namespace, aiNamespaceRunlevelPatch).Return(nil)
 
 				wg.Add(1)
 				assistedController.PostInstallConfigs(context.TODO(), &wg, status)


### PR DESCRIPTION
With the `run-level` label being completely dropped in
https://github.com/openshift/assisted-installer/pull/291, we are now
removing the remaining logic handling it in the post-installation steps.

Contributes-to: [OCPBUGSM-29833](https://issues.redhat.com/browse/OCPBUGSM-29833)