### PR TITLE
NO-ISSUE: remove dependabot bumps of docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,7 @@ updates:
     labels:
       - "approved"
       - "lgtm"
-      - "ok-to-test"
       - "go"
       - "dependencies"
-    commit-message:
-      prefix: "NO-ISSUE"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
     commit-message:
       prefix: "NO-ISSUE"


### PR DESCRIPTION
Since it requires D/S changes and changes in openshift/release repo, it isn't really something that we'd like to go in automatically.

In addition, we no longer need the ok-to-test label, as dependabot is a trusted-app.