### PR TITLE
OCPBUGSM-31802: hosts that were moved to ready state in k8s, didn't send

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -220,17 +220,20 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 
 			continue
 		}
+
+		if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
+			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
+				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
+			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
+				log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
+				continue
+			}
+		}
+
 		if common.IsK8sNodeIsReady(node) {
 			log.Infof("Found new ready node %s with inventory id %s, kubernetes id %s, updating its status to %s",
 				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageDone)
 			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageDone, ""); err != nil {
-				log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
-				continue
-			}
-		} else if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
-			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
-				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
-			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
 				log.WithError(err).Errorf("Failed to update node %s installation status", node.Name)
 				continue
 			}

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		node0Id := strfmt.UUID("7916fa89-ea7a-443e-a862-b3e930309f65")
 		node1Id := strfmt.UUID("eb82821f-bf21-4614-9a3b-ecb07929f238")
 		node2Id := strfmt.UUID("b898d516-3e16-49d0-86a5-0ad5bd04e3ed")
-		currentState := models.HostProgressInfo{CurrentStage: models.HostStageConfiguring}
+		currentState := models.HostProgressInfo{CurrentStage: models.HostStageJoined}
 		currentStatus := models.HostStatusInstallingInProgress
 		inventoryNamesIds = map[string]inventory_client.HostData{
 			"node0": {Host: &models.Host{InfraEnvID: infraEnvId, ID: &node0Id, Progress: &currentState, Status: &currentStatus}},
@@ -247,6 +247,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("waitAndUpdateNodesStatus happy flow - all nodes installing", func() {
+
+			updateProgressSuccess([]models.HostStage{models.HostStageJoined,
+				models.HostStageJoined,
+				models.HostStageJoined}, inventoryNamesIds)
 			updateProgressSuccess(defaultStages, inventoryNamesIds)
 
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageConfiguring)


### PR DESCRIPTION
joined status to the cluster.
Now they will send joined and only then done