### PR TITLE
Latest triage issues fixes

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -939,7 +939,7 @@ func (c controller) waitingForClusterOperators(ctx context.Context) error {
 		result := c.isOperatorAvailable(NewClusterOperatorHandler(c.kc, consoleOperatorName))
 
 		if c.WaitForClusterVersion {
-			result = c.isOperatorAvailable(NewClusterVersionHandler(c.kc, timer))
+			result = c.isOperatorAvailable(NewClusterVersionHandler(c.kc, timer)) && result
 		}
 
 		return result

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -36,9 +36,10 @@ import (
 const (
 	// We retry 10 times in 30sec interval meaning that we tolerate the operator to be in failed
 	// state for 5minutes.
-	failedOperatorRetry       = 10
-	generalWaitTimeoutInt     = 30
-	controllerLogsSecondsAgo  = 120 * 60
+	failedOperatorRetry   = 10
+	generalWaitTimeoutInt = 30
+	// zero means -> bring all logs
+	controllerLogsSecondsAgo  = 0
 	consoleOperatorName       = "console"
 	ingressConfigMapName      = "default-ingress-cert"
 	ingressConfigMapNamespace = "openshift-config-managed"


### PR DESCRIPTION
[MGMT-8240](https://issues.redhat.com/browse/MGMT-8240): Controller should validate that console and cvo statuses 
were both updated in service
In case we failed to send console operator status but succeeded cvo we will stuck in finalizing

[MGMT-8238](https://issues.redhat.com/browse/MGMT-8238): assisted-controller should send all logs and not just the last 2 hours