### PR TITLE
OCPBUGSM-30066: Retry wait for operator in case it failed

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -283,6 +283,10 @@ func CsvStatusToOperatorStatus(csvStatus string) models.OperatorStatus {
 	}
 }
 
+func IsStatusFailed(operatorStatus models.OperatorStatus) bool {
+	return operatorStatus == models.OperatorStatusFailed
+}
+
 func ClusterOperatorConditionsToMonitoredOperatorStatus(conditions []configv1.ClusterOperatorStatusCondition) (models.OperatorStatus, string) {
 	for _, condition := range conditions {
 		if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionTrue {


### PR DESCRIPTION
This commit add a retry mechanism while waiting for the operator to be
ready. If we apply the CR of the operator it may happen (bug 1968606),
that the OLM will report the Failed state, even that it's actually
progressing. So we decided to ignore the failed state for few times.