### PR TITLE
Bug 1979009: Change log message about EFI support

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -220,9 +220,9 @@ func (o *ops) Reboot() error {
 }
 
 func (o *ops) SetBootOrder(device string) error {
-	_, err := o.ExecPrivilegeCommand(o.logWriter, "test", "-d", "/sys/firmware/efi")
+	_, err := o.ExecPrivilegeCommand(nil, "test", "-d", "/sys/firmware/efi")
 	if err != nil {
-		o.log.Info("efi not supported")
+		o.log.Info("Setting boot order on efi is not supported. Skipping...")
 		return nil
 	}
 


### PR DESCRIPTION
 - Minor log changes on `setting EFI boot order unsupported`
 - In `SetBootOrder` function - passing `liveLogger=nil` in order to not have an uneeded log at that stage
   (Failed executing nsenter...)