### PR TITLE
MGMT-11348: Changes for upstream multi-arch support

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer
 
@@ -9,7 +10,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN make installer
+RUN TARGETPLATFORM=$TARGETPLATFORM make installer
 
 FROM quay.io/centos/centos:stream8
 
@@ -17,3 +18,4 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/instal
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy
 
 ENTRYPOINT ["/usr/bin/installer"]
+

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,6 +1,10 @@
-FROM quay.io/openshift/origin-cli:4.11.0 AS cli
+FROM quay.io/openshift/origin-cli-artifacts:latest as cli-artifacts
+ARG TARGETPLATFORM
+RUN mkdir -p /usr/share/openshift/assisted
+RUN case $TARGETPLATFORM in "") dir=linux_amd64;; *) dir=`echo $TARGETPLATFORM | sed 's@/@_@'` ;; esac ;  ln /usr/share/openshift/${dir}/oc /usr/share/openshift/assisted
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer
 
@@ -11,12 +15,12 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN make controller
+RUN TARGETPLATFORM=$TARGETPLATFORM make controller
 
 FROM quay.io/centos/centos:stream8
 
 RUN yum -y install make gcc unzip wget curl rsync && yum clean all
+COPY --from=cli-artifacts /usr/share/openshift/assisted/oc /usr/bin/oc
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller
-COPY --from=cli /usr/bin/oc /usr/bin/oc
 
 ENTRYPOINT ["/usr/bin/assisted-installer-controller"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ TEST_FORMAT ?= standard-verbose
 GOTEST_FLAGS = --format=$(TEST_FORMAT) -- -count=1 -cover -coverprofile=$(REPORTS)/$(TEST_SCENARIO)_coverage.out
 GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo.reportFile=./junit_$(TEST_SCENARIO)_test.xml
 
+# Multiarch support.  Transform argument passed from docker buidx tool to go build arguments to support cross compiling
+GO_BUILD_ARCHITECTURE_VARS := $(if ${TARGETPLATFORM},$(shell echo ${TARGETPLATFORM} | awk -F / '{printf("GOOS=%s GOARCH=%s", $$1, $$2)}'),)
+GO_BUILD_VARS := CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
+
 all: lint format-check build-images unit-test
 
 ci-lint: vendor-diff
@@ -58,10 +62,10 @@ endif
 build: installer controller
 
 installer:
-	CGO_ENABLED=0 go build -o build/installer src/main/main.go
+	$(GO_BUILD_VARS) go build -o build/installer src/main/main.go
 
 controller:
-	CGO_ENABLED=0 go build -o build/assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
+	$(GO_BUILD_VARS) go build -o build/assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
 
 build-images: installer-image controller-image
 


### PR DESCRIPTION
Let Dockerfile and Makefile respond to TARGETPLATFORM setting which is
set by docker buildx when building multi-arch images.

/cc @tsorya 