### PR TITLE
[release-ocm-2.5] MGMT-11365: fix flaky installation of golangci-lint (#510)

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.17
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
+COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN yum install -y docker && \
     yum clean all
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -236,7 +236,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).Times(1)
 		mockbmclient.EXPECT().DownloadFile(gomock.Any(), customManifestsFile, gomock.Any()).DoAndReturn(
 			func(ctx context.Context, filename, dest string) error {
-				if err := ioutil.WriteFile(dest, []byte("[]"), 0644); err != nil {
+				if err := ioutil.WriteFile(dest, []byte("[]"), 0600); err != nil {
 					return err
 				}
 				return nil

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -810,6 +810,7 @@ func (o *ops) CreateManifests(kubeconfig string, content []byte) error {
 	defer os.Remove(file.Name())
 
 	// Write the content to the temporary file:
+	// #nosec
 	if err = ioutil.WriteFile(file.Name(), content, 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backports https://github.com/openshift/assisted-installer/pull/510.