### PR TITLE
MGMT-12115: assisted-installer-controller Job does not apply Addition…

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -68,8 +68,11 @@ spec:
                   name: assisted-installer-controller-config
                   key: must-gather-image
                   optional: true
-          {{if .CACertPath}}
+
           volumeMounts:
+           - name: host-ca-bundle
+             mountPath: /etc/pki
+          {{if .CACertPath}}
           - name: service-ca-cert-config
             mountPath: {{.CACertPath}}
           {{end}}
@@ -82,9 +85,12 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
         operator: Exists
-      {{if .CACertPath}}
       volumes:
-      - name: service-ca-cert-config
-        hostPath:
-          path: {{.CACertPath}}
-      {{end}}
+        - name: host-ca-bundle
+          hostPath:
+            path: /etc/pki
+        {{if .CACertPath}}
+        - name: service-ca-cert-config
+          hostPath:
+            path: {{.CACertPath}}
+        {{end}}


### PR DESCRIPTION
[MGMT-12115](https://issues.redhat.com//browse/MGMT-12115): assisted-installer-controller Job does not apply Additional Root CA Trust Bundle

Changing to mount all /etc/pki folder from host to controller in order to use same certificates as host has.