### PR TITLE
NO-ISSUE: add backofflimit 100 and imagePullPolicy: IfNotPresent to assisted controller

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: assisted-installer-controller
           image: {{.ControllerImage}}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             # Define the environment variable
             - name: CLUSTER_ID
@@ -73,6 +73,7 @@ spec:
             mountPath: {{.CACertPath}}
           {{end}}
       restartPolicy: OnFailure
+      backoffLimit: 100
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
NO-ISSUE: add backofflimit 100 and imagePullPolicy: IfNotPresent to assisted controller
backofflimit 100 will allow us to see controller retrying in case we
reached timeout and controller failed for unknown reason