### PR TITLE
Bug Fix: Add additionalTrustBundle defined CA Certificates from RHCOS CA Trust as a default

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -84,7 +84,7 @@ type ControllerConfig struct {
 	URL                     string `envconfig:"INVENTORY_URL" required:"true"`
 	PullSecretToken         string `envconfig:"PULL_SECRET_TOKEN" required:"true" secret:"true"`
 	SkipCertVerification    bool   `envconfig:"SKIP_CERT_VERIFICATION" required:"false" default:"false"`
-	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"`
+	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:""`
 	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
 	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
 	HighAvailabilityMode    string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -84,7 +84,7 @@ type ControllerConfig struct {
 	URL                     string `envconfig:"INVENTORY_URL" required:"true"`
 	PullSecretToken         string `envconfig:"PULL_SECRET_TOKEN" required:"true" secret:"true"`
 	SkipCertVerification    bool   `envconfig:"SKIP_CERT_VERIFICATION" required:"false" default:"false"`
-	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:""`
+	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"`
 	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
 	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
 	HighAvailabilityMode    string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -65,7 +65,7 @@ func (c *Config) ProcessArgs(args []string) {
 	flagSet.StringVar(&c.AgentImage, "agent-image", "quay.io/ocpmetal/assisted-installer-agent:latest",
 		"Assisted Installer Agent image URL that will be used to send logs on successful installation")
 	flagSet.BoolVar(&c.SkipCertVerification, "insecure", false, "Do not validate TLS certificate")
-	flagSet.StringVar(&c.CACertPath, "cacert", "", "Path to custom CA certificate in PEM format")
+	flagSet.StringVar(&c.CACertPath, "cacert", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", "Path to custom CA certificate in PEM format")
 	flagSet.StringVar(&c.HTTPProxy, "http-proxy", "", "A proxy URL to use for creating HTTP connections outside the cluster")
 	flagSet.StringVar(&c.HTTPSProxy, "https-proxy", "", "A proxy URL to use for creating HTTPS connections outside the cluster")
 	flagSet.StringVar(&c.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")


### PR DESCRIPTION
Addresses Issue #513 

When additionalTrustBundle Root CA certificates are added to the RHCOS trusted store the assisted-installer-controller Job Pod needs to have them mounted - add the default `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` for CACertPath.