### PR TITLE
MGMT-8064: Dry mode multi-node cluster support

### DIFF
--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -13,6 +13,8 @@ type DryRunConfig struct {
 	DryRunEnabled        bool   `envconfig:"DRY_ENABLE"`
 	FakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
 	ForcedHostID         string `envconfig:"DRY_HOST_ID"`
+	DryRunHostnames      string `envconfig:"DRY_HOSTNAMES"`
+	DryRunIps            string `envconfig:"DRY_IPS"`
 }
 
 var GlobalDryRunConfig DryRunConfig
@@ -21,6 +23,8 @@ var DefaultDryRunConfig DryRunConfig = DryRunConfig{
 	DryRunEnabled:        false,
 	FakeRebootMarkerPath: "",
 	ForcedHostID:         "",
+	DryRunHostnames:      "",
+	DryRunIps:            "",
 }
 
 func ProcessDryRunArgs() {
@@ -33,5 +37,7 @@ func ProcessDryRunArgs() {
 	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
 	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
 	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
+	flag.StringVar(&GlobalDryRunConfig.DryRunHostnames, "dry-run-hostnames", DefaultDryRunConfig.DryRunHostnames, "A comma separated list of all hostnames within the dry cluster")
+	flag.StringVar(&GlobalDryRunConfig.DryRunIps, "dry-run-ips", DefaultDryRunConfig.DryRunHostnames, "A comma separated list of all ip addresses of hosts within the dry cluster")
 	flag.Parse()
 }

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -39,6 +39,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
 )
@@ -204,6 +205,10 @@ func (c *k8sClient) ListMachines() (*machinev1beta1.MachineList, error) {
 }
 
 func (c *k8sClient) PatchEtcd() error {
+	if config.GlobalDryRunConfig.DryRunEnabled {
+		return nil
+	}
+
 	c.log.Info("Patching etcd")
 	data := []byte(`{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`)
 	result, err := c.ocClient.OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, data, metav1.PatchOptions{})

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -13,7 +13,7 @@ import (
 	assistedinstallercontroller "github.com/openshift/assisted-installer/src/assisted_installer_controller"
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-installer/src/k8s_client"
-	"github.com/openshift/assisted-installer/src/main/assisted-installer-controller/drymock"
+	"github.com/openshift/assisted-installer/src/main/drymock"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
 	"github.com/openshift/assisted-service/client/installer"
@@ -69,7 +69,7 @@ func main() {
 		mockController := gomock.NewController(ginkgo.GinkgoT())
 		kc = k8s_client.NewMockK8SClient(mockController)
 		mock, _ := kc.(*k8s_client.MockK8SClient)
-		drymock.PrepareDryMock(mock, logger, Options.ControllerConfig.DryRunHostnames, Options.ControllerConfig.DryMcsAccessIps)
+		drymock.PrepareControllerDryMock(mock, logger, Options.ControllerConfig.DryRunHostnames, Options.ControllerConfig.DryMcsAccessIps)
 	}
 
 	err = kc.SetProxyEnvVars()


### PR DESCRIPTION
In multi-node cluster, the bootstrap node tries to connect to the
control plane started by the other control plane nodes.

In dry mode, this control plane doesn't really exist, so it has to be
mocked similarly to how we mock the cluster for the controller in dry
mode.

This commit adds this mocking to the installer to support multi-node
clusters