### PR TITLE
MGMT-11100: Add router get router status logic in case of sno failure

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
@@ -99,6 +99,7 @@ rules:
       - operator.openshift.io
     resources:
       - etcds
+      - ingresscontrollers
     verbs:
       - patch
   - apiGroups:

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -49,6 +49,7 @@ type K8SClient interface {
 	ListMasterNodes() (*v1.NodeList, error)
 	PatchEtcd() error
 	UnPatchEtcd() error
+	EnableRouterAccessLogs() error
 	PatchControlPlaneReplicas() error
 	UnPatchControlPlaneReplicas() error
 	ListNodes() (*v1.NodeList, error)
@@ -221,6 +222,18 @@ func (c *k8sClient) UnPatchEtcd() error {
 	result, err := c.ocClient.OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, data, metav1.PatchOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to unpatch etcd")
+	}
+	c.log.Info(result)
+	return nil
+}
+
+func (c *k8sClient) EnableRouterAccessLogs() error {
+	c.log.Info("Enabling router logs")
+	data := []byte(`{"spec":{"logging":{"access":{"destination":{"type":"Container"}}}}}`)
+	result, err := c.ocClient.OperatorV1().IngressControllers("openshift-ingress-operator").Patch(context.Background(),
+		"default", types.MergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Failed to patch router")
 	}
 	c.log.Info(result)
 	return nil

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -84,6 +84,20 @@ func (mr *MockK8SClientMockRecorder) UnPatchEtcd() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnPatchEtcd", reflect.TypeOf((*MockK8SClient)(nil).UnPatchEtcd))
 }
 
+// EnableRouterAccessLogs mocks base method
+func (m *MockK8SClient) EnableRouterAccessLogs() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableRouterAccessLogs")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableRouterAccessLogs indicates an expected call of EnableRouterAccessLogs
+func (mr *MockK8SClientMockRecorder) EnableRouterAccessLogs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableRouterAccessLogs", reflect.TypeOf((*MockK8SClient)(nil).EnableRouterAccessLogs))
+}
+
 // PatchControlPlaneReplicas mocks base method
 func (m *MockK8SClient) PatchControlPlaneReplicas() error {
 	m.ctrl.T.Helper()

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -310,3 +310,19 @@ func ClusterOperatorConditionsToMonitoredOperatorStatus(conditions []configv1.Cl
 
 	return models.OperatorStatusProgressing, ""
 }
+
+// Get preferred outbound ip of this machine
+func GetOutboundIP() (string, error) {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr()
+	if localAddr == nil {
+		return "", fmt.Errorf("no address was found")
+	}
+
+	return localAddr.(*net.UDPAddr).IP.String(), nil
+}


### PR DESCRIPTION
    MGMT-11100: Adding get router status logic in case of sno failure.
    Currently we have known issue in sno flow where router healthcheck fails
    from pods network. This pr add verification that router is reachable
    from host network and enables router access log.
    This change is temporary till we will not find an issue we encountered