### PR TITLE
MGMT-10348: backofflimit in assisted controller is set in a wrong place and does nothing

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -4,6 +4,7 @@ metadata:
   name: assisted-installer-controller
   namespace: assisted-installer
 spec:
+  backoffLimit: 100
   template:
     metadata:
       labels:
@@ -73,7 +74,6 @@ spec:
             mountPath: {{.CACertPath}}
           {{end}}
       restartPolicy: OnFailure
-      backoffLimit: 100
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
[MGMT-10348](https://issues.redhat.com//browse/MGMT-10348): backofflimit in assisted controller is set in a wrong place and does nothing