### PR TITLE
AGENT-75: Add assisted installer images into OCP playload for Agent Work

### DIFF
--- a/Dockerfile.assisted-installer-controller.ocp
+++ b/Dockerfile.assisted-installer-controller.ocp
@@ -10,6 +10,8 @@ RUN make controller
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 
+LABEL io.openshift.release.operator=true
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 

--- a/Dockerfile.assisted-installer.ocp
+++ b/Dockerfile.assisted-installer.ocp
@@ -9,6 +9,8 @@ RUN make installer
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 
+LABEL io.openshift.release.operator=true
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy
 


### PR DESCRIPTION
Once the images are building successfully in OSBS (and only then), they can be added to the release payload image by setting a label in the Dockerfile:

`LABEL io.openshift.release.operator=true`