### PR TITLE
NO-ISSUE Fix build error created when PR #311 merged

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -457,7 +457,8 @@ func (c controller) applyPostInstallManifests() bool {
 	defer os.RemoveAll(tempDir)
 
 	customManifestPath := path.Join(tempDir, customManifestsFile)
-	if err := c.ic.DownloadFile(ctx, customManifestsFile, customManifestPath); err != nil {
+	err = c.ic.DownloadFile(ctx, customManifestsFile, customManifestPath)
+	if err != nil {
 		return false
 	}
 


### PR DESCRIPTION
The following build error was introduced when #311 was merged

```
04:30:32  INFO [runner] linters took 31.854032639s with stages: goanalysis_metalinter: 24.07037174s, unused: 7.779939059s 
04:30:32  src/assisted_installer_controller/assisted_installer_controller.go:460:5: shadow: declaration of "err" shadows declaration at line 453 (govet)
04:30:32  	if err := c.ic.DownloadFile(ctx, customManifestsFile, customManifestPath); err != nil {
04:30:32  	   ^
04:30:32  INFO File cache stats: 1 entries of total size 37.7KiB 
04:30:32  INFO Memory: 318 samples, avg is 771.2MB, max is 1485.3MB 
04:30:32  INFO Execution took 36.471920287s       
```

Signed-off-by: Lisa Rashidi-Ranjbar <lranjbar@redhat.com>