### PR TITLE
OCPBUGS-3166: assisted-installer: pod creation fails due to violations of security policies in 4.12

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-nm.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-nm.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: assisted-installer
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"


### PR DESCRIPTION
OCPBUGS-3166: assisted-installer: pod creation fails due to violations of security policies in 4.12

Adding privileged labels to namespace