### PR TITLE
MGMT-9379: Fix arguments to make sure that HighAvailabilityMode is updated correctly to ensure it is unset for workers.

### DIFF
--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -13,21 +13,62 @@ func TestConfig(t *testing.T) {
 	RunSpecs(t, "config_test")
 }
 
-var _ = Describe("SetInstallerArgs", func() {
+var _ = Describe("ProcessArgs", func() {
 
 	It("Should not deserialize installer args when they are not supplied.", func() {
 		config := &Config{}
-		Expect(config.SetInstallerArgs("")).To(BeNil())
+		arguments := []string{"--role", "worker", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8"}
+		config.ProcessArgs(arguments)
 		Expect(len(config.InstallerArgs)).To(BeZero())
 	})
 
 	It("Should deserialize installer args correctly when they are supplied correctly.", func() {
 		config := &Config{}
-		Expect(config.SetInstallerArgs("[\"arg1=foo\", \"arg2=bar\"]")).To(BeNil())
+		arguments := []string{"--role", "worker", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--installer-args", "[\"arg1=foo\", \"arg2=bar\"]"}
+		config.ProcessArgs(arguments)
 		Expect(len(config.InstallerArgs)).To(Equal(2))
 		Expect(config.InstallerArgs[0]).To(Equal("arg1=foo"))
 		Expect(config.InstallerArgs[1]).To(Equal("arg2=bar"))
 	})
+
+	It("HighAvailabilityMode should be set to empty string if the host role is worker.", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleWorker), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		config.ProcessArgs(arguments)
+		Expect(config.HighAvailabilityMode).To(BeEmpty())
+	})
+
+	It("HighAvailabilityMode should be unchanged if the host role is master.", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleMaster), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		config.ProcessArgs(arguments)
+		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+	})
+
+	It("HighAvailabilityMode should be unchanged if the host role is bootstrap.", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		config.ProcessArgs(arguments)
+		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+	})
+
+	It("InfraEnvId should be set to ClusterId if the InfraEnvId is not defined", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		config.ProcessArgs(arguments)
+		Expect(config.InfraEnvID).To(Equal(config.ClusterID))
+	})
+
+	It("InfraEnvId should not be set to ClusterId if the InfraEnvId is defined", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--infra-env-id", "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		config.ProcessArgs(arguments)
+		Expect(config.InfraEnvID).To(Equal("9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8"))
+	})
+
+})
+
+var _ = Describe("SetInstallerArgs", func() {
 
 	It("Should raise an error when supplied installer args could not be parsed.", func() {
 		config := &Config{}
@@ -35,55 +76,4 @@ var _ = Describe("SetInstallerArgs", func() {
 		Expect(len(config.InstallerArgs)).To(BeZero())
 	})
 
-})
-
-var _ = Describe("SetDefaults", func() {
-
-	It("HighAvailabilityMode should be set to empty string if the host role is worker.", func() {
-		config := &Config{
-			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
-			Role:                 string(models.HostRoleWorker),
-			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
-		}
-		config.SetDefaults()
-		Expect(config.HighAvailabilityMode).To(BeEmpty())
-	})
-
-	It("HighAvailabilityMode should be unchanged if the host role is master.", func() {
-		config := &Config{
-			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
-			Role:                 string(models.HostRoleMaster),
-			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
-		}
-		config.SetDefaults()
-		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
-	})
-
-	It("HighAvailabilityMode should be unchanged if the host role is bootstrap.", func() {
-		config := &Config{
-			ClusterID:            "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
-			Role:                 string(models.HostRoleBootstrap),
-			HighAvailabilityMode: models.ClusterHighAvailabilityModeFull,
-		}
-		config.SetDefaults()
-		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
-	})
-
-	It("InfraEnvId should be set to ClusterId if the InfraEnvId is not defined", func() {
-		config := &Config{
-			ClusterID:  "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
-			InfraEnvID: "",
-		}
-		config.SetDefaults()
-		Expect(config.InfraEnvID).To(Equal(config.ClusterID))
-	})
-
-	It("InfraEnvId should not be set to ClusterId if the InfraEnvId is defined", func() {
-		config := &Config{
-			ClusterID:  "0ae63135-5f7c-431e-9c72-0efaf2cb83b8",
-			InfraEnvID: "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8",
-		}
-		config.SetDefaults()
-		Expect(config.InfraEnvID).To(Equal("9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8"))
-	})
 })

--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -2,11 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"flag"
-	"fmt"
 	"os"
-
-	"github.com/kelseyhightower/envconfig"
 )
 
 // DryRunConfig defines configuration of the agent's dry-run mode
@@ -58,25 +54,4 @@ func DryParseClusterHosts(clusterHostsJsonPath string, parsedClusterHosts *DryCl
 	}
 
 	return nil
-}
-
-func ProcessDryRunArgs(dryRunConfig *DryRunConfig) {
-	err := envconfig.Process("dryconfig", &DefaultDryRunConfig)
-	if err != nil {
-		fmt.Printf("envconfig error: %v", err)
-		os.Exit(1)
-	}
-
-	flag.BoolVar(&dryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
-	flag.StringVar(&dryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
-	flag.StringVar(&dryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
-	flag.StringVar(&dryRunConfig.DryRunClusterHostsPath, "dry-run-cluster-hosts-path", DefaultDryRunConfig.DryRunClusterHostsPath, "A path to a JSON file with information about hosts in the cluster")
-	flag.Parse()
-
-	if dryRunConfig.DryRunEnabled {
-		if parseErr := DryParseClusterHosts(dryRunConfig.DryRunClusterHostsPath, &dryRunConfig.ParsedClusterHosts); parseErr != nil {
-			fmt.Printf("Error parsing cluster hosts: %v", parseErr)
-			os.Exit(1)
-		}
-	}
 }

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 func main() {
-	installerConfig := config.ProcessArgs()
-	config.ProcessDryRunArgs(&installerConfig.DryRunConfig)
+	installerConfig := &config.Config{}
+	installerConfig.ProcessArgs(os.Args[1:])
 	logger := utils.InitLogger(installerConfig.Verbose, true, installerConfig.ForcedHostID, config.DefaultDryRunConfig.DryRunEnabled)
 	installerConfig.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
 	if installerConfig.PullSecretToken == "" {


### PR DESCRIPTION
After merging [MGMT-9379](https://issues.redhat.com//browse/MGMT-9379) it was found that the parameter changes that we
applied to HighAvailabilityMode were ineffective in the installer.

After tracking down the root cause, the problem was that the command
line arguments were being parsed twice, once for the main arguments and
once again for the "dry run arguments". On the second parse, the changes
we made to the first parse were overwritten, rendering them ineffective.

This PR fixes that by merging together the code that performs the parse
on main parameters and dry run arguments.

I also removed the static way of parsing arguments and replaced it with
a more "instance based" approach, this is cleaner, causes less confusion
and is also more testable as we can pass an args array to it.

As a result, we can now test the whole method ProcessArgs(..) and I have
added tests to ensure that specific command line parameters achieve the
desired effect.