### PR TITLE
MGMT-3817: assisted-controller should always send logs

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -888,6 +888,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			reportLogProgressSuccess()
 			mockk8sclient.EXPECT().GetPods(assistedController.Namespace, gomock.Any(), fmt.Sprintf("status.phase=%s", v1.PodRunning)).Return([]v1.Pod{pod}, nil).MinTimes(1)
 			mockk8sclient.EXPECT().GetPodLogsAsBuffer(assistedController.Namespace, "test", gomock.Any()).Return(nil, fmt.Errorf("dummy")).MinTimes(1)
+			mockbmclient.EXPECT().UploadLogs(gomock.Any(), assistedController.ClusterID, models.LogsTypeController, gomock.Any()).Return(nil).MinTimes(1)
 			ctx, cancel := context.WithCancel(context.Background())
 			wg.Add(1)
 			go assistedController.UploadLogs(ctx, &wg)

--- a/src/common/common.go
+++ b/src/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -97,7 +98,8 @@ func UploadPodLogs(kc k8s_client.K8SClient, ic inventory_client.InventoryClient,
 	log.Infof("Uploading logs for %s in %s", podName, namespace)
 	podLogs, err := kc.GetPodLogsAsBuffer(namespace, podName, sinceSeconds)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get logs of pod %s", podName)
+		podLogs = &bytes.Buffer{}
+		podLogs.WriteString(errors.Wrapf(err, "Failed to get logs of pod %s", podName).Error())
 	}
 	pr, pw := io.Pipe()
 	defer pr.Close()


### PR DESCRIPTION
 Right now in case we kube-api-server is not reachable we will not send
    any logs. This code is changing, from now in case kube-api error we will
    send this error as log
