### PR TITLE
MGMT-7635 Fix logs gathering on SNO when failing to complete bootstrapping

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	MCOImage             string
 	ControllerImage      string
 	AgentImage           string
-	InstallationTimeout  uint
 	PullSecretToken      string `secret:"true"`
 	SkipCertVerification bool
 	CACertPath           string
@@ -60,8 +59,6 @@ func ProcessArgs() {
 		"Assisted Installer Controller image URL")
 	flag.StringVar(&ret.AgentImage, "agent-image", "quay.io/ocpmetal/assisted-installer-agent:latest",
 		"Assisted Installer Agent image URL that will be used to send logs on successful installation")
-	// Remove installation-timeout once the assisted-service stop sending it.
-	flag.UintVar(&ret.InstallationTimeout, "installation-timeout", 120, "Installation timeout in minutes - OBSOLETE")
 	flag.BoolVar(&ret.SkipCertVerification, "insecure", false, "Do not validate TLS certificate")
 	flag.StringVar(&ret.CACertPath, "cacert", "", "Path to custom CA certificate in PEM format")
 	flag.StringVar(&ret.HTTPProxy, "http-proxy", "", "A proxy URL to use for creating HTTP connections outside the cluster")

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -195,6 +195,12 @@ func (i *installer) writeImageToDisk(ignitionPath string) error {
 
 func (i *installer) startBootstrap() error {
 	i.log.Infof("Running bootstrap")
+	// This is required for the log collection command to work since it will try to mount this directory
+	// This directory is also required by `generateSshKeyPair` as it will place the key there
+	if err := i.ops.Mkdir(sshDir); err != nil {
+		i.log.WithError(err).Error("Failed to create SSH dir")
+		return err
+	}
 	ignitionFileName := "bootstrap.ign"
 	ignitionPath, err := i.getFileFromService(ignitionFileName)
 	if err != nil {
@@ -289,10 +295,6 @@ func (i *installer) extractIgnitionToFS(ignitionPath string) (err error) {
 
 func (i *installer) generateSshKeyPair() error {
 	i.log.Info("Generating new SSH key pair")
-	if err := i.ops.Mkdir(sshDir); err != nil {
-		i.log.WithError(err).Error("Failed to create SSH dir")
-		return err
-	}
 	if _, err := i.ops.ExecPrivilegeCommand(utils.NewLogWriter(i.log), "ssh-keygen", "-q", "-f", sshKeyPath, "-N", ""); err != nil {
 		i.log.WithError(err).Error("Failed to generate SSH key pair")
 		return err

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -233,7 +233,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockops.EXPECT().ExtractFromIgnition(filepath.Join(InstallDir, bootstrapIgn), dockerConfigFile).Return(nil).Times(1)
 		}
 		generateSshKeyPairSuccess := func() {
-			mkdirSuccess(sshDir)
 			mockops.EXPECT().ExecPrivilegeCommand(gomock.Any(), "ssh-keygen", "-q", "-f", sshKeyPath, "-N", "").Return("OK", nil).Times(1)
 		}
 		createOpenshiftSshManifestSuccess := func() {
@@ -242,6 +241,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 		bootstrapSetup := func() {
 			cleanInstallDevice()
+			mkdirSuccess(sshDir)
 			mkdirSuccess(InstallDir)
 			downloadFileSuccess(bootstrapIgn)
 			extractSecretFromIgnitionSuccess()
@@ -330,6 +330,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			})
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
+			mkdirSuccess(sshDir)
 			downloadFileSuccess(bootstrapIgn)
 			extractSecretFromIgnitionSuccess()
 			extractIgnitionToFS("Success", nil)
@@ -378,6 +379,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			})
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
+			mkdirSuccess(sshDir)
 			downloadFileSuccess(bootstrapIgn)
 			downloadHostIgnitionSuccess(hostId, "master-host-id.ign")
 			writeToDiskSuccess(gomock.Any())
@@ -695,6 +697,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		singleNodeBootstrapSetup := func() {
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
+			mkdirSuccess(sshDir)
 			downloadFileSuccess(bootstrapIgn)
 			extractSecretFromIgnitionSuccess()
 			extractIgnitionToFS("Success", nil)


### PR DESCRIPTION
[MGMT-7635](https://issues.redhat.com/browse/MGMT-7635) Fix logs gathering on SNO when failing to complete bootstrapping
The log_sender command failed to mount /root/.ssh due to: "no such file or directory" error.
This code ensure the directory get created once the bootstrap flow begin
