### PR TITLE
MGMT-9379: Disregard HA mode for worker.

### DIFF
--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "config_test")
+}
+
+var _ = Describe("SetInstallerArgs", func() {
+
+	It("Should not deserialize installer args when they are not supplied.", func() {
+		config := &Config{}
+		Expect(config.SetInstallerArgs("")).To(BeNil())
+		Expect(len(config.InstallerArgs)).To(BeZero())
+	})
+
+	It("Should deserialize installer args correctly when they are supplied correctly.", func() {
+		config := &Config{}
+		Expect(config.SetInstallerArgs("[\"arg1=foo\", \"arg2=bar\"]")).To(BeNil())
+		Expect(len(config.InstallerArgs)).To(Equal(2))
+		Expect(config.InstallerArgs[0]).To(Equal("arg1=foo"))
+		Expect(config.InstallerArgs[1]).To(Equal("arg2=bar"))
+	})
+
+	It("Should raise an error when supplied installer args could not be parsed.", func() {
+		config := &Config{}
+		Expect(config.SetInstallerArgs("Non JSON string!!!")).Error()
+		Expect(len(config.InstallerArgs)).To(BeZero())
+	})
+
+})
+
+var _ = Describe("SetDefaults", func() {
+
+	It("HighAvailabilityMode should be set to empty string if the host role is worker.", func() {
+		config := &Config{
+			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
+			Role:                 string(models.HostRoleWorker),
+			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
+		}
+		config.SetDefaults()
+		Expect(config.HighAvailabilityMode).To(BeEmpty())
+	})
+
+	It("HighAvailabilityMode should be unchanged if the host role is master.", func() {
+		config := &Config{
+			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
+			Role:                 string(models.HostRoleMaster),
+			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
+		}
+		config.SetDefaults()
+		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+	})
+
+	It("HighAvailabilityMode should be unchanged if the host role is bootstrap.", func() {
+		config := &Config{
+			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
+			Role:                 string(models.HostRoleBootstrap),
+			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
+		}
+		config.SetDefaults()
+		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+	})
+
+	It("InfraEnvId should be set to ClusterId if the InfraEnvId is not defined", func() {
+		config := &Config{
+			ClusterID:  "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
+			InfraEnvID: "",
+		}
+		config.SetDefaults()
+		Expect(config.InfraEnvID).To(Equal(config.ClusterID))
+	})
+
+	It("InfraEnvId should not be set to ClusterId if the InfraEnvId is defined", func() {
+		config := &Config{
+			ClusterID:  "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
+			InfraEnvID: "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8",
+		}
+		config.SetDefaults()
+		Expect(config.InfraEnvID).To(Equal("9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8"))
+	})
+})

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -119,6 +119,10 @@ func (i *installer) InstallNode() error {
 
 	i.UpdateHostInstallProgress(models.HostStageInstalling, i.Config.Role)
 	var ignitionPath string
+
+	// i.HighAvailabilityMode is set as an empty string for workers
+	// regardless of the availability mode of the cluster they are joining
+	// as it is of no consequence to them.
 	if i.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
 		i.log.Info("Installing single node openshift")
 		ignitionPath, err = i.createSingleNodeMasterIgnition()


### PR DESCRIPTION
When adding a worker to a 2nd day cluster, HA mode is irrelevant, so
we shall not be passing it here.

It used to be the case that a day 2 worker could only be added to an HA
cluster. We are making this change to allow the addition of a day 2
worker to a non HA cluster.

The condition [1] was blocking this.

That validation ensures that Day 1 SNO clusters will only accept Master
or Bootstrap roles for the host being installed.

This change will validate that the installer has not been called with
high availability mode set for a worker, if this has occurred, the
installer will reject the request with an error.

[1] https://github.com/openshift/assisted-installer/blob/d67d2843d0e757ef5643e6c873b49e61ef83a0ea/src/config/config.go#L93-L99
