### PR TITLE
Bug 2073998: Modify assisted installer, to use more efficient queries when accessing the assisted service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/assisted-installer-agent v1.0.9
-	github.com/openshift/assisted-service v1.0.10-0.20220403100847-e32775972980
+	github.com/openshift/assisted-service v1.0.10-0.20220410161729-e15861d5649d
 	github.com/openshift/assisted-service/models v0.0.0
 	github.com/openshift/client-go v0.0.0-20220302123837-25b55b99bd24
 	github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597
@@ -74,7 +74,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -105,7 +105,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect; indirectv0.0.0-20220315080954-241ad46db74a
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect
@@ -159,8 +159,9 @@ replace (
 	github.com/metal3-io/baremetal-operator/apis => github.com/openshift/baremetal-operator/apis v0.0.0-20220217140404-6b1ecb71984f
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils => github.com/openshift/baremetal-operator/pkg/hardwareutils v0.0.0-20220217140404-6b1ecb71984f
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20220310165943-abf6417c2748
-	github.com/openshift/assisted-service/api => github.com/openshift/assisted-service/api v0.0.0-20220314012014-141adc8ae8f8
-	github.com/openshift/assisted-service/models => github.com/openshift/assisted-service/models v0.0.0-20220320125840-bf8fcab0e181
+	github.com/openshift/assisted-service v1.0.10-0.20220315080954-241ad46db74a => github.com/openshift/assisted-service v1.0.10-0.20220324105330-f28bddc8d95a
+	github.com/openshift/assisted-service/api => github.com/openshift/assisted-service/api v0.0.0-20220315080954-241ad46db74a
+	github.com/openshift/assisted-service/models => github.com/openshift/assisted-service/models v0.0.0-20220324105330-f28bddc8d95a
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201022175424-d30c7a274820
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201016155852-4090a6970205
 

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,9 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.0 h1:EmVIxB5jzbllGIjiCV5JG4VylbK3KE400tLGLI1cdfU=
+github.com/golang-jwt/jwt/v4 v4.4.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-migrate/migrate/v4 v4.6.2/go.mod h1:JYi6reN3+Z734VZ0akNuyOJNcrg45ZL7LDBMW3WGJL0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -1164,11 +1165,11 @@ github.com/openshift/api v0.0.0-20220310165943-abf6417c2748/go.mod h1:F/eU6jgr6Q
 github.com/openshift/assisted-installer-agent v1.0.9 h1:s81YAJXegCHpRgLrZJZkscf+7UAQI9tsaaKmJDt3NOE=
 github.com/openshift/assisted-installer-agent v1.0.9/go.mod h1:9KhBmp9fvRY1spNbAtK2KbmGYSLBi0bP0GSsIXroyQY=
 github.com/openshift/assisted-service v0.0.0-20200830102625-2f0da134c290/go.mod h1:2B7eiF34TSZA9XEEgZSpnS6uwowORikRZVWApjMYbMs=
-github.com/openshift/assisted-service v1.0.10-0.20220403100847-e32775972980 h1:MFplUdf4KIwmylFfnp5aD7ndNKUFtEhoLqc5R/a42ZM=
-github.com/openshift/assisted-service v1.0.10-0.20220403100847-e32775972980/go.mod h1:TcA+nXQMitIEpO2rZzZbQ2hXZihrlehcmvfJzf6Njn8=
-github.com/openshift/assisted-service/api v0.0.0-20220314012014-141adc8ae8f8/go.mod h1:KXLo37GRdMYq/8PHRbvWPW9AEZjLI3NdFCySAwBJfAQ=
-github.com/openshift/assisted-service/models v0.0.0-20220320125840-bf8fcab0e181 h1:uXzdSyxfMVLaBYfD3GnVpUByCRL1aY2LwcTb1ejf9Wk=
-github.com/openshift/assisted-service/models v0.0.0-20220320125840-bf8fcab0e181/go.mod h1:jTawnnM2LU/AzpZLYxPeXQy4qBRl5iwFo1bu3zrPv2s=
+github.com/openshift/assisted-service v1.0.10-0.20220410161729-e15861d5649d h1:Y2a+hwsyPk6PQIDgzFygbouZIgSEC2xO+hh8daJE/r4=
+github.com/openshift/assisted-service v1.0.10-0.20220410161729-e15861d5649d/go.mod h1:TcA+nXQMitIEpO2rZzZbQ2hXZihrlehcmvfJzf6Njn8=
+github.com/openshift/assisted-service/api v0.0.0-20220315080954-241ad46db74a/go.mod h1:KXLo37GRdMYq/8PHRbvWPW9AEZjLI3NdFCySAwBJfAQ=
+github.com/openshift/assisted-service/models v0.0.0-20220324105330-f28bddc8d95a h1:gXwOpc9fdk+f4ezUQYUmar35dpJI/a2Ws6UdnFd9BTg=
+github.com/openshift/assisted-service/models v0.0.0-20220324105330-f28bddc8d95a/go.mod h1:jTawnnM2LU/AzpZLYxPeXQy4qBRl5iwFo1bu3zrPv2s=
 github.com/openshift/baremetal-operator/apis v0.0.0-20220217140404-6b1ecb71984f h1:I90Nqv4Gq1L7q9xC69i8drrGi9cJikI0lnhxwSHTkjE=
 github.com/openshift/baremetal-operator/apis v0.0.0-20220217140404-6b1ecb71984f/go.mod h1:bTFE2qR9PJJQbLC6Gd74c3WXcgYnR1njVDgabCxXQNI=
 github.com/openshift/baremetal-operator/pkg/hardwareutils v0.0.0-20220217140404-6b1ecb71984f h1:hHra0TWuiDS9Yas6i38MZ7VsguUfV++SkGf7QSyo3S8=

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -413,7 +413,7 @@ func (c controller) PostInstallConfigs(ctx context.Context, wg *sync.WaitGroup) 
 	}()
 	err := utils.WaitForPredicateWithContext(ctx, LongWaitTimeout, GeneralWaitInterval, func() bool {
 		ctxReq := utils.GenerateRequestContext()
-		cluster, err := c.ic.GetCluster(ctx)
+		cluster, err := c.ic.GetCluster(ctx, false)
 		if err != nil {
 			utils.RequestIDLogger(ctxReq, c.log).WithError(err).Errorf("Failed to get cluster %s from assisted-service", c.ClusterID)
 			return false
@@ -1198,7 +1198,7 @@ func (c *controller) UploadLogs(ctx context.Context, wg *sync.WaitGroup) {
 func (c controller) SetReadyState() {
 	c.log.Infof("Start waiting to be ready")
 	_ = utils.WaitForPredicate(WaitTimeout, 1*time.Second, func() bool {
-		_, err := c.ic.GetCluster(context.TODO())
+		_, err := c.ic.GetCluster(context.TODO(), false)
 		if err != nil {
 			c.log.WithError(err).Warningf("Failed to connect to assisted service")
 			return false

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -189,7 +189,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	setClusterAsFinalizing := func() {
 		finalizing := models.ClusterStatusFinalizing
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &finalizing}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: &finalizing}, nil).Times(1)
 	}
 
 	uploadIngressCert := func(clusterID string) {
@@ -248,8 +248,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	Context("Waiting for 3 nodes", func() {
 		It("Set ready event", func() {
 			// fail to connect to assisted and then succeed
-			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, nil).Times(3)
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, nil).Times(3)
 
 			// fail to connect to ocp and then succeed
 			mockk8sclient.EXPECT().ListNodes().Return(nil, fmt.Errorf("dummy")).Times(1)
@@ -589,7 +589,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			It("failure if console not available in service or failed to set status and success if available", func() {
 				installing := models.ClusterStatusInstalling
-				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(2)
+				mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: &installing}, nil).Times(2)
 
 				mockGetServiceOperators([]models.MonitoredOperator{{Name: consoleOperatorName, Status: models.OperatorStatusProgressing}})
 				mockk8sclient.EXPECT().GetClusterOperator(consoleOperatorName).Return(validConsoleOperator, nil).Times(2)
@@ -615,7 +615,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			It("success", func() {
 				installing := models.ClusterStatusInstalling
-				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(1)
+				mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: &installing}, nil).Times(1)
 				setControllerWaitForOLMOperators(assistedController.ClusterID)
 				setCvoAsAvailable()
 
@@ -633,7 +633,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			It("lots of failures then success", func() {
 				installing := models.ClusterStatusInstalling
-				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(1)
+				mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: &installing}, nil).Times(1)
 				setClusterAsFinalizing()
 
 				// Console errors
@@ -750,7 +750,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			})
 			It("success", func() {
 				installing := models.ClusterStatusInstalling
-				mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: &installing}, nil).Times(1)
+				mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: &installing}, nil).Times(1)
 				setControllerWaitForOLMOperators(assistedController.ClusterID)
 				mockGetOLMOperators([]models.MonitoredOperator{})
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "").Return(fmt.Errorf("dummy")).Times(1)

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -652,23 +652,23 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				{string(models.HostStageWaitingForControlPlane)},
 				{string(models.HostStageRebooting)},
 			})
-			cluster := models.Cluster{
-				Hosts: []*models.Host{
-					{
-						Role: models.HostRoleMaster,
-						Progress: &models.HostProgressInfo{
-							CurrentStage: models.HostStageDone,
-						},
+			cluster := models.Cluster{}
+			hosts := models.HostList{
+				{
+					Role: models.HostRoleMaster,
+					Progress: &models.HostProgressInfo{
+						CurrentStage: models.HostStageDone,
 					},
-					{
-						Role: models.HostRoleMaster,
-						Progress: &models.HostProgressInfo{
-							CurrentStage: models.HostStageDone,
-						},
+				},
+				{
+					Role: models.HostRoleMaster,
+					Progress: &models.HostProgressInfo{
+						CurrentStage: models.HostStageDone,
 					},
 				},
 			}
-			mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&cluster, nil).Times(1)
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&cluster, nil).Times(1)
+			mockbmclient.EXPECT().ListsHostsForRole(gomock.Any(), "master").Return(hosts, nil).Times(1)
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
 			downloadHostIgnitionSuccess(infraEnvId, hostId, "worker-host-id.ign")

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -14,70 +14,30 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// MockInventoryClient is a mock of InventoryClient interface.
+// MockInventoryClient is a mock of InventoryClient interface
 type MockInventoryClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockInventoryClientMockRecorder
 }
 
-// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient.
+// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient
 type MockInventoryClientMockRecorder struct {
 	mock *MockInventoryClient
 }
 
-// NewMockInventoryClient creates a new mock instance.
+// NewMockInventoryClient creates a new mock instance
 func NewMockInventoryClient(ctrl *gomock.Controller) *MockInventoryClient {
 	mock := &MockInventoryClient{ctrl: ctrl}
 	mock.recorder = &MockInventoryClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInventoryClient) EXPECT() *MockInventoryClientMockRecorder {
 	return m.recorder
 }
 
-// ClusterLogProgressReport mocks base method.
-func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
-}
-
-// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport.
-func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
-}
-
-// CompleteInstallation mocks base method.
-func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CompleteInstallation indicates an expected call of CompleteInstallation.
-func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
-}
-
-// DownloadClusterCredentials mocks base method.
-func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, filename, dest string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadClusterCredentials", ctx, filename, dest)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials.
-func (mr *MockInventoryClientMockRecorder) DownloadClusterCredentials(ctx, filename, dest interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadClusterCredentials", reflect.TypeOf((*MockInventoryClient)(nil).DownloadClusterCredentials), ctx, filename, dest)
-}
-
-// DownloadFile mocks base method.
+// DownloadFile mocks base method
 func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
