### PR TITLE
MGMT-9244: Prevent assisted-agent from rebooting the node when managed by IPA

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -288,11 +288,6 @@ func installerArgs(ignitionPath string, device string, extra []string) []string 
 }
 
 func (o *ops) Reboot() error {
-	if o.installerConfig.DryRunEnabled {
-		_, err := o.ExecPrivilegeCommand(o.logWriter, "touch", o.installerConfig.FakeRebootMarkerPath)
-		return errors.Wrap(err, "failed to touch fake reboot marker")
-	}
-
 	o.log.Info("Rebooting node")
 	_, err := o.ExecPrivilegeCommand(o.logWriter, "shutdown", "-r", "+1", "'Installation completed, server is going to reboot.'")
 	if err != nil {


### PR DESCRIPTION
In case ironic-agent.service exists on the node the assisted-installer will not reboot the node. 
Instead, it will stop the assisted-agent (agent.service) in order to let the ironic-agent know that the assisted-agent served its purpose, and let the ironic agent reboot the node