### PR TITLE
MGMT-10330: Do not restart network manager on single node clusters

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -306,10 +306,14 @@ func (i *installer) startBootstrap() error {
 	}
 
 	// restart NetworkManager to trigger NetworkManager/dispatcher.d/30-local-dns-prepender
-	err = i.ops.SystemctlAction("restart", "NetworkManager.service")
-	if err != nil {
-		i.log.Error(err)
-		return err
+	// we don't do it on SNO because the "local-dns-prepender" is not even
+	// available on none-platform
+	if i.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone {
+		err = i.ops.SystemctlAction("restart", "NetworkManager.service")
+		if err != nil {
+			i.log.Error(err)
+			return err
+		}
 	}
 
 	if err = i.ops.PrepareController(); err != nil {

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -784,9 +784,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().CreateRandomHostname(gomock.Any()).Return(nil).Times(1)
 			}
 		}
-		restartNetworkManager := func(err error) {
-			mockops.EXPECT().SystemctlAction("restart", "NetworkManager.service").Return(err).Times(1)
-		}
 		startServicesSuccess := func() {
 			services := []string{"bootkube.service", "progress.service", "approve-csr.service"}
 			for i := range services {
@@ -828,7 +825,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			// single node bootstrap flow
 			singleNodeBootstrapSetup()
 			checkLocalHostname("localhost", nil)
-			restartNetworkManager(nil)
 			prepareControllerSuccess()
 			startServicesSuccess()
 			waitForBootkubeSuccess()
@@ -852,9 +848,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			})
 			// single node bootstrap flow
 			singleNodeBootstrapSetup()
-			checkLocalHostname("not localhost", nil)
 			err := fmt.Errorf("Failed to restart NetworkManager")
-			restartNetworkManager(err)
+			checkLocalHostname("not localhost", err)
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(err))
 		})
@@ -865,7 +860,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			// single node bootstrap flow
 			singleNodeBootstrapSetup()
 			checkLocalHostname("localhost", nil)
-			restartNetworkManager(nil)
 			prepareControllerSuccess()
 			startServicesSuccess()
 			waitForBootkubeSuccess()


### PR DESCRIPTION
The comment above the restart call states:
`restart NetworkManager to trigger NetworkManager/dispatcher.d/30-local-dns-prepender`

In SNO, this script does not exist since SNO is none-platform and that
script is only created by the installer in other platforms.

Since this script doesn't exist on SNO, there's no point in restarting
NetworkManager on SNO to trigger it to run.

The reason we avoid the restart is because we have a suspicion it might
be related to a bug we observe with SNO that we can't really explain:

https://issues.redhat.com/browse/MGMT-10330

/cc @tsorya