### PR TITLE
NO-ISSUE: Jenkins should only build images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 
     stage('build') {
         steps {
-            sh 'skipper make'
+            sh 'skipper make build-images'
         }
     }
 


### PR DESCRIPTION
Jenkins build is broken on master since
https://github.com/openshift/assisted-installer/pull/412.

This fix tells to Jenkins to only build the images, since all the other
steps (lint, unit tests) are already part of Prow jobs.