### PR TITLE
MGMT-9985: Eliminate use of global variables in assisted-installer

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Config struct {
+	DryRunConfig
 	Role                 string
 	ClusterID            string
 	InfraEnvID           string
@@ -38,15 +39,13 @@ type Config struct {
 	DisksToFormat        ArrayFlags
 }
 
-var GlobalConfig Config
-
 func printHelpAndExit() {
 	flag.CommandLine.Usage()
 	os.Exit(0)
 }
 
-func ProcessArgs() {
-	ret := &GlobalConfig
+func ProcessArgs() *Config {
+	ret := &Config{}
 	flag.StringVar(&ret.Role, "role", string(models.HostRoleMaster), "The node role")
 	flag.StringVar(&ret.ClusterID, "cluster-id", "", "The cluster id")
 	flag.StringVar(&ret.InfraEnvID, "infra-env-id", "", "This host infra env id")
@@ -101,4 +100,5 @@ func ProcessArgs() {
 	if ret.InfraEnvID == "" {
 		ret.InfraEnvID = ret.ClusterID
 	}
+	return ret
 }

--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -19,9 +19,7 @@ type DryRunConfig struct {
 	ParsedClusterHosts DryClusterHosts
 }
 
-var GlobalDryRunConfig DryRunConfig
-
-var DefaultDryRunConfig DryRunConfig = DryRunConfig{
+var DefaultDryRunConfig = DryRunConfig{
 	DryRunEnabled:          false,
 	FakeRebootMarkerPath:   "",
 	ForcedHostID:           "",
@@ -62,21 +60,21 @@ func DryParseClusterHosts(clusterHostsJsonPath string, parsedClusterHosts *DryCl
 	return nil
 }
 
-func ProcessDryRunArgs() {
+func ProcessDryRunArgs(dryRunConfig *DryRunConfig) {
 	err := envconfig.Process("dryconfig", &DefaultDryRunConfig)
 	if err != nil {
 		fmt.Printf("envconfig error: %v", err)
 		os.Exit(1)
 	}
 
-	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
-	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
-	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
-	flag.StringVar(&GlobalDryRunConfig.DryRunClusterHostsPath, "dry-run-cluster-hosts-path", DefaultDryRunConfig.DryRunClusterHostsPath, "A path to a JSON file with information about hosts in the cluster")
+	flag.BoolVar(&dryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
+	flag.StringVar(&dryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
+	flag.StringVar(&dryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
+	flag.StringVar(&dryRunConfig.DryRunClusterHostsPath, "dry-run-cluster-hosts-path", DefaultDryRunConfig.DryRunClusterHostsPath, "A path to a JSON file with information about hosts in the cluster")
 	flag.Parse()
 
-	if GlobalDryRunConfig.DryRunEnabled {
-		if parseErr := DryParseClusterHosts(GlobalDryRunConfig.DryRunClusterHostsPath, &GlobalDryRunConfig.ParsedClusterHosts); parseErr != nil {
+	if dryRunConfig.DryRunEnabled {
+		if parseErr := DryParseClusterHosts(dryRunConfig.DryRunClusterHostsPath, &dryRunConfig.ParsedClusterHosts); parseErr != nil {
 			fmt.Printf("Error parsing cluster hosts: %v", parseErr)
 			os.Exit(1)
 		}

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -38,7 +38,6 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
 )
@@ -204,10 +203,6 @@ func (c *k8sClient) ListMachines() (*machinev1beta1.MachineList, error) {
 }
 
 func (c *k8sClient) PatchEtcd() error {
-	if config.GlobalDryRunConfig.DryRunEnabled {
-		return nil
-	}
-
 	c.log.Info("Patching etcd")
 	data := []byte(`{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`)
 	result, err := c.ocClient.OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, data, metav1.PatchOptions{})

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -1,94 +1,22 @@
 package main
 
 import (
-	"net/http"
 	"os"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/openshift/assisted-installer/src/ignition"
-	"github.com/openshift/assisted-installer/src/main/drymock"
-
-	"github.com/golang/mock/gomock"
-	"github.com/onsi/ginkgo"
 	"github.com/openshift/assisted-installer/src/config"
 	"github.com/openshift/assisted-installer/src/installer"
-	"github.com/openshift/assisted-installer/src/inventory_client"
-	"github.com/openshift/assisted-installer/src/k8s_client"
-	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
-	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/secretdump"
 )
 
-// In dry run mode we prefer to get quick feedback about errors rather
-// than keep retrying many times.
-const dryRunMaximumInventoryClientRetries = 3
-
 func main() {
-	config.ProcessArgs()
-	config.ProcessDryRunArgs()
-	logger := utils.InitLogger(config.GlobalConfig.Verbose, true, config.GlobalDryRunConfig.ForcedHostID, config.DefaultDryRunConfig.DryRunEnabled)
-	config.GlobalConfig.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
-	if config.GlobalConfig.PullSecretToken == "" {
+	installerConfig := config.ProcessArgs()
+	config.ProcessDryRunArgs(&installerConfig.DryRunConfig)
+	logger := utils.InitLogger(installerConfig.Verbose, true, installerConfig.ForcedHostID, config.DefaultDryRunConfig.DryRunEnabled)
+	installerConfig.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
+	if installerConfig.PullSecretToken == "" {
 		logger.Warnf("Agent Authentication Token not set")
 	}
-
-	logger.Infof("Assisted installer started. Configuration is:\n %s", secretdump.DumpSecretStruct(config.GlobalConfig))
-	logger.Infof("Dry configuration is:\n %s", secretdump.DumpSecretStruct(config.GlobalDryRunConfig))
-
-	numRetries := inventory_client.DefaultMaxRetries
-	if config.GlobalDryRunConfig.DryRunEnabled {
-		numRetries = dryRunMaximumInventoryClientRetries
-	}
-
-	client, err := inventory_client.CreateInventoryClientWithDelay(
-		config.GlobalConfig.ClusterID,
-		config.GlobalConfig.URL,
-		config.GlobalConfig.PullSecretToken,
-		config.GlobalConfig.SkipCertVerification,
-		config.GlobalConfig.CACertPath,
-		logger,
-		http.ProxyFromEnvironment,
-		inventory_client.DefaultRetryMinDelay,
-		inventory_client.DefaultRetryMaxDelay,
-		numRetries,
-		inventory_client.DefaultMinRetries,
-	)
-
-	if err != nil {
-		logger.Fatalf("Failed to create inventory client %e", err)
-	}
-
-	o := ops.NewOps(logger, true)
-
-	var k8sClientBuilder k8s_client.K8SClientBuilder
-	if !config.GlobalDryRunConfig.DryRunEnabled {
-		k8sClientBuilder = k8s_client.NewK8SClient
-	} else {
-		k8sClientBuilder = func(configPath string, logger *logrus.Logger) (k8s_client.K8SClient, error) {
-			var kc k8s_client.K8SClient
-			mockController := gomock.NewController(ginkgo.GinkgoT())
-			kc = k8s_client.NewMockK8SClient(mockController)
-			mock, _ := kc.(*k8s_client.MockK8SClient)
-			drymock.PrepareInstallerDryK8sMock(mock, logger, o, config.GlobalDryRunConfig.ParsedClusterHosts)
-			return kc, nil
-		}
-	}
-
-	ai := installer.NewAssistedInstaller(logger,
-		config.GlobalConfig,
-		o,
-		client,
-		k8sClientBuilder,
-		ignition.NewIgnition(),
-	)
-
-	// Try to format requested disks. May fail formatting some disks, this is not an error.
-	ai.FormatDisks()
-
-	if err := ai.InstallNode(); err != nil {
-		ai.UpdateHostInstallProgress(models.HostStageFailed, err.Error())
+	if err := installer.RunInstaller(installerConfig, logger); err != nil {
 		os.Exit(1)
 	}
 }

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -5,20 +5,19 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/assisted-installer/src/config"
 )
 
 var _ = Describe("ExecCommandError", func() {
 	pullSecret := "TEST-TOKEN"
-	config.GlobalConfig.PullSecretToken = pullSecret
 
 	It("Creates the correct error for mkdir", func() {
 		err := &ExecCommandError{
-			Command: "mkdir",
-			Args:    []string{"-p", "/somedir"},
-			Env:     []string{"HOME=/home/userZ"},
-			ExitErr: fmt.Errorf("Permission denied"),
-			Output:  "mkdir: cannot create directory ‘/somedir’: Permission denied",
+			Command:         "mkdir",
+			Args:            []string{"-p", "/somedir"},
+			Env:             []string{"HOME=/home/userZ"},
+			ExitErr:         fmt.Errorf("Permission denied"),
+			Output:          "mkdir: cannot create directory ‘/somedir’: Permission denied",
+			PullSecretToken: pullSecret,
 		}
 		wantError := "failed executing mkdir [-p /somedir], Error Permission denied, LastOutput \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
 		wantDetailedError := "failed executing mkdir [-p /somedir], env vars [HOME=/home/userZ], error Permission denied, waitStatus 0, Output \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
@@ -29,12 +28,13 @@ var _ = Describe("ExecCommandError", func() {
 
 	It("Creates the correct error for ignition extract", func() {
 		err := &ExecCommandError{
-			Command:    "nsenter",
-			Args:       []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot", "--pull-secret", pullSecret},
-			Env:        []string{"HOME=/home/userZ", fmt.Sprintf("PULL_SECRET_TOKEN=%s", pullSecret)},
-			ExitErr:    fmt.Errorf("exit status 255"),
-			WaitStatus: 255,
-			Output:     "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
+			Command:         "nsenter",
+			Args:            []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot", "--pull-secret", pullSecret},
+			Env:             []string{"HOME=/home/userZ", fmt.Sprintf("PULL_SECRET_TOKEN=%s", pullSecret)},
+			ExitErr:         fmt.Errorf("exit status 255"),
+			WaitStatus:      255,
+			Output:          "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
+			PullSecretToken: pullSecret,
 		}
 		wantError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot --pull-secret <SECRET>], Error exit status 255, LastOutput "... or: Timeout was reached
 F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`


### PR DESCRIPTION
In order to enable running the assisted installer in the combined agent,
use of global variables have to be eliminated,

[MGMT-9991](https://issues.redhat.com//browse/MGMT-9991): Separate installer main function to contain only flag
processing and environment variables handling.

Move the rest of the functionality to separate function.

/cc @omertuc 