### PR TITLE
MGMT-7760: Switch to stream8

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 RUN make installer
 
-FROM quay.io/centos/centos:centos8
+FROM quay.io/centos/centos:stream8
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 RUN make controller
 
-FROM quay.io/centos/centos:centos8
+FROM quay.io/centos/centos:stream8
 
 RUN yum -y install make gcc unzip wget curl rsync && yum clean all
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller


### PR DESCRIPTION
The original plan was to move all images to ubi8. This is not possible due to the lack
of some packages that are needed for other projects. We are now going to switch all images
to stream8 with the hope that the consistency accross repos will prevent (or help) with
debugging current/future issues in CI.

The goal is to keep component's builds as consistent as possible in the channels we are
releasing them on

Signed-off-by: Flavio Percoco <flavio@redhat.com>