### PR TITLE
MGMT-10450: Timeout writing to disk reported from bootstrap node when failing to start bootkube

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -43,6 +43,8 @@ const (
 	ovnKubernetes                = "OVNKubernetes"
 	numMasterNodes               = 3
 	singleNodeMasterIgnitionPath = "/opt/openshift/master.ign"
+	waitingForMastersStatusInfo  = "Waiting for masters to join bootstrap control plane"
+	waitingForBootstrapToPrepare = "Waiting for bootstrap node preparation"
 )
 
 var generalWaitTimeout = 30 * time.Second
@@ -146,6 +148,7 @@ func (i *installer) InstallNode() error {
 	}
 
 	if isBootstrap {
+		i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, waitingForBootstrapToPrepare)
 		if err = bootstrapErrGroup.Wait(); err != nil {
 			i.log.Errorf("Bootstrap failed %s", err)
 			return err
@@ -413,7 +416,7 @@ func (i *installer) waitForControlPlane(ctx context.Context) error {
 		i.log.Error(err)
 		return err
 	}
-	i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, "")
+	i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, waitingForMastersStatusInfo)
 
 	if err = i.waitForMinMasterNodes(ctx, kc); err != nil {
 		return err

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -265,7 +265,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				})
 				It("bootstrap role happy flow", func() {
 					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
-						{string(models.HostStageWaitingForControlPlane)},
+						{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
+						{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
 						{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 						{string(models.HostStageWritingImageToDisk)},
 						{string(models.HostStageRebooting)},
@@ -296,7 +297,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				})
 				It("bootstrap role happy flow ovn-kubernetes", func() {
 					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
-						{string(models.HostStageWaitingForControlPlane)},
+						{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
+						{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
 						{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 						{string(models.HostStageWritingImageToDisk)},
 						{string(models.HostStageRebooting)},
@@ -334,6 +336,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk)},
+				{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 			})
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
@@ -353,7 +356,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("bootstrap role extract ignition retry", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
-				{string(models.HostStageWaitingForControlPlane)},
+				{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
+				{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageRebooting)},
@@ -384,6 +388,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk)},
+				{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 			})
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)
@@ -404,6 +409,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk)},
+				{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 			})
 			bootstrapSetup()
 			checkLocalHostname("not localhost", nil)


### PR DESCRIPTION
[MGMT-10450](https://issues.redhat.com//browse/MGMT-10450): Timeout writing to disk reported from bootstrap node when failing to start bootkube

After writing to disk we will update status to waiting for control plane
with info relevant to the state