### PR TITLE
MGMT-8330: Minimize number of inventory client retries in assisted-co…

### DIFF
--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	defaultRetryMinDelay = time.Duration(2) * time.Second
-	defaultRetryMaxDelay = time.Duration(10) * time.Second
-	defaultMinRetries    = 10
+	DefaultRetryMinDelay = time.Duration(2) * time.Second
+	DefaultRetryMaxDelay = time.Duration(10) * time.Second
+	DefaultMinRetries    = 10
 	defaultMaxRetries    = 360
 )
 
@@ -76,7 +76,7 @@ type HostData struct {
 func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,
 	logger *logrus.Logger, proxyFunc func(*http.Request) (*url.URL, error)) (*inventoryClient, error) {
 	return CreateInventoryClientWithDelay(clusterId, inventoryURL, pullSecret, insecure, caPath,
-		logger, proxyFunc, defaultRetryMinDelay, defaultRetryMaxDelay, defaultMaxRetries, defaultMinRetries)
+		logger, proxyFunc, DefaultRetryMinDelay, DefaultRetryMaxDelay, defaultMaxRetries, DefaultMinRetries)
 }
 
 func CreateInventoryClientWithDelay(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,


### PR DESCRIPTION
[MGMT-8330](https://issues.redhat.com/browse/MGMT-8330): Minimize number of inventory client retries in assisted-controller

everything in assisted-controller runs in loops, we prefer to fail early on error and to retry on the next loop
this will allow us to show service error more quickly and not to be blocked for half an hour on api call
Setting maximum 15 retries