### PR TITLE
NO-ISSUE: Fix error log printing the wrong error variable

### DIFF
--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -76,8 +76,8 @@ func ProcessDryRunArgs() {
 	flag.Parse()
 
 	if GlobalDryRunConfig.DryRunEnabled {
-		if DryParseClusterHosts(GlobalDryRunConfig.DryRunClusterHostsPath, &GlobalDryRunConfig.ParsedClusterHosts) != nil {
-			fmt.Printf("Error parsing cluster hosts: %v", err)
+		if parseErr := DryParseClusterHosts(GlobalDryRunConfig.DryRunClusterHostsPath, &GlobalDryRunConfig.ParsedClusterHosts); parseErr != nil {
+			fmt.Printf("Error parsing cluster hosts: %v", parseErr)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
`err` didn't get re-assigned so it always held a previously assigned
`nil` leading to an uninformative error message