### PR TITLE
MGMT-8781: Fix controller updating configuring status with stale data

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -253,7 +253,17 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 			}
 		}
 	}
-	c.updateConfiguringStatusIfNeeded(assistedNodesMap)
+
+	// Since the host statuses may have changed due to the above loop,
+	// we need to get the updated list of hosts again so we don't operate
+	// on stale data.
+	assistedNodesMapUpdated, err2 := c.ic.GetHosts(ctxReq, log, ignoreStatuses)
+	if err2 != nil {
+		log.WithError(err2).Error("Failed to get node map from the assisted service")
+		return KeepWaiting
+	}
+
+	c.updateConfiguringStatusIfNeeded(assistedNodesMapUpdated)
 	return KeepWaiting
 }
 

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -272,7 +272,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageConfiguring)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-				Return(hosts, nil).Times(1)
+				Return(hosts, nil).Times(2)
 			configuringSuccess()
 			listNodes()
 
@@ -296,7 +296,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageConfiguring)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-				Return(hosts, nil).Times(1)
+				Return(hosts, nil).Times(2)
 			// not ready nodes
 			nodes := GetKubeNodes(kubeNamesIds)
 			for _, node := range nodes.Items {
@@ -321,7 +321,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageJoined)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-				Return(hosts, nil).Times(1)
+				Return(hosts, nil).Times(2)
 			nodes := GetKubeNodes(kubeNamesIds)
 			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
 			updateProgressSuccess(done, inventoryNamesIds)
@@ -377,7 +377,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 						targetMap[key] = value
 					}
 					mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-						Return(targetMap, nil).Times(1)
+						Return(targetMap, nil).Times(2)
 					delete(inventoryNamesIds, name)
 				}
 				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
@@ -420,7 +420,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockk8sclient.EXPECT().ListNodes().Return(GetKubeNodes(kubeNamesIds), nil).Times(2)
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageJoined)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-				Return(hosts, nil).Times(2)
+				Return(hosts, nil).Times(4)
 			updateProgressSuccessFailureTest(defaultStages, hosts)
 			hosts = create3Hosts(models.HostStatusInstalled, models.HostStageDone)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
@@ -447,7 +447,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess(defaultStages, hosts)
 			hosts = create3Hosts(models.HostStatusInstalled, models.HostStageDone)
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
-				Return(hosts, nil).Times(1)
+				Return(hosts, nil).Times(2)
 
 			listNodesOneFailure()
 			configuringSuccess()


### PR DESCRIPTION
`updateConfiguringStatusIfNeeded` gets passed `assistedNodesMap` which
at that point may already contain stale data if any of conditions in the
loop above it are met.

As a result, when it's time to set the configuring status for that host,
the service will respond with an error because that host already has stage
"done" (due to the condition in the loop mentioned previously) and you may
not go from stage "done" to stage "configuring".

`notValidStates` in `SetConfiguringStatusForHosts` was supposed to prevent
this from happening but since it's using stale data, that check fails.

Currently when the controller gets error responses from the service it retries
a few times and only gives up after about 15 retries (with 2 seconds in between).

If you try to install a cluster with 100 hosts and all of them become ready at about
the same time, this loop will be wasting almost an hour trying to set them all to
"configuring" while they're already "done".

This commit fixes that issue by requesting fresh data from the service
after updating the stages of the hosts and before calling `updateConfiguringStatusIfNeeded`