### PR TITLE
Bug 2055978: host fail to boot from installation disk in case of multiple active "Red Hat Enterprise Linux" boot entries

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -312,12 +312,32 @@ func (o *ops) SetBootOrder(device string) error {
 	o.log.Info("Setting efibootmgr to boot from disk")
 
 	// efi-system is installed onto partition 2
-	_, err = o.ExecPrivilegeCommand(o.logWriter, "efibootmgr", "-v", "-d", device, "-p", "2", "-c", "-L", "Red Hat Enterprise Linux", "-l", o.getEfiFilePath())
+	out, err := o.ExecPrivilegeCommand(o.logWriter, "efibootmgr", "-v", "-d", device, "-p", "2", "-c", "-L", "Red Hat Enterprise Linux", "-l", o.getEfiFilePath())
 	if err != nil {
 		o.log.Errorf("Failed to set efibootmgr to boot from disk %s, err: %s", device, err)
 		return err
 	}
+	o.handleDuplicateEntries(out)
 	return nil
+}
+
+func (o *ops) handleDuplicateEntries(output string) {
+	r := regexp.MustCompile(`Boot(.*) has same label Red Hat Enterprise Linux`)
+	for _, line := range strings.Split(output, "\n") {
+		DupBootEntry := r.FindStringSubmatch(line)
+		if len(DupBootEntry) > 0 {
+			o.log.Infof("Found duplicate value in boot manager: %s", line)
+			o.deleteBootEntry(DupBootEntry[len(DupBootEntry)-1])
+		}
+	}
+}
+
+func (o *ops) deleteBootEntry(bootNum string) {
+	o.log.Infof("Removing boot entry number %s", bootNum)
+	_, err := o.ExecPrivilegeCommand(o.logWriter, "efibootmgr", "-v", "--delete-bootnum", "--bootnum", bootNum, "-l", o.getEfiFilePath())
+	if err != nil {
+		o.log.Errorf("Failed to delete duplicate Red Hat Enterprise Linux label %s, err: %s", bootNum, err)
+	}
 }
 
 func (o *ops) getEfiFilePath() string {


### PR DESCRIPTION
Bug 2055978: host fail to boot from installation disk in case of multiple active "Red Hat Enterprise Linux" boot entries
Removing duplicate efi boot entries

