### PR TITLE
NO-ISSUE: Add `replaces` entry in go.mod for `irifrance/gini` which has moved in GitHub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971
 	github.com/openshift/hive/pkg/apis => github.com/carbonin/hive/pkg/apis v0.0.0-20210209195732-57e8c3ae12d1
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20201026110925-50ea569da51b
+	github.com/irifrance/gini => github.com/go-air/gini v1.0.1
 	k8s.io/api => k8s.io/api v0.19.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.19.2
 	k8s.io/client-go => k8s.io/client-go v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,7 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-air/gini v1.0.1/go.mod h1:swH5OTtiG/X/YrU06r288qZwq6I1agpbuXQOB55xqGU=
 github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-bindata/go-bindata/v3 v3.1.3/go.mod h1:1/zrpXsLD8YDIbhZRqXzm1Ghc7NhEvIN9+Z6R5/xH4I=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
The https://github.com/irifrance/gin repo we indirectly depended on via our
`github.com/operator-framework/operator-lifecycle-manager v0.18.0` dependency
has moved to https://github.com/go-air/gin. This invalid dependency was fixed in newer
versions of the operator-lifecycle-manager, but I prefer just fixing this issue
with a `replace` directive rather than dealing with an olm upgrade.

Without this `replace` directive, attempting to work on the installer repository
locally causes my IDE / go commands to complain about irifrance/gin being gone,
this `replace` directive fixes those issues.