### PR TITLE
MGMT-12070: Assisted controller should not set status done on host more than once

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -251,7 +251,7 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 			}
 		}
 
-		if common.IsK8sNodeIsReady(node) {
+		if common.IsK8sNodeIsReady(node) && host.Host.Progress.CurrentStage != models.HostStageDone {
 			log.Infof("Found new ready node %s with inventory id %s, kubernetes id %s, updating its status to %s",
 				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageDone)
 			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageDone, ""); err != nil {

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -337,6 +337,19 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			exit := assistedController.waitAndUpdateNodesStatus()
 			Expect(exit).Should(Equal(false))
 		})
+		It("waitAndUpdateNodesStatus don't update progress for hosts in stage done", func() {
+
+			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageDone, "")
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+				Return(hosts, nil).Times(2)
+			nodes := GetKubeNodes(kubeNamesIds)
+			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
+			configuringSuccess()
+
+			exit := assistedController.waitAndUpdateNodesStatus()
+			Expect(exit).Should(Equal(false))
+
+		})
 
 		It("2aitAndUpdateNodesStatus getHost failure", func() {
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).


### PR DESCRIPTION
[MGMT-12070](https://issues.redhat.com//browse/MGMT-12070): Assisted controller should not set status done on host more than once #543