@@ -85,13 +45,27 @@ func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest s
 	return ret0
 }
 
-// DownloadFile indicates an expected call of DownloadFile.
+// DownloadFile indicates an expected call of DownloadFile
 func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
 }
 
-// DownloadHostIgnition mocks base method.
+// DownloadClusterCredentials mocks base method
+func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, filename, dest string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadClusterCredentials", ctx, filename, dest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials
+func (mr *MockInventoryClientMockRecorder) DownloadClusterCredentials(ctx, filename, dest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadClusterCredentials", reflect.TypeOf((*MockInventoryClient)(nil).DownloadClusterCredentials), ctx, filename, dest)
+}
+
+// DownloadHostIgnition mocks base method
 func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnvID, hostID, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadHostIgnition", ctx, infraEnvID, hostID, dest)
@@ -99,58 +73,27 @@ func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnv
 	return ret0
 }
 
-// DownloadHostIgnition indicates an expected call of DownloadHostIgnition.
+// DownloadHostIgnition indicates an expected call of DownloadHostIgnition
 func (mr *MockInventoryClientMockRecorder) DownloadHostIgnition(ctx, infraEnvID, hostID, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadHostIgnition", reflect.TypeOf((*MockInventoryClient)(nil).DownloadHostIgnition), ctx, infraEnvID, hostID, dest)
 }
 
