### PR TITLE
NO-ISSUE: add stage info in case converged flow is enabled

### DIFF
--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -629,7 +629,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), conf.Role},
 				{string(models.HostStageWritingImageToDisk)},
-				{string(models.HostStageRebooting)},
+				{string(models.HostStageRebooting), "Ironic will reboot the node shortly"},
 			})
 			cleanInstallDevice()
 			mkdirSuccess(InstallDir)


### PR DESCRIPTION
This should allow us to know if the assisted installer triggred the reboot or not