### PR TITLE
MGMT-7713 Worker won't get updated to 'Waiting for ignition' when installing with IPv6

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -45,7 +45,7 @@ func SetConfiguringStatusForHosts(client inventory_client.InventoryClient, inven
 			continue
 		}
 		log.Infof("Verifying if host %s pulled ignition", hostName)
-		pat := fmt.Sprintf("(%s).{1,20}(Ignition)", strings.Join(host.IPs, "|"))
+		pat := fmt.Sprintf("(%s).{1,40}(Ignition)", strings.Join(host.IPs, "|"))
 		pattern, err := regexp.Compile(pat)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to compile regex from host %s ips list", hostName)

--- a/src/common/common_test.go
+++ b/src/common/common_test.go
@@ -41,7 +41,7 @@ var _ = Describe("verify common", func() {
 				IPs: []string{"192.168.126.10", "192.168.11.122", "fe80::5054:ff:fe9a:4738"}},
 				"node1": {Host: &models.Host{InfraEnvID: infraEnvId, ID: &node1Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}, Role: models.HostRoleMaster}, IPs: []string{"192.168.126.11", "192.168.11.123", "fe80::5054:ff:fe9a:4739"}},
 				"node2": {Host: &models.Host{InfraEnvID: infraEnvId, ID: &node2Id, Progress: &models.HostProgressInfo{CurrentStage: models.HostStageRebooting}, Role: models.HostRoleWorker}, IPs: []string{"192.168.126.12", "192.168.11.124", "fe80::5054:ff:fe9a:4740"}}}
-
+			// note that in the MCS log we use node 1 IPv6 address
 			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), infraEnvId.String(), node1Id.String(), models.HostStageConfiguring, gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
 			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), infraEnvId.String(), node2Id.String(), models.HostStageWaitingForIgnition, gomock.Any()).Return(nil).Times(1)
 			SetConfiguringStatusForHosts(mockbmclient, testInventoryIdsIps, logs, true, l)

--- a/test_files/mcs_logs.txt
+++ b/test_files/mcs_logs.txt
@@ -4,6 +4,6 @@
 2020-07-01T16:57:08.449846700+00:00 stderr F I0701 16:57:08.449808       1 api.go:102] Pool master requested by 192.168.126.12:32780 User-Agent:"Ignition/2.6.0" 
 2020-07-01T16:57:08.449904020+00:00 stderr F I0701 16:57:08.449893       1 bootstrap_server.go:64] reading file "/etc/mcs/bootstrap/machine-pools/master.yaml"
 2020-07-01T16:57:08.451073060+00:00 stderr F I0701 16:57:08.451054       1 bootstrap_server.go:84] reading file "/etc/mcs/bootstrap/machine-configs/rendered-master-39287e7d053e8395ab3c1ecd762dd578.yaml"
-2020-07-01T16:57:22.319520480+00:00 stderr F I0701 16:57:22.319461       1 api.go:102] Pool master requested by 192.168.126.11:40548 User-Agent:"Ignition/2.6.0" 
+2020-07-01T16:57:22.319520480+00:00 stderr F I0701 16:57:22.319461       1 api.go:102] Pool master requested by [fe80::5054:ff:fe9a:4739%ens3]:40548 User-Agent:"Ignition/2.6.0"
 2020-07-01T16:57:22.319520480+00:00 stderr F I0701 16:57:22.319485       1 bootstrap_server.go:64] reading file "/etc/mcs/bootstrap/machine-pools/master.yaml"
 2020-07-01T16:57:22.320165920+00:00 stderr F I0701 16:57:22.320128       1 bootstrap_server.go:84] reading file "/etc/mcs/bootstrap/machine-configs/rendered-master-39287e7d053e8395ab3c1ecd762dd578.yaml"


### PR DESCRIPTION
Updated the regex to allow more chars between the host IP and 'Ignition'
this is required because in the MCS log the host IP is logged as scoped literal IPv6 address
e.g. [fe80::ff:fe9d:12ac%ens3]:42692
This should also allow master nodes to get updated to 'Configuring'
