### PR TITLE
MGMT-8064: Improve performance of installer/controller dry mode in multi-node clusters

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/assisted-installer/src/common"
+	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-installer/src/k8s_client"
 	"github.com/openshift/assisted-installer/src/ops"
@@ -85,9 +86,10 @@ type ControllerConfig struct {
 	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
 	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
 	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
-	DryRunHostnames         string `envconfig:"DRY_HOSTNAMES" required:"false" default:""`
-	DryMcsAccessIps         string `envconfig:"DRY_MCS_ACCESS_IPS" required:"false" default:""`
 	DryFakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH" required:"false" default:""`
+	DryRunClusterHosts      string `envconfig:"DRY_CLUSTER_HOSTS"`
+	// DryRunClusterHosts gets parsed into ParsedClusterHosts by config.DryParseClusterHosts
+	ParsedClusterHosts config.DryClusterHosts
 }
 type Controller interface {
 	WaitAndUpdateNodesStatus(status *ControllerStatus)

--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -10,21 +11,55 @@ import (
 
 // DryRunConfig defines configuration of the agent's dry-run mode
 type DryRunConfig struct {
-	DryRunEnabled        bool   `envconfig:"DRY_ENABLE"`
-	FakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
-	ForcedHostID         string `envconfig:"DRY_HOST_ID"`
-	DryRunHostnames      string `envconfig:"DRY_HOSTNAMES"`
-	DryRunIps            string `envconfig:"DRY_IPS"`
+	DryRunEnabled          bool   `envconfig:"DRY_ENABLE"`
+	FakeRebootMarkerPath   string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
+	ForcedHostID           string `envconfig:"DRY_HOST_ID"`
+	DryRunClusterHostsPath string `envconfig:"DRY_CLUSTER_HOSTS_PATH"`
+	// DryRunClusterHostsPath gets read parsed into ParsedClusterHosts by DryParseClusterHosts
+	ParsedClusterHosts DryClusterHosts
 }
 
 var GlobalDryRunConfig DryRunConfig
 
 var DefaultDryRunConfig DryRunConfig = DryRunConfig{
-	DryRunEnabled:        false,
-	FakeRebootMarkerPath: "",
-	ForcedHostID:         "",
-	DryRunHostnames:      "",
-	DryRunIps:            "",
+	DryRunEnabled:          false,
+	FakeRebootMarkerPath:   "",
+	ForcedHostID:           "",
+	DryRunClusterHostsPath: "",
+}
+
+type DryClusterHost struct {
+	// The hostname is used to link between the cluster node to the inventory host
+	Hostname string `json:"hostname"`
+	// The IP is used to fake MCS logs for the host pulling ignition
+	Ip string `json:"ip"`
+	// The reboot marker path is used to allow the bootstrap node to track which node completed
+	// reboot and which still haven't
+	RebootMarkerPath string `json:"rebootMarkerPath"`
+}
+
+// An array containing information about all hosts in the cluster. This is used
+// for tracking when cluster hosts complete reboot so their status can be mocked
+// by the controller / bootstrap host accordingly
+type DryClusterHosts []DryClusterHost
+
+// DryParseClusterHosts parses the JSON hosts file string into a DryClusterHosts
+func DryParseClusterHosts(clusterHostsJsonPath string, parsedClusterHosts *DryClusterHosts) error {
+	if clusterHostsJsonPath == "" {
+		return nil
+	}
+
+	clusterHostsJson, err := os.ReadFile(clusterHostsJsonPath)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(clusterHostsJson, parsedClusterHosts)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ProcessDryRunArgs() {
@@ -37,7 +72,13 @@ func ProcessDryRunArgs() {
 	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
 	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
 	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
-	flag.StringVar(&GlobalDryRunConfig.DryRunHostnames, "dry-run-hostnames", DefaultDryRunConfig.DryRunHostnames, "A comma separated list of all hostnames within the dry cluster")
-	flag.StringVar(&GlobalDryRunConfig.DryRunIps, "dry-run-ips", DefaultDryRunConfig.DryRunHostnames, "A comma separated list of all ip addresses of hosts within the dry cluster")
+	flag.StringVar(&GlobalDryRunConfig.DryRunClusterHostsPath, "dry-run-cluster-hosts-path", DefaultDryRunConfig.DryRunClusterHostsPath, "A path to a JSON file with information about hosts in the cluster")
 	flag.Parse()
+
+	if GlobalDryRunConfig.DryRunEnabled {
+		if DryParseClusterHosts(GlobalDryRunConfig.DryRunClusterHostsPath, &GlobalDryRunConfig.ParsedClusterHosts) != nil {
+			fmt.Printf("Error parsing cluster hosts: %v", err)
+			os.Exit(1)
+		}
+	}
 }

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -38,7 +38,7 @@ const (
 	DefaultRetryMinDelay = time.Duration(2) * time.Second
 	DefaultRetryMaxDelay = time.Duration(10) * time.Second
 	DefaultMinRetries    = 10
-	defaultMaxRetries    = 360
+	DefaultMaxRetries    = 360
 )
 
 //go:generate mockgen -source=inventory_client.go -package=inventory_client -destination=mock_inventory_client.go
@@ -76,7 +76,7 @@ type HostData struct {
 func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,
 	logger *logrus.Logger, proxyFunc func(*http.Request) (*url.URL, error)) (*inventoryClient, error) {
 	return CreateInventoryClientWithDelay(clusterId, inventoryURL, pullSecret, insecure, caPath,
-		logger, proxyFunc, DefaultRetryMinDelay, DefaultRetryMaxDelay, defaultMaxRetries, DefaultMinRetries)
+		logger, proxyFunc, DefaultRetryMinDelay, DefaultRetryMaxDelay, DefaultMaxRetries, DefaultMinRetries)
 }
 
 func CreateInventoryClientWithDelay(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -397,3 +397,17 @@ func (mr *MockOpsMockRecorder) CreateManifests(arg0, arg1 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManifests", reflect.TypeOf((*MockOps)(nil).CreateManifests), arg0, arg1)
 }
+
+// DryRebootHappened mocks base method
+func (m *MockOps) DryRebootHappened(markerPath string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DryRebootHappened", markerPath)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DryRebootHappened indicates an expected call of DryRebootHappened
+func (mr *MockOpsMockRecorder) DryRebootHappened(markerPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRebootHappened", reflect.TypeOf((*MockOps)(nil).DryRebootHappened), markerPath)
+}


### PR DESCRIPTION
Installing multi-node clusters using dry-mode / swarm had some
performance issues that are solved in this commit:

- Let the controller know about the reboot marker path of each and every
  one of the cluster hosts. This allows it to mock the creation of k8s
  node objects for each node only once that host actually reboots. This
  prevents some odd race conditions.
  Since we now need to give the controller even more per-host
  information, the comma seperated `DryRunHostnames` and `DryMcsAccessIps`,
  along with the new reboot marker path information, have been merged
  into a single `DryRunClusterHosts` parameter which is a JSON
  representing that information about all hosts in the cluster.

- Rename `defaultMaxRetries` to `DefaultMaxRetries`

- In installer dry run mode, use `dryRunMaximumInventoryClientRetries`
  rather than `DefaultMaxRetries` to get quick feedback about errors rather
  than keep retrying many times.

- Rename `handleClusterStatus` to more clear `didInstallationFinish`
  name

- Add `ClusterStatusAddingHosts` as one of the states checked  by
  `didInstallationFinish`. As can be seen in https://github.com/openshift/assisted-service/blob/6278140aa99dca8d11f723b8d20694bdc9329e94/internal/controller/controllers/clusterdeployments_controller.go#L1832 the service
  in kube-api mode immediately moves non-sno clusters to the day2
  state once they finish installation. This meant that users of
  `didInstallationFinish` would get a wrong answer and as a result
  loop forever when installing multi-node clusters using kube-api.
  This applies to non dry-run mode as well.
  (This was unnoticed probably because people don't go out of their
  way to check that the controller stopped running after installing
  a cluster).