### PR TITLE
MGMT-12050: Pinning golang.org/x/sys dependency due to golang incompatibility

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -10,4 +10,5 @@ RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c84
               github.com/golang/mock/mockgen@v1.4.3  \
               gotest.tools/gotestsum@v0.5.3 \
               github.com/axw/gocov/gocov \
+              golang.org/x/sys@v0.0.0-20220908164124-27713097b956 \
               github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737


### PR DESCRIPTION
2.4 jobs in assisted-installer are failing to build docker images with
the following error:

```
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/syscall.go:83:7: undefined: unsafe.Slice
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
note: module requires Go 1.17
```

References:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-installer-release-ocm-2.4-mirror-nightly-image/1569893960787169280

Same issue as in https://github.com/openshift/assisted-installer-agent/pull/434