-// GetCluster mocks base method.
-func (m *MockInventoryClient) GetCluster(ctx context.Context) (*models.Cluster, error) {
+// UpdateHostInstallProgress mocks base method
+func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx)
-	ret0, _ := ret[0].(*models.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetCluster indicates an expected call of GetCluster.
-func (mr *MockInventoryClientMockRecorder) GetCluster(ctx interface{}) *gomock.Call {
+// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress
+func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
 }
 
-// GetClusterMonitoredOLMOperators mocks base method.
-func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string) ([]models.MonitoredOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion)
-	ret0, _ := ret[0].([]models.MonitoredOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators.
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion)
-}
-
-// GetClusterMonitoredOperator mocks base method.
-func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
-	ret0, _ := ret[0].(*models.MonitoredOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator.
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
-}
-
-// GetEnabledHostsNamesHosts mocks base method.
+// GetEnabledHostsNamesHosts mocks base method
 func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
@@ -159,13 +102,101 @@ func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log
 	return ret0, ret1
 }
 
-// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts.
+// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts
 func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
 }
 
-// GetHosts mocks base method.
+// UploadIngressCa mocks base method
+func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadIngressCa indicates an expected call of UploadIngressCa
+func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
+}
+
+// GetCluster mocks base method
+func (m *MockInventoryClient) GetCluster(ctx context.Context, withHosts bool) (*models.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCluster", ctx, withHosts)
+	ret0, _ := ret[0].(*models.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCluster indicates an expected call of GetCluster
+func (mr *MockInventoryClientMockRecorder) GetCluster(ctx, withHosts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx, withHosts)
+}
+
+// ListsHostsForRole mocks base method
+func (m *MockInventoryClient) ListsHostsForRole(ctx context.Context, role string) (models.HostList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListsHostsForRole", ctx, role)
+	ret0, _ := ret[0].(models.HostList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListsHostsForRole indicates an expected call of ListsHostsForRole
+func (mr *MockInventoryClientMockRecorder) ListsHostsForRole(ctx, role interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListsHostsForRole", reflect.TypeOf((*MockInventoryClient)(nil).ListsHostsForRole), ctx, role)
+}
+
+// GetClusterMonitoredOperator mocks base method
+func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
+	ret0, _ := ret[0].(*models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
+}
+
+// GetClusterMonitoredOLMOperators mocks base method
+func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string) ([]models.MonitoredOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion)
+	ret0, _ := ret[0].([]models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion)
+}
+
+// CompleteInstallation mocks base method
+func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompleteInstallation indicates an expected call of CompleteInstallation
+func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
+}
+
+// GetHosts mocks base method
 func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogger, skippedStatuses []string) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHosts", ctx, log, skippedStatuses)
