### PR TITLE
Bug 2086273: Cleanup disk which is part of a raid and have lvm on it

### DIFF
--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -85,7 +85,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	cleanInstallDevice := func() {
 		mockops.EXPECT().GetVGByPV(device).Return("", nil).Times(1)
-		mockops.EXPECT().IsRaidDevice(device).Return(false).Times(1)
+		mockops.EXPECT().IsRaidMember(device).Return(false).Times(1)
 		mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 	}
 
@@ -503,6 +503,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	})
 	Context("Master role", func() {
 		installerArgs := []string{"-n", "--append-karg", "nameserver=8.8.8.8"}
+		raidDevice := "/dev/md0"
 		conf := config.Config{Role: string(models.HostRoleMaster),
 			ClusterID:        "cluster-id",
 			InfraEnvID:       "infra-env-id",
@@ -539,7 +540,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVGByPV(device).Return("vg1", nil).Times(1)
 				mockops.EXPECT().RemoveVG("vg1").Return(nil).Times(1)
-				mockops.EXPECT().IsRaidDevice(device).Return(false).Times(1)
+				mockops.EXPECT().IsRaidMember(device).Return(false).Times(1)
 				mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 				mockops.EXPECT().RemovePV(device).Return(nil).Times(1)
 			}
@@ -564,8 +565,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("HostRoleMaster role raid cleanup disk - happy flow", func() {
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVGByPV(device).Return("", nil).Times(1)
-				mockops.EXPECT().IsRaidDevice(device).Return(true).Times(1)
-				mockops.EXPECT().CleanRaidDevice(device).Return(nil).Times(1)
+				mockops.EXPECT().IsRaidMember(device).Return(true).Times(1)
+				mockops.EXPECT().GetRaidDevices(device).Return([]string{raidDevice}, nil).Times(1)
+				mockops.EXPECT().GetVGByPV(raidDevice).Return("", nil).Times(1)
+				mockops.EXPECT().CleanRaidMembership(device).Return(nil).Times(1)
 				mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 			}
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})
@@ -580,8 +583,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVGByPV(device).Return("", nil).Times(1)
-				mockops.EXPECT().IsRaidDevice(device).Return(true).Times(1)
-				mockops.EXPECT().CleanRaidDevice(device).Return(err).Times(1)
+				mockops.EXPECT().IsRaidMember(device).Return(true).Times(1)
+				mockops.EXPECT().GetRaidDevices(device).Return([]string{raidDevice}, nil).Times(1)
+				mockops.EXPECT().GetVGByPV(raidDevice).Return("", nil).Times(1)
+				mockops.EXPECT().CleanRaidMembership(device).Return(err).Times(1)
 			}
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})
 			cleanInstallDeviceClean()

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -249,32 +249,47 @@ func (mr *MockOpsMockRecorder) Wipefs(device interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wipefs", reflect.TypeOf((*MockOps)(nil).Wipefs), device)
 }
 
-// IsRaidDevice mocks base method
-func (m *MockOps) IsRaidDevice(device string) bool {
+// IsRaidMember mocks base method
+func (m *MockOps) IsRaidMember(device string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRaidDevice", device)
+	ret := m.ctrl.Call(m, "IsRaidMember", device)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsRaidDevice indicates an expected call of IsRaidDevice
-func (mr *MockOpsMockRecorder) IsRaidDevice(device interface{}) *gomock.Call {
+// IsRaidMember indicates an expected call of IsRaidMember
+func (mr *MockOpsMockRecorder) IsRaidMember(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRaidDevice", reflect.TypeOf((*MockOps)(nil).IsRaidDevice), device)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRaidMember", reflect.TypeOf((*MockOps)(nil).IsRaidMember), device)
 }
 
-// CleanRaidDevice mocks base method
-func (m *MockOps) CleanRaidDevice(device string) error {
+// GetRaidDevices mocks base method
+func (m *MockOps) GetRaidDevices(device string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanRaidDevice", device)
+	ret := m.ctrl.Call(m, "GetRaidDevices", device)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRaidDevices indicates an expected call of GetRaidDevices
+func (mr *MockOpsMockRecorder) GetRaidDevices(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRaidDevices", reflect.TypeOf((*MockOps)(nil).GetRaidDevices), device)
+}
+
+// CleanRaidMembership mocks base method
+func (m *MockOps) CleanRaidMembership(device string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanRaidMembership", device)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CleanRaidDevice indicates an expected call of CleanRaidDevice
-func (mr *MockOpsMockRecorder) CleanRaidDevice(device interface{}) *gomock.Call {
+// CleanRaidMembership indicates an expected call of CleanRaidMembership
+func (mr *MockOpsMockRecorder) CleanRaidMembership(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRaidDevice", reflect.TypeOf((*MockOps)(nil).CleanRaidDevice), device)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRaidMembership", reflect.TypeOf((*MockOps)(nil).CleanRaidMembership), device)
 }
 
 // GetMCSLogs mocks base method


### PR DESCRIPTION
Cleanup Raid PVs and VGs before stopping it and removing the installation disk membership.
Solving "mdadm: Cannot get exclusive access to /dev/md0" When trying to stop a raid with LVM on it.