### PR TITLE
MGMT-12057: Remove enablement of router access logs in controller, not needed anymore

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -1094,7 +1094,6 @@ func (c controller) logRouterStatus() {
 	c.log.Infof("Start checking router status")
 	var cl *models.Cluster
 	var err error
-	patched := false
 	//nolint:gosec // need insecure TLS option for testing and development
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -1122,7 +1121,7 @@ func (c controller) logRouterStatus() {
 			if err != nil {
 				c.log.WithError(err).Warning("Failed to reach console")
 			} else {
-				c.log.Infof("console url status %s", r.Status)
+				c.log.Infof("canary url status %s", r.Status)
 			}
 
 			url := fmt.Sprintf("http://%s/_______internal_router_healthz", localIp)
@@ -1131,17 +1130,6 @@ func (c controller) logRouterStatus() {
 				c.log.WithError(err).Warning("Failed to reach internal router health")
 			} else {
 				c.log.Infof("route internal health status %s", r.Status)
-			}
-
-			if !patched {
-
-				c.log.Infof("Enabling router access logs, router call can fail after it")
-				err = c.kc.EnableRouterAccessLogs()
-				if err != nil {
-					c.log.WithError(err).Errorf("Failed to enable router logs")
-				} else {
-					patched = true
-				}
 			}
 			return false
 		})

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -1222,7 +1222,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			successUpload()
 			logClusterOperatorsSuccess()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(0).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
-			mockk8sclient.EXPECT().EnableRouterAccessLogs().Times(0).Return(nil)
 			callUploadLogs(50 * time.Millisecond)
 		})
 		It("Validate upload logs not blocked by router validation failure (with must-gather logs)", func() {
@@ -1239,7 +1238,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			assistedController.HighAvailabilityMode = models.ClusterHighAvailabilityModeNone
 			successUpload()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(1).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
-			mockk8sclient.EXPECT().EnableRouterAccessLogs().Times(1).Return(nil)
 			logClusterOperatorsSuccess()
 			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
 			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -50,7 +50,6 @@ type K8SClient interface {
 	ListMasterNodes() (*v1.NodeList, error)
 	PatchEtcd() error
 	UnPatchEtcd() error
-	EnableRouterAccessLogs() error
 	PatchControlPlaneReplicas() error
 	UnPatchControlPlaneReplicas() error
 	ListNodes() (*v1.NodeList, error)
@@ -240,18 +239,6 @@ func (c *k8sClient) UnPatchEtcd() error {
 	result, err := c.ocClient.OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, data, metav1.PatchOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to unpatch etcd")
-	}
-	c.log.Info(result)
-	return nil
-}
-
-func (c *k8sClient) EnableRouterAccessLogs() error {
-	c.log.Info("Enabling router logs")
-	data := []byte(`{"spec":{"logging":{"access":{"destination":{"type":"Container"}}}}}`)
-	result, err := c.ocClient.OperatorV1().IngressControllers("openshift-ingress-operator").Patch(context.Background(),
-		"default", types.MergePatchType, data, metav1.PatchOptions{})
-	if err != nil {
-		return errors.Wrap(err, "Failed to patch router")
 	}
 	c.log.Info(result)
 	return nil

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -86,20 +86,6 @@ func (mr *MockK8SClientMockRecorder) UnPatchEtcd() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnPatchEtcd", reflect.TypeOf((*MockK8SClient)(nil).UnPatchEtcd))
 }
 
-// EnableRouterAccessLogs mocks base method
-func (m *MockK8SClient) EnableRouterAccessLogs() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableRouterAccessLogs")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnableRouterAccessLogs indicates an expected call of EnableRouterAccessLogs
-func (mr *MockK8SClientMockRecorder) EnableRouterAccessLogs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableRouterAccessLogs", reflect.TypeOf((*MockK8SClient)(nil).EnableRouterAccessLogs))
-}
-
 // PatchControlPlaneReplicas mocks base method
 func (m *MockK8SClient) PatchControlPlaneReplicas() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
[MGMT-12057](https://issues.redhat.com//browse/MGMT-12057): Remove enablement of router access logs in controller, not needed anymore