### PR TITLE
change all 'go get' commands to 'go install'

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -5,9 +5,9 @@ ENV GOFLAGS=""
 COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN yum install -y docker && \
     yum clean all
-RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
-              github.com/onsi/ginkgo/ginkgo@v1.12.2  \
-              github.com/golang/mock/mockgen@v1.4.3  \
-              gotest.tools/gotestsum@v0.5.3 \
-              github.com/axw/gocov/gocov \
-              github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
+RUN go install golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
+    && go install github.com/onsi/ginkgo/ginkgo@v1.12.2 \
+    && go install github.com/golang/mock/mockgen@v1.4.3 \
+    && go install gotest.tools/gotestsum@v1.6.3 \
+    && go install github.com/axw/gocov/gocov@latest \
+    && go install github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737


### PR DESCRIPTION
``go get`` might result in ``go.mod`` changes meaning we might use different dependencies versions than intended.
In addition, this kind of usage of ``go get`` is deprecated in go 1.17 and is blocked in go version >= 1.19.