### PR TITLE
NO-ISSUE: Reverting removal of dependabot image bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "NO-ISSUE"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "NO-ISSUE"


### PR DESCRIPTION
Reverting most of https://github.com/openshift/assisted-installer/pull/457 because we would still want to have reminders for new docker images.

For more context: https://github.com/openshift/assisted-installer-agent/pull/352#issuecomment-1123333744

/cc @omertuc @eliorerz 