### PR TITLE
NO-ISSUE: Fix jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,8 +64,6 @@ pipeline {
                sh '''curl -X POST -H 'Content-type: application/json' --data-binary "@data.txt" https://hooks.slack.com/services/${SLACK_TOKEN}'''
            }
 
-            junit '**/reports/junit*.xml'
-            cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
         }
     }
   }


### PR DESCRIPTION
Since https://github.com/openshift/assisted-installer/pull/414, jenkins
does not generate junit/coverage information, so we shoudn't publish
them.
