### PR TITLE
MGMT-10085: Get real filepath of RAID device

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -510,7 +510,12 @@ func (o *ops) getRaidDevices2Members() (map[string][]string, error) {
 		}
 
 		fields := strings.Fields(lines[i])
-		raidDeviceName := fields[1]
+		// In case of symlink, get real file path
+		raidDeviceName, err := filepath.EvalSymlinks(fields[1])
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to evaluate raid symlink")
+		}
+
 		i++
 
 		// Ensuring that we have at least two lines per device.


### PR DESCRIPTION
When having LVM on top of software raid, the name of the device reported by mdadm is a symlink to the real block device in /dev, causing problems identifying which LVM volume groups need to be removed before cleaning the RAID

This should fix that issue