### PR TITLE
Bug 1981465: Assisted installer wait for ready master nodes on bootst…

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	InstallDir                   = "/opt/install-dir"
-	KubeconfigPathLoopBack       = "/opt/openshift/auth/kubeconfig-loopback"
 	KubeconfigPath               = "/opt/openshift/auth/kubeconfig"
 	minMasterNodes               = 2
 	dockerConfigFile             = "/root/.docker/config.json"
@@ -337,12 +336,18 @@ func (i *installer) waitForNetworkType(kc k8s_client.K8SClient) error {
 }
 
 func (i *installer) waitForControlPlane(ctx context.Context) error {
-	kc, err := i.kcBuilder(KubeconfigPathLoopBack, i.log)
+	err := i.ops.ReloadHostFile("/etc/resolv.conf")
+	if err != nil {
+		i.log.WithError(err).Error("Failed to reload resolv.conf")
+		return err
+	}
+	kc, err := i.kcBuilder(KubeconfigPath, i.log)
 	if err != nil {
 		i.log.Error(err)
 		return err
 	}
 	i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, "")
+
 	if err = i.waitForMinMasterNodes(ctx, kc); err != nil {
 		return err
 	}
@@ -364,7 +369,7 @@ func (i *installer) waitForControlPlane(ctx context.Context) error {
 	i.waitForBootkube(ctx)
 
 	// waiting for controller pod to be running
-	if err := i.waitForController(); err != nil {
+	if err := i.waitForController(kc); err != nil {
 		i.log.Error(err)
 		return err
 	}
@@ -469,20 +474,9 @@ func (i *installer) waitForBootkube(ctx context.Context) {
 	}
 }
 
-func (i *installer) waitForController() error {
+func (i *installer) waitForController(kc k8s_client.K8SClient) error {
 	i.log.Infof("Waiting for controller to be ready")
 	i.UpdateHostInstallProgress(models.HostStageWaitingForController, "waiting for controller pod ready event")
-	err := i.ops.ReloadHostFile("/etc/resolv.conf")
-	if err != nil {
-		i.log.WithError(err).Error("Failed to reload resolv.conf")
-		return err
-	}
-
-	kc, err := i.kcBuilder(KubeconfigPath, i.log)
-	if err != nil {
-		i.log.WithError(err).Errorf("Failed to create kc client from %s", KubeconfigPath)
-		return err
-	}
 
 	events := map[string]string{}
 	tickerUploadLogs := time.NewTicker(5 * time.Minute)


### PR DESCRIPTION
…rap kube-apiserver though the kube-apiserver moved to one of the masters

On the bootstrap node the assisted-installer use the loopback-kubeconfig
to query the kube-apiserver for the number of ready master nodes.

Usually both master nodes join the cluster and become ready before
bootkube takes down the bootstrap control plane so the loopback kubeconfig works.
But in case clusteer bootstrap finish before the 2 master nodes
are ready the assisted-installer will wait forever since the it's
using the loopback-kubeconfig and the bootstrap control plane is down
resulting in "connection refused"

The assisted-installer should query the kube-apiserver running on
one of the master nodes, for that to work it should use the real
kubeconfig instead of the loopback kubeconfig.