@@ -174,67 +205,13 @@ func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogg
 	return ret0, ret1
 }
 
-// GetHosts indicates an expected call of GetHosts.
+// GetHosts indicates an expected call of GetHosts
 func (mr *MockInventoryClientMockRecorder) GetHosts(ctx, log, skippedStatuses interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetHosts), ctx, log, skippedStatuses)
 }
 
-// HostLogProgressReport mocks base method.
-func (m *MockInventoryClient) HostLogProgressReport(ctx context.Context, infraEnvId, hostId string, progress models.LogsState) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HostLogProgressReport", ctx, infraEnvId, hostId, progress)
-}
-
-// HostLogProgressReport indicates an expected call of HostLogProgressReport.
-func (mr *MockInventoryClientMockRecorder) HostLogProgressReport(ctx, infraEnvId, hostId, progress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).HostLogProgressReport), ctx, infraEnvId, hostId, progress)
-}
-
-// UpdateClusterOperator mocks base method.
-func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterOperator", ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateClusterOperator indicates an expected call of UpdateClusterOperator.
-func (mr *MockInventoryClientMockRecorder) UpdateClusterOperator(ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterOperator", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterOperator), ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
-}
-
-// UpdateHostInstallProgress mocks base method.
-func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress.
-func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
-}
-
-// UploadIngressCa mocks base method.
-func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadIngressCa indicates an expected call of UploadIngressCa.
-func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
-}
-
-// UploadLogs mocks base method.
+// UploadLogs mocks base method
 func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
@@ -242,8 +219,46 @@ func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, 
 	return ret0
 }
 
-// UploadLogs indicates an expected call of UploadLogs.
+// UploadLogs indicates an expected call of UploadLogs
 func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
+}
+
+// ClusterLogProgressReport mocks base method
+func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
+}
+
+// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport
+func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
+}
+
+// HostLogProgressReport mocks base method
+func (m *MockInventoryClient) HostLogProgressReport(ctx context.Context, infraEnvId, hostId string, progress models.LogsState) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HostLogProgressReport", ctx, infraEnvId, hostId, progress)
+}
+
+// HostLogProgressReport indicates an expected call of HostLogProgressReport
+func (mr *MockInventoryClientMockRecorder) HostLogProgressReport(ctx, infraEnvId, hostId, progress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).HostLogProgressReport), ctx, infraEnvId, hostId, progress)
+}
+
+// UpdateClusterOperator mocks base method
+func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterOperator", ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterOperator indicates an expected call of UpdateClusterOperator
+func (mr *MockInventoryClientMockRecorder) UpdateClusterOperator(ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterOperator", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterOperator), ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
 }

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -152,7 +152,7 @@ func waitForInstallation(client inventory_client.InventoryClient, log logrus.Fie
 
 	for {
 		time.Sleep(waitForInstallationInterval)
-		cluster, err := client.GetCluster(reqCtx)
+		cluster, err := client.GetCluster(reqCtx, false)
 		if err != nil {
 			// In case cluster was deleted or controller is not authorised
 			// we should exit controller after maximumErrorsBeforeExit errors

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -45,22 +45,22 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	It("Waiting for cluster installed - first cluster error then installed", func() {
 		// fail to connect to assisted and then succeed
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, fmt.Errorf("dummy")).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
 	})
 
 	It("Waiting for cluster cancelled", func() {
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusCancelled)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusCancelled)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
 	})
 
 	It("Waiting for cluster error - should set error status", func() {
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusError)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusError)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(true))
@@ -71,9 +71,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
 		Expect(exitCode).Should(Equal(0))
@@ -84,10 +84,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewV2GetClusterNotFound()).Times(maximumErrorsBeforeExit)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterNotFound()).Times(maximumErrorsBeforeExit)
 
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
@@ -99,9 +99,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewV2GetClusterNotFound()).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterNotFound()).Times(1)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
@@ -113,9 +113,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))
@@ -127,9 +127,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		exit = func(code int) {
 			exitCode = code
 		}
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit - 2)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit - 2)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any()).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, status)
 		Expect(status.HasError()).Should(Equal(false))


### PR DESCRIPTION
    - When worker is waiting for 2 ready master nodes, ask only for masters
      instead of all hosts
    - Change locations that only need cluster without hosts, to request only
      cluster.
This is backport to 2.5
Original PRs:
https://github.com/openshift/assisted-installer/pull/427
And 
https://github.com/openshift/assisted-installer/pull/435


/cc @filanov 