### PR TITLE
NO-ISSUE: Update go-openapi/runtime and fix url building

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/ReneKroon/ttlcache/v2 v2.11.0
 	github.com/coreos/ignition/v2 v2.13.0
-	github.com/go-openapi/runtime v0.19.28
+	github.com/go-openapi/runtime v0.22.0
 	github.com/go-openapi/strfmt v0.21.1
 	github.com/go-openapi/swag v0.19.15
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/go-openapi/runtime v0.19.15/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2g
 github.com/go-openapi/runtime v0.19.16/go.mod h1:5P9104EJgYcizotuXhEuUrzVc+j1RiSjahULvYmlv98=
 github.com/go-openapi/runtime v0.19.20/go.mod h1:Lm9YGCeecBnUUkFTxPC4s1+lwrkJ0pthx8YvyjCfkgk=
 github.com/go-openapi/runtime v0.19.24/go.mod h1:Lm9YGCeecBnUUkFTxPC4s1+lwrkJ0pthx8YvyjCfkgk=
-github.com/go-openapi/runtime v0.19.28 h1:9lYu6axek8LJrVkMVViVirRcpoaCxXX7+sSvmizGVnA=
-github.com/go-openapi/runtime v0.19.28/go.mod h1:BvrQtn6iVb2QmiVXRsFAm6ZCAZBpbVKFfN6QWCp582M=
+github.com/go-openapi/runtime v0.22.0 h1:vY2D0u807kkcwidaj0YJuq4zyAWQnjLNDpJcVBrUFNs=
+github.com/go-openapi/runtime v0.22.0/go.mod h1:aQg+kaIQEn+A2CRSY1TxbM8+sT9g2V3aLc1FbIAnbbs=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"syscall"
 	"time"
@@ -84,7 +85,8 @@ func CreateInventoryClientWithDelay(clusterId string, inventoryURL string, pullS
 	retryMinDelay, retryMaxDelay time.Duration, maxRetries int, minRetries int) (*inventoryClient, error) {
 	clientConfig := client.Config{}
 	var err error
-	clientConfig.URL, err = url.ParseRequestURI(createUrl(inventoryURL))
+
+	clientConfig.URL, err = createUrl(inventoryURL)
 	if err != nil {
 		return nil, err
 	}
@@ -327,11 +329,13 @@ func (c *inventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogger, 
 	return namesIdsMap, nil
 }
 
-func createUrl(baseURL string) string {
-	return fmt.Sprintf("%s/%s",
-		baseURL,
-		client.DefaultBasePath,
-	)
+func createUrl(baseURL string) (*url.URL, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, client.DefaultBasePath)
+	return u, nil
 }
 
 func (c *inventoryClient) createDownloadParams(filename string) *installer.V2DownloadClusterFilesParams {


### PR DESCRIPTION
This update to go-openapi/runtime exposed a bug in our url handling
where we add extra slashes to the url path.
Previously this seemed to have been cleaned up transparently by the
client but now ends up dropping the base path.