### PR TITLE
MGMT-8248: Hot fix for ODF

### DIFF
--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -25,7 +25,7 @@ func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 	operatorName := handler.GetName()
 	c.log.Infof("Checking <%s> operator availability status", operatorName)
 
-	operatorStatusInService, isAvailable := c.isOperatorAvailableInService(operatorName)
+	operatorStatusInService, isAvailable := c.isOperatorAvailableInService(operatorName, c.OpenshiftVersion)
 	if isAvailable {
 		return true
 	}
@@ -53,8 +53,8 @@ func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 	return false
 }
 
-func (c controller) isOperatorAvailableInService(operatorName string) (*models.MonitoredOperator, bool) {
-	operatorStatusInService, err := c.ic.GetClusterMonitoredOperator(utils.GenerateRequestContext(), c.ClusterID, operatorName)
+func (c controller) isOperatorAvailableInService(operatorName string, openshiftVersion string) (*models.MonitoredOperator, bool) {
+	operatorStatusInService, err := c.ic.GetClusterMonitoredOperator(utils.GenerateRequestContext(), c.ClusterID, operatorName, openshiftVersion)
 	if err != nil {
 		c.log.WithError(err).Errorf("Failed to get cluster %s %s operator status", c.ClusterID, operatorName)
 		return nil, false
@@ -158,14 +158,11 @@ func (handler ClusterServiceVersionHandler) GetStatus() (models.OperatorStatus, 
 	if err != nil {
 		return "", "", err
 	}
-
 	csv, err := handler.kc.GetCSV(handler.operator.Namespace, csvName)
 	if err != nil {
 		return "", "", err
 	}
-
 	operatorStatus := utils.CsvStatusToOperatorStatus(string(csv.Status.Phase))
-
 	return operatorStatus, csv.Status.Message, nil
 }
 

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -14,44 +14,56 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// MockInventoryClient is a mock of InventoryClient interface
+// MockInventoryClient is a mock of InventoryClient interface.
 type MockInventoryClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockInventoryClientMockRecorder
 }
 
-// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient
+// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient.
 type MockInventoryClientMockRecorder struct {
 	mock *MockInventoryClient
 }
 
-// NewMockInventoryClient creates a new mock instance
+// NewMockInventoryClient creates a new mock instance.
 func NewMockInventoryClient(ctrl *gomock.Controller) *MockInventoryClient {
 	mock := &MockInventoryClient{ctrl: ctrl}
 	mock.recorder = &MockInventoryClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInventoryClient) EXPECT() *MockInventoryClientMockRecorder {
 	return m.recorder
 }
 
-// DownloadFile mocks base method
-func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
+// ClusterLogProgressReport mocks base method.
+func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
+	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
+}
+
+// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport.
+func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
+}
+
+// CompleteInstallation mocks base method.
+func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DownloadFile indicates an expected call of DownloadFile
-func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
+// CompleteInstallation indicates an expected call of CompleteInstallation.
+func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
 }
 
-// DownloadClusterCredentials mocks base method
+// DownloadClusterCredentials mocks base method.
 func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, filename, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadClusterCredentials", ctx, filename, dest)
@@ -59,13 +71,27 @@ func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, fi
 	return ret0
 }
 
-// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials
+// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials.
 func (mr *MockInventoryClientMockRecorder) DownloadClusterCredentials(ctx, filename, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadClusterCredentials", reflect.TypeOf((*MockInventoryClient)(nil).DownloadClusterCredentials), ctx, filename, dest)
 }
 
-// DownloadHostIgnition mocks base method
+// DownloadFile mocks base method.
+func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DownloadFile indicates an expected call of DownloadFile.
+func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
+}
+
+// DownloadHostIgnition mocks base method.
 func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnvID, hostID, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadHostIgnition", ctx, infraEnvID, hostID, dest)
@@ -73,56 +99,13 @@ func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnv
 	return ret0
 }
 
-// DownloadHostIgnition indicates an expected call of DownloadHostIgnition
+// DownloadHostIgnition indicates an expected call of DownloadHostIgnition.
 func (mr *MockInventoryClientMockRecorder) DownloadHostIgnition(ctx, infraEnvID, hostID, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadHostIgnition", reflect.TypeOf((*MockInventoryClient)(nil).DownloadHostIgnition), ctx, infraEnvID, hostID, dest)
 }
 
-// UpdateHostInstallProgress mocks base method
-func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress
-func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
-}
-
-// GetEnabledHostsNamesHosts mocks base method
-func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
-	ret0, _ := ret[0].(map[string]HostData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts
-func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
-}
-
-// UploadIngressCa mocks base method
-func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadIngressCa indicates an expected call of UploadIngressCa
-func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
-}
-
-// GetCluster mocks base method
+// GetCluster mocks base method.
 func (m *MockInventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCluster", ctx)
@@ -131,57 +114,58 @@ func (m *MockInventoryClient) GetCluster(ctx context.Context) (*models.Cluster, 
 	return ret0, ret1
 }
 
-// GetCluster indicates an expected call of GetCluster
+// GetCluster indicates an expected call of GetCluster.
 func (mr *MockInventoryClientMockRecorder) GetCluster(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx)
 }
 
-// GetClusterMonitoredOperator mocks base method
-func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName string) (*models.MonitoredOperator, error) {
+// GetClusterMonitoredOLMOperators mocks base method.
+func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string) ([]models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName)
-	ret0, _ := ret[0].(*models.MonitoredOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName)
-}
-
-// GetClusterMonitoredOLMOperators mocks base method
-func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId string) ([]models.MonitoredOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId)
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion)
 	ret0, _ := ret[0].([]models.MonitoredOperator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId interface{}) *gomock.Call {
+// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators.
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion)
 }
 
-// CompleteInstallation mocks base method
-func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
+// GetClusterMonitoredOperator mocks base method.
+func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
+	ret0, _ := ret[0].(*models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// CompleteInstallation indicates an expected call of CompleteInstallation
-func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
+// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator.
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
 }
 
-// GetHosts mocks base method
+// GetEnabledHostsNamesHosts mocks base method.
+func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
+	ret0, _ := ret[0].(map[string]HostData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts.
+func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
+}
+
+// GetHosts mocks base method.
 func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogger, skippedStatuses []string) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHosts", ctx, log, skippedStatuses)
@@ -190,51 +174,25 @@ func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogg
 	return ret0, ret1
 }
 
-// GetHosts indicates an expected call of GetHosts
+// GetHosts indicates an expected call of GetHosts.
 func (mr *MockInventoryClientMockRecorder) GetHosts(ctx, log, skippedStatuses interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetHosts), ctx, log, skippedStatuses)
 }
 
-// UploadLogs mocks base method
-func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadLogs indicates an expected call of UploadLogs
-func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
-}
-
-// ClusterLogProgressReport mocks base method
-func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
-}
-
-// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport
-func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
-}
-
-// HostLogProgressReport mocks base method
+// HostLogProgressReport mocks base method.
 func (m *MockInventoryClient) HostLogProgressReport(ctx context.Context, infraEnvId, hostId string, progress models.LogsState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HostLogProgressReport", ctx, infraEnvId, hostId, progress)
 }
 
-// HostLogProgressReport indicates an expected call of HostLogProgressReport
+// HostLogProgressReport indicates an expected call of HostLogProgressReport.
 func (mr *MockInventoryClientMockRecorder) HostLogProgressReport(ctx, infraEnvId, hostId, progress interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).HostLogProgressReport), ctx, infraEnvId, hostId, progress)
 }
 
-// UpdateClusterOperator mocks base method
+// UpdateClusterOperator mocks base method.
 func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterOperator", ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
@@ -242,8 +200,50 @@ func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, cluster
 	return ret0
 }
 
-// UpdateClusterOperator indicates an expected call of UpdateClusterOperator
+// UpdateClusterOperator indicates an expected call of UpdateClusterOperator.
 func (mr *MockInventoryClientMockRecorder) UpdateClusterOperator(ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterOperator", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterOperator), ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
+}
+
+// UpdateHostInstallProgress mocks base method.
+func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress.
+func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
+}
+
+// UploadIngressCa mocks base method.
+func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadIngressCa indicates an expected call of UploadIngressCa.
+func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
+}
+
+// UploadLogs mocks base method.
+func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadLogs indicates an expected call of UploadLogs.
+func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
 }


### PR DESCRIPTION
As we are renaming the OCS operator to ODF, but on OCP4.8, we still have OCS operator. So, added a temporary fix that renames the operator name and subscription name to OCS for OCP version 4.8. This is to be removed after, OCP4.8 is removed from Saas day1 support.

Signed-off-by: Rewant Soni <resoni@redhat.com>