### PR TITLE
OCPBUGSM-31942: Return error on failed status operator update

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -742,7 +742,11 @@ func (c controller) getProgressingOLMOperators() ([]*models.MonitoredOperator, e
 
 func (c controller) updatePendingOLMOperators() error {
 	c.log.Infof("Updating pending OLM operators")
-	operators, _ := c.getProgressingOLMOperators()
+	operators, err := c.getProgressingOLMOperators()
+	if err != nil {
+		return err
+	}
+
 	for _, operator := range operators {
 		err := c.ic.UpdateClusterOperator(context.TODO(), c.ClusterID, operator.Name, models.OperatorStatusFailed, "Waiting for operator timed out")
 		if err != nil {


### PR DESCRIPTION
The method call getProgressingOLMOperators could return error in case
the assisted service API is unavailable. In that case we wouldn't update
the status of the operators which are pending and it may happend that
the cluster will hang in finalizing state.