### PR TITLE
MGMT-8064: Introduce dry run mode to the installer

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -73,16 +73,20 @@ var (
 // as a first step it will wait till nodes are added to cluster and update their status to Done
 
 type ControllerConfig struct {
-	ClusterID             string `envconfig:"CLUSTER_ID" required:"true"`
-	URL                   string `envconfig:"INVENTORY_URL" required:"true"`
-	PullSecretToken       string `envconfig:"PULL_SECRET_TOKEN" required:"true" secret:"true"`
-	SkipCertVerification  bool   `envconfig:"SKIP_CERT_VERIFICATION" required:"false" default:"false"`
-	CACertPath            string `envconfig:"CA_CERT_PATH" required:"false" default:""`
-	Namespace             string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
-	OpenshiftVersion      string `envconfig:"OPENSHIFT_VERSION" required:"true"`
-	HighAvailabilityMode  string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`
-	WaitForClusterVersion bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
-	MustGatherImage       string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
+	ClusterID               string `envconfig:"CLUSTER_ID" required:"true"`
+	URL                     string `envconfig:"INVENTORY_URL" required:"true"`
+	PullSecretToken         string `envconfig:"PULL_SECRET_TOKEN" required:"true" secret:"true"`
+	SkipCertVerification    bool   `envconfig:"SKIP_CERT_VERIFICATION" required:"false" default:"false"`
+	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:""`
+	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
+	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
+	HighAvailabilityMode    string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`
+	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
+	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
+	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
+	DryRunHostnames         string `envconfig:"DRY_HOSTNAMES" required:"false" default:""`
+	DryMcsAccessIps         string `envconfig:"DRY_MCS_ACCESS_IPS" required:"false" default:""`
+	DryFakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH" required:"false" default:""`
 }
 type Controller interface {
 	WaitAndUpdateNodesStatus(status *ControllerStatus)
@@ -253,7 +257,6 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 }
 
 func (c *controller) HackDNSAddressConflict(wg *sync.WaitGroup) {
-
 	c.log.Infof("Making sure service %s can reserve the .10 address", dnsServiceName)
 
 	defer func() {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	HighAvailabilityMode string
 	CheckClusterVersion  bool
 	MustGatherImage      string
+	DisksToFormat        ArrayFlags
 }
 
 var GlobalConfig Config
@@ -68,12 +69,14 @@ func ProcessArgs() {
 	flag.StringVar(&ret.HighAvailabilityMode, "high-availability-mode", "Full", "high-availability expectations. default is 'Full', which represents the behavior in a \"normal\" cluster. Use 'None' for single-node deployment")
 	flag.BoolVar(&ret.CheckClusterVersion, "check-cluster-version", false, "Do not monitor CVO")
 	flag.StringVar(&ret.MustGatherImage, "must-gather-image", "", "Custom must-gather image")
+	flag.Var(&ret.DisksToFormat, "format-disk", "Disk to format. Can be specified multiple times")
 
 	var installerArgs string
 	flag.StringVar(&installerArgs, "installer-args", "", "JSON array of additional coreos-installer arguments")
 
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
+
 	if ret.NoProxy != "" {
 		utils.SetNoProxyEnv(ret.NoProxy)
 	}

--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+// DryRunConfig defines configuration of the agent's dry-run mode
+type DryRunConfig struct {
+	DryRunEnabled        bool   `envconfig:"DRY_ENABLE"`
+	FakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
+	ForcedHostID         string `envconfig:"DRY_HOST_ID"`
+}
+
+var GlobalDryRunConfig DryRunConfig
+
+var DefaultDryRunConfig DryRunConfig = DryRunConfig{
+	DryRunEnabled:        false,
+	FakeRebootMarkerPath: "",
+	ForcedHostID:         "",
+}
+
+func ProcessDryRunArgs() {
+	err := envconfig.Process("dryconfig", &DefaultDryRunConfig)
+	if err != nil {
+		fmt.Printf("envconfig error: %v", err)
+		os.Exit(1)
+	}
+
+	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
+	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
+	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
+	flag.Parse()
+}

--- a/src/config/flag_array.go
+++ b/src/config/flag_array.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"strings"
+)
+
+// New type to be used by the built-in go `flag` library -
+// this type allows flags to be passed multiple times in the
+// commandline arguments, such that all values of flags become
+// members of this array
+type ArrayFlags []string
+
+// String is implemented to fit the flag.Value interface
+func (a *ArrayFlags) String() string {
+	return strings.Join([]string(*a), ",")
+}
+
+// Set is implemented to fit the flag.Value interface
+func (a *ArrayFlags) Set(value string) error {
+	// Each time we encounter the flag, add an entry to the list,
+	// this way the flag can be specified multiple times
+	*a = append(*a, value)
+	return nil
+}

--- a/src/main/assisted-installer-controller/drymock/dry_mode_k8s_mock.go
+++ b/src/main/assisted-installer-controller/drymock/dry_mode_k8s_mock.go
@@ -1,0 +1,255 @@
+package drymock
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/golang/mock/gomock"
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/assisted-installer/src/k8s_client"
+	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"github.com/sirupsen/logrus"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// prepareDryMock utilizes k8s_client.MockK8SClient to fake the k8s API to make the
+// controller think it's running on an actual cluster, just enough to make it pass an installation.
+// Used in dry mode.
+func PrepareDryMock(mockk8sclient *k8s_client.MockK8SClient, logger *logrus.Logger, hostnames string, mcsAccessIps string) {
+	// Called by main
+	mockk8sclient.EXPECT().SetProxyEnvVars().Return(nil).AnyTimes()
+
+	// Called by GetReadyState to make sure we're online
+	nodeList := v1.NodeList{}
+	mockk8sclient.EXPECT().ListNodes().Return(&nodeList, nil).Times(1)
+
+	// Called a lot
+	mockk8sclient.EXPECT().CreateEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(args ...string) {
+		logger.Infof("Fake creating event %+v", args)
+	}).AnyTimes()
+
+	// Called by GetReadyState to make sure we're online
+	csrs := certificatesv1.CertificateSigningRequestList{}
+	mockk8sclient.EXPECT().ListCsrs().Return(&csrs, nil).AnyTimes()
+
+	bmhs := metal3v1alpha1.BareMetalHostList{}
+	mockk8sclient.EXPECT().ListBMHs().Return(bmhs, nil).AnyTimes()
+
+	machines := machinev1beta1.MachineList{}
+	mockk8sclient.EXPECT().ListMachines().Return(&machines, nil).AnyTimes()
+
+	mockk8sclient.EXPECT().IsMetalProvisioningExists().Return(true, nil).AnyTimes()
+
+	// The controller looks at MCS pod logs to determine whether hosts downloaded ignition or not, so we fake the MCS pod logs
+	fakeMcsName := "dry-mcs"
+	podListMcs := []v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: fakeMcsName}}}
+	mockk8sclient.EXPECT().GetPods(gomock.Any(), map[string]string{"k8s-app": "machine-config-server"}, gomock.Any()).Return(podListMcs, nil).AnyTimes()
+
+	mcsLogs := ""
+	for _, ip := range strings.Split(mcsAccessIps, ",") {
+		// Add IP access log for each IP, this is how the controller determines which node has downloaded the ignition
+		mcsLogs += fmt.Sprintf("%s.(Ignition)\n", ip)
+	}
+	mockk8sclient.EXPECT().GetPodLogs(gomock.Any(), fakeMcsName, gomock.Any()).Return(mcsLogs, nil).AnyTimes()
+
+	// The controller compares AI host objects to cluster Node objects (Either by name or by IP) to check which AI hosts are already
+	// joined as nodes. This fakes the node list so that check will pass
+	nodeListPopulated := v1.NodeList{}
+	for _, hostname := range strings.Split(hostnames, ",") {
+		nodeListPopulated.Items = append(nodeListPopulated.Items, v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hostname,
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		})
+	}
+	mockk8sclient.EXPECT().ListNodes().Return(&nodeListPopulated, nil).AnyTimes()
+
+	// The controller
+	myselfName := "dry-controller"
+	podListMyself := []v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: myselfName}}}
+	mockk8sclient.EXPECT().GetPods(gomock.Any(), map[string]string{"job-name": "assisted-installer-controller"}, gomock.Any()).Return(podListMyself, nil).AnyTimes()
+
+	b := bytes.NewBufferString(`Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry
+Dry`)
+
+	mockk8sclient.EXPECT().GetPodLogsAsBuffer(gomock.Any(), gomock.Any(), gomock.Any()).Return(b, nil).AnyTimes()
+
+	availableConditions := []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:    configv1.OperatorAvailable,
+			Status:  configv1.ConditionTrue,
+			Message: "All is well",
+		},
+		{
+			Type:    configv1.OperatorProgressing,
+			Status:  configv1.ConditionTrue,
+			Message: "All is well",
+		},
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: "All is well",
+		},
+	}
+
+	clusterOperator := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: availableConditions,
+		},
+	}
+	mockk8sclient.EXPECT().GetClusterOperator(gomock.Any()).Return(&clusterOperator, nil).AnyTimes()
+
+	clusterVersion := configv1.ClusterVersion{
+		Status: configv1.ClusterVersionStatus{
+			Conditions: availableConditions,
+		},
+	}
+	mockk8sclient.EXPECT().GetClusterVersion(gomock.Any()).Return(&clusterVersion, nil).AnyTimes()
+
+	configMap := v1.ConfigMap{
+		Data: map[string]string{
+			"ca-bundle.crt": `-----BEGIN CERTIFICATE-----
+MIIExTCCAq0CFCqc5fg5zMGmG6yY/PsVukKCsTWiMA0GCSqGSIb3DQEBCwUAMB8x
+CzAJBgNVBAYTAlVTMRAwDgYDVQQKDAdSZWQgSGF0MB4XDTIxMTAyOTIyNTY0MVoX
+DTIyMTAyOTIyNTY0MVowHzELMAkGA1UEBhMCVVMxEDAOBgNVBAoMB1JlZCBIYXQw
+ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDqR5zsx+2WpNTO0RBYFrQd
+swo5ALC9XIj1EfcxXECdtZE/6ZBXS/bxkN7DsB5ych9GVgBrmX0093Qng9US/CXF
+5vTthG/+BhH0u3+6x6bRLagqayuRWiD/mQRZ10X1EswIebH6pMXXKweLK/Sg9PlB
+FtD2JNIQhirdUSMkF4ud0yoW66YE+vJGFyHBAEB5A2ws+4ymaxyVYBJVfdS8nCfU
+gPee1h6DjmUO8GyeF3kY2eVERqTW6E+BhrjOB1DOcHacxj4t2CQMUJRXNqL2QMLz
+n1tRyBPoVI8BjQNzI8+Hb6g6vKIFvtVoJrqeT/ASgZkEaPJt4sP1ss2ODhGUuLNB
+fz/ZzFgglswJEFhBtv4J2zXkoI69KdFAxaa37qULL6MxNQ+y4LhfBc5WzqHdg4EI
+5xtbuCpHErpc1VIDe1Ok3NXsFHN99tH+vwA6fcYmz9VjE/HKMHRzwNRjmDW1cdNO
+uAgZTkslhfiu1rjxlIetU6LH2lBKy9UtoRjNw014F2IJeje8j1WHuR/ih705qkVf
+wYG2NKMRRUV12tpKwuqX/TQFa++aB95vhjZsAtrB2P66CWROtFCjd8woHEkZEGHt
+Gh8R4UXxk2VvHlglb8tvEr+n3Fuz41dLZeepZR2CzaySgjLUAqOahO3ZmEitUtiw
+GB5Q3+bhB9lUVFd0IGuQEwIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQBi507wwqP+
+Yc8xEeKXxazheIUuf1o9WH1XTdUJPklRdwZj7HxZa49FzammW7MWhVNbqsD6bZdp
+5Iy9JCsJBP5Z6gWbP3LgypcWw4xmNiPXZw+9pbnRmIiObGvWEnHmtI6MTvAHZttd
+sEnrvH7LV2Dr7TZzfV7mrOh2JgDlQ5yOvXx9x9sV9GaqGbx5tK11S//Th5TfGkXQ
+CoygE/SwZPAHM4jcU//j5/QbYegtJIVFK/JQrMcc37ecwcYf0f3q5GZ/c4zUBQ7Z
+BZMSGMGObxNqIIW3QsB+sZyfpZxWUanxJiKy9Uw8jBq+zswWep8WXnFtL1wyHeiB
+MpYEls0yPGsCeEF3vFlpFR1Aob0nLAimAEyxf4GUZiI1CCqWzhIQ8jaiSfnsyh9f
+irj1Q/xTIEK4sbyl//QXLpW/OXgXUG6WIlyvg1LPdbngfU5S8DxSXse9JHIno+cD
+7Ugdiw+3c32FQnX4vqKLhtT7IClWmyTN84tcKMJVKhreQ+Yz0+eCTIwV5JQFTsRp
+tGxE/NUwbjuRib3HvsiuCUIcRQKJQerdAYWob47cnIA/YH0Hngq1Ci1GtcuYJQnP
+dEFgad6P3hMZTOg7yVkMOd3QtgVQ9I8dXqS2nG9EMEh97WIhi6f5ztvcQvQ5tXjh
+1OZbvvo716WbONeK0GuS3WbwVTQFSUBtCA==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIExTCCAq0CFCqc5fg5zMGmG6yY/PsVukKCsTWiMA0GCSqGSIb3DQEBCwUAMB8x
+CzAJBgNVBAYTAlVTMRAwDgYDVQQKDAdSZWQgSGF0MB4XDTIxMTAyOTIyNTY0MVoX
+DTIyMTAyOTIyNTY0MVowHzELMAkGA1UEBhMCVVMxEDAOBgNVBAoMB1JlZCBIYXQw
+ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDqR5zsx+2WpNTO0RBYFrQd
+swo5ALC9XIj1EfcxXECdtZE/6ZBXS/bxkN7DsB5ych9GVgBrmX0093Qng9US/CXF
+5vTthG/+BhH0u3+6x6bRLagqayuRWiD/mQRZ10X1EswIebH6pMXXKweLK/Sg9PlB
+FtD2JNIQhirdUSMkF4ud0yoW66YE+vJGFyHBAEB5A2ws+4ymaxyVYBJVfdS8nCfU
+gPee1h6DjmUO8GyeF3kY2eVERqTW6E+BhrjOB1DOcHacxj4t2CQMUJRXNqL2QMLz
+n1tRyBPoVI8BjQNzI8+Hb6g6vKIFvtVoJrqeT/ASgZkEaPJt4sP1ss2ODhGUuLNB
+fz/ZzFgglswJEFhBtv4J2zXkoI69KdFAxaa37qULL6MxNQ+y4LhfBc5WzqHdg4EI
+5xtbuCpHErpc1VIDe1Ok3NXsFHN99tH+vwA6fcYmz9VjE/HKMHRzwNRjmDW1cdNO
+uAgZTkslhfiu1rjxlIetU6LH2lBKy9UtoRjNw014F2IJeje8j1WHuR/ih705qkVf
+wYG2NKMRRUV12tpKwuqX/TQFa++aB95vhjZsAtrB2P66CWROtFCjd8woHEkZEGHt
+Gh8R4UXxk2VvHlglb8tvEr+n3Fuz41dLZeepZR2CzaySgjLUAqOahO3ZmEitUtiw
+GB5Q3+bhB9lUVFd0IGuQEwIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQBi507wwqP+
+Yc8xEeKXxazheIUuf1o9WH1XTdUJPklRdwZj7HxZa49FzammW7MWhVNbqsD6bZdp
+5Iy9JCsJBP5Z6gWbP3LgypcWw4xmNiPXZw+9pbnRmIiObGvWEnHmtI6MTvAHZttd
+sEnrvH7LV2Dr7TZzfV7mrOh2JgDlQ5yOvXx9x9sV9GaqGbx5tK11S//Th5TfGkXQ
+CoygE/SwZPAHM4jcU//j5/QbYegtJIVFK/JQrMcc37ecwcYf0f3q5GZ/c4zUBQ7Z
+BZMSGMGObxNqIIW3QsB+sZyfpZxWUanxJiKy9Uw8jBq+zswWep8WXnFtL1wyHeiB
+MpYEls0yPGsCeEF3vFlpFR1Aob0nLAimAEyxf4GUZiI1CCqWzhIQ8jaiSfnsyh9f
+irj1Q/xTIEK4sbyl//QXLpW/OXgXUG6WIlyvg1LPdbngfU5S8DxSXse9JHIno+cD
+7Ugdiw+3c32FQnX4vqKLhtT7IClWmyTN84tcKMJVKhreQ+Yz0+eCTIwV5JQFTsRp
+tGxE/NUwbjuRib3HvsiuCUIcRQKJQerdAYWob47cnIA/YH0Hngq1Ci1GtcuYJQnP
+dEFgad6P3hMZTOg7yVkMOd3QtgVQ9I8dXqS2nG9EMEh97WIhi6f5ztvcQvQ5tXjh
+1OZbvvo716WbONeK0GuS3WbwVTQFSUBtCA==
+-----END CERTIFICATE-----
+`,
+		},
+	}
+	mockk8sclient.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(&configMap, nil).AnyTimes()
+
+	clusterOperatorList := &configv1.ClusterOperatorList{}
+
+	for _, operatorName := range []string{
+		"authentication",
+		"baremetal",
+		"cloud-controller-manager",
+		"cloud-credential",
+		"cluster-autoscaler",
+		"config-operator",
+		"console",
+		"csi-snapshot-controller",
+		"dns",
+		"etcd",
+		"image-registry",
+		"ingress",
+		"insights",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-scheduler",
+		"kube-storage-version-migrator",
+		"machine-api",
+		"machine-approver",
+		"machine-config",
+		"marketplace",
+		"monitoring",
+		"network",
+		"node-tuning",
+		"openshift-apiserver",
+		"openshift-controller-manager",
+		"openshift-samples",
+		"operator-lifecycle-manager",
+		"operator-lifecycle-manager-catalog",
+		"operator-lifecycle-manager-packageserver",
+		"service-ca",
+		"storage",
+	} {
+		clusterOperator := configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: operatorName,
+			},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorAvailable,
+						Status: configv1.ConditionTrue,
+					},
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: configv1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		clusterOperatorList.Items = append(clusterOperatorList.Items, clusterOperator)
+	}
+
+	mockk8sclient.EXPECT().ListClusterOperators().Return(clusterOperatorList, nil).AnyTimes()
+}

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -370,6 +370,20 @@ func (mr *MockOpsMockRecorder) EvaluateDiskSymlink(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDiskSymlink", reflect.TypeOf((*MockOps)(nil).EvaluateDiskSymlink), arg0)
 }
 
+// FormatDisk mocks base method
+func (m *MockOps) FormatDisk(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FormatDisk", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FormatDisk indicates an expected call of FormatDisk
+func (mr *MockOpsMockRecorder) FormatDisk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatDisk", reflect.TypeOf((*MockOps)(nil).FormatDisk), arg0)
+}
+
 // CreateManifests mocks base method
 func (m *MockOps) CreateManifests(arg0 string, arg1 []byte) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This commit introduces a dry run mode to the installer and the
controller. The mode is activated in both components when the
`DRY_ENABLE=true` environment is set (or when the `--dry-run`
flag is passed to them).

On the installer, the dry run mode disables several destructive actions
performed by the installer. The purpose of the dry run mode in the installer
is mostly allowing us to run a lot of installers on the same machine, without
causing harm to that machine, but still communicating with the service. This is useful
when performing load testing to the service.

See the diff for the exact actions that were disabled, but here's a
summary -
- `extractIgnitionToFS` skipped (it's not needed if we're not really
  installing, and multiple installers running on the same machine
  may compete on the paths required for this, and it's also really slow)
- `updateSingleNodeIgnition` skipped (it's not needed if we're not really
  installing, and because extractIgnitionToFS is no longer performed,
  we're missing the file required)
- `generateSshKeyPair` skipped (multiple installers will compete on those
  files, and also it modifies the keys on the host machine, which is
  something we want to avoid)
- `cleanupInstallDevice` skipped (for obvious reasons)
- `checkLocalhostName` skipped (this function forces a random hostname, we
  don't want that)
- `coreos-installer` replaced - instead of calling `coreos-installer` we'll
  now call `dry-installer` - it's up to the installer dry mode user to
  make sure such executable exists in the PATH - this executable needs
  to print progress similarly to the coreos-installer (since these
  printed lines get sent to the service as installation progress)
- `SystemctlAction` - all systemctl actions are now skipped, they're
  usually destructive an unnecessary in dry run mode.
- `Reboot` - Doesn't actually reboot, instead it creates a file in the
  path given by `DRY_FAKE_REBOOT_MARKER_PATH` to signal to the dry run
  agent that they should also stop (this is because in a regular non-dry
  flow the agent gets "magically" stopped by the machine rebooting).
- `SetBootOrder` - skipped for obvious reasons
- `CreateOpenshiftSshManifest` - skipped, not needed

Other than disabling some actions, I've also added a new CLI flag
to the installer (which works even in non-dry mode) - the user can
now pass `--format-disk` flags, as many as they want, which will
cause the installer to format the given disks. The reason for this
change is that up till now, the service asked the host to format
disks by passing it raw `dd ...` commands that were chained as
`bash -c "dd ...; dd ...; podman run...` commands to installer,
which is problematic because it doesn't give us any way
to disable those `dd` calls when we want a dry run mode - they're
outside of the installer's control. Now that we have this new API
that allows the installer to perform the formatting on its own,
we can disable said formatting in dry run mode, when using newer
versions of the service which respect this new API rather than
using `dd`.

Some other new features to the installer -
- Added journal `DRY_AGENT_ID` field to help separate between
  logs of multiple dry run installers running at the same time on the
  same machine

The controller has also been modified with a dry mode. The dry mode in
the controller allows it to run on any machine, rather than run inside
the spoke k8s cluster. `k8s_client.MockK8SClient` has been utilized to
fake the k8s API to make the controller think it's running on an
actual cluster, just enough to make it pass an installation.

Unlike the agent dry mode which stops when it sees `DRY_FAKE_REBOOT_MARKER_PATH`
was created, the controller does the opposite - it sleeps until that
file is created, and only then starts. This is convenient because it
allows the dry agent/installer/controller to all be launched at once,
and the controller would only actually start doing its job when a fake
reboot happened, as it does in a real installation.

`assistedController.HackDNSAddressConflict` has been completely
disabled in the dry controller because it's too complicated to mock
for it, and it's also unnecessary because there's no real cluster.

Other unrelated changes in this commit -
- `removePullSecret` bug fixed - when the `PullSecretToken` was empty,
  `ReplaceAll` caused some funky looking strings. This censoring is now
  disabled when the pull secret is empty.
