### PR TITLE
OCPBUGSM-46219: OCPBUGSM-46220: Update golang version to 1.18.1.

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,13 +1,14 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN yum install -y docker && \
     yum clean all
-RUN go install golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
-    && go install github.com/onsi/ginkgo/ginkgo@v1.12.2 \
-    && go install github.com/golang/mock/mockgen@v1.4.3 \
-    && go install gotest.tools/gotestsum@v1.6.3 \
-    && go install github.com/axw/gocov/gocov@latest \
-    && go install github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
+
+RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
+    go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
+    go install github.com/golang/mock/mockgen@v1.6.0 && \
+    go install gotest.tools/gotestsum@v1.6.3 && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -3,7 +3,7 @@ ARG TARGETPLATFORM
 RUN mkdir -p /usr/share/openshift/assisted
 RUN case $TARGETPLATFORM in "") dir=linux_amd64;; *) dir=`echo $TARGETPLATFORM | sed 's@/@_@'` ;; esac ;  ln /usr/share/openshift/${dir}/oc /usr/share/openshift/assisted
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/assisted-installer
 
-go 1.17
+go 1.18
 
 require (
 	github.com/PuerkitoBio/rehttp v1.1.0

--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -274,7 +274,7 @@ func (handler ClusterServiceVersionHandler) OnChange(newStatus models.OperatorSt
 		if handler.retries < failedOperatorRetry {
 			// FIXME: We retry the check of the operator status in case it's in failed state to WA bug 1968606
 			// Remove this code when bug 1968606 is fixed
-			handler.retries++
+			handler.retries++ //nolint:staticcheck
 			return false
 		}
 		handler.status.OperatorError(handler.operator.Name)

--- a/src/ignition/mock_ignition.go
+++ b/src/ignition/mock_ignition.go
@@ -11,59 +11,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockIgnition is a mock of Ignition interface
+// MockIgnition is a mock of Ignition interface.
 type MockIgnition struct {
 	ctrl     *gomock.Controller
 	recorder *MockIgnitionMockRecorder
 }
 
-// MockIgnitionMockRecorder is the mock recorder for MockIgnition
+// MockIgnitionMockRecorder is the mock recorder for MockIgnition.
 type MockIgnitionMockRecorder struct {
 	mock *MockIgnition
 }
 
-// NewMockIgnition creates a new mock instance
+// NewMockIgnition creates a new mock instance.
 func NewMockIgnition(ctrl *gomock.Controller) *MockIgnition {
 	mock := &MockIgnition{ctrl: ctrl}
 	mock.recorder = &MockIgnitionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIgnition) EXPECT() *MockIgnitionMockRecorder {
 	return m.recorder
 }
 
-// ParseIgnitionFile mocks base method
-func (m *MockIgnition) ParseIgnitionFile(path string) (*types.Config, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ParseIgnitionFile", path)
-	ret0, _ := ret[0].(*types.Config)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ParseIgnitionFile indicates an expected call of ParseIgnitionFile
-func (mr *MockIgnitionMockRecorder) ParseIgnitionFile(path interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseIgnitionFile", reflect.TypeOf((*MockIgnition)(nil).ParseIgnitionFile), path)
-}
-
-// WriteIgnitionFile mocks base method
-func (m *MockIgnition) WriteIgnitionFile(path string, config *types.Config) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteIgnitionFile", path, config)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WriteIgnitionFile indicates an expected call of WriteIgnitionFile
-func (mr *MockIgnitionMockRecorder) WriteIgnitionFile(path, config interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteIgnitionFile", reflect.TypeOf((*MockIgnition)(nil).WriteIgnitionFile), path, config)
-}
-
-// MergeIgnitionConfig mocks base method
+// MergeIgnitionConfig mocks base method.
 func (m *MockIgnition) MergeIgnitionConfig(base, overrides *types.Config) (*types.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergeIgnitionConfig", base, overrides)
@@ -72,8 +43,37 @@ func (m *MockIgnition) MergeIgnitionConfig(base, overrides *types.Config) (*type
 	return ret0, ret1
 }
 
-// MergeIgnitionConfig indicates an expected call of MergeIgnitionConfig
+// MergeIgnitionConfig indicates an expected call of MergeIgnitionConfig.
 func (mr *MockIgnitionMockRecorder) MergeIgnitionConfig(base, overrides interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeIgnitionConfig", reflect.TypeOf((*MockIgnition)(nil).MergeIgnitionConfig), base, overrides)
+}
+
+// ParseIgnitionFile mocks base method.
+func (m *MockIgnition) ParseIgnitionFile(path string) (*types.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParseIgnitionFile", path)
+	ret0, _ := ret[0].(*types.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ParseIgnitionFile indicates an expected call of ParseIgnitionFile.
+func (mr *MockIgnitionMockRecorder) ParseIgnitionFile(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseIgnitionFile", reflect.TypeOf((*MockIgnition)(nil).ParseIgnitionFile), path)
+}
+
+// WriteIgnitionFile mocks base method.
+func (m *MockIgnition) WriteIgnitionFile(path string, config *types.Config) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteIgnitionFile", path, config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteIgnitionFile indicates an expected call of WriteIgnitionFile.
+func (mr *MockIgnitionMockRecorder) WriteIgnitionFile(path, config interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteIgnitionFile", reflect.TypeOf((*MockIgnition)(nil).WriteIgnitionFile), path, config)
 }

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -14,44 +14,56 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// MockInventoryClient is a mock of InventoryClient interface
+// MockInventoryClient is a mock of InventoryClient interface.
 type MockInventoryClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockInventoryClientMockRecorder
 }
 
-// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient
+// MockInventoryClientMockRecorder is the mock recorder for MockInventoryClient.
 type MockInventoryClientMockRecorder struct {
 	mock *MockInventoryClient
 }
 
-// NewMockInventoryClient creates a new mock instance
+// NewMockInventoryClient creates a new mock instance.
 func NewMockInventoryClient(ctrl *gomock.Controller) *MockInventoryClient {
 	mock := &MockInventoryClient{ctrl: ctrl}
 	mock.recorder = &MockInventoryClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInventoryClient) EXPECT() *MockInventoryClientMockRecorder {
 	return m.recorder
 }
 
-// DownloadFile mocks base method
-func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
+// ClusterLogProgressReport mocks base method.
+func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
+	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
+}
+
+// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport.
+func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
+}
+
+// CompleteInstallation mocks base method.
+func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DownloadFile indicates an expected call of DownloadFile
-func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
+// CompleteInstallation indicates an expected call of CompleteInstallation.
+func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
 }
 
-// DownloadClusterCredentials mocks base method
+// DownloadClusterCredentials mocks base method.
 func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, filename, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadClusterCredentials", ctx, filename, dest)
@@ -59,13 +71,27 @@ func (m *MockInventoryClient) DownloadClusterCredentials(ctx context.Context, fi
 	return ret0
 }
 
-// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials
+// DownloadClusterCredentials indicates an expected call of DownloadClusterCredentials.
 func (mr *MockInventoryClientMockRecorder) DownloadClusterCredentials(ctx, filename, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadClusterCredentials", reflect.TypeOf((*MockInventoryClient)(nil).DownloadClusterCredentials), ctx, filename, dest)
 }
 
-// DownloadHostIgnition mocks base method
+// DownloadFile mocks base method.
+func (m *MockInventoryClient) DownloadFile(ctx context.Context, filename, dest string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadFile", ctx, filename, dest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DownloadFile indicates an expected call of DownloadFile.
+func (mr *MockInventoryClientMockRecorder) DownloadFile(ctx, filename, dest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockInventoryClient)(nil).DownloadFile), ctx, filename, dest)
+}
+
+// DownloadHostIgnition mocks base method.
 func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnvID, hostID, dest string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadHostIgnition", ctx, infraEnvID, hostID, dest)
@@ -73,56 +99,13 @@ func (m *MockInventoryClient) DownloadHostIgnition(ctx context.Context, infraEnv
 	return ret0
 }
 
-// DownloadHostIgnition indicates an expected call of DownloadHostIgnition
+// DownloadHostIgnition indicates an expected call of DownloadHostIgnition.
 func (mr *MockInventoryClientMockRecorder) DownloadHostIgnition(ctx, infraEnvID, hostID, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadHostIgnition", reflect.TypeOf((*MockInventoryClient)(nil).DownloadHostIgnition), ctx, infraEnvID, hostID, dest)
 }
 
-// UpdateHostInstallProgress mocks base method
-func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress
-func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
-}
-
-// GetEnabledHostsNamesHosts mocks base method
-func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
-	ret0, _ := ret[0].(map[string]HostData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts
-func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
-}
-
-// UploadIngressCa mocks base method
-func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadIngressCa indicates an expected call of UploadIngressCa
-func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
-}
-
-// GetCluster mocks base method
+// GetCluster mocks base method.
 func (m *MockInventoryClient) GetCluster(ctx context.Context, withHosts bool) (*models.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCluster", ctx, withHosts)
@@ -131,43 +114,13 @@ func (m *MockInventoryClient) GetCluster(ctx context.Context, withHosts bool) (*
 	return ret0, ret1
 }
 
-// GetCluster indicates an expected call of GetCluster
+// GetCluster indicates an expected call of GetCluster.
 func (mr *MockInventoryClientMockRecorder) GetCluster(ctx, withHosts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockInventoryClient)(nil).GetCluster), ctx, withHosts)
 }
 
-// ListsHostsForRole mocks base method
-func (m *MockInventoryClient) ListsHostsForRole(ctx context.Context, role string) (models.HostList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListsHostsForRole", ctx, role)
-	ret0, _ := ret[0].(models.HostList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListsHostsForRole indicates an expected call of ListsHostsForRole
-func (mr *MockInventoryClientMockRecorder) ListsHostsForRole(ctx, role interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListsHostsForRole", reflect.TypeOf((*MockInventoryClient)(nil).ListsHostsForRole), ctx, role)
-}
-
-// GetClusterMonitoredOperator mocks base method
-func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
-	ret0, _ := ret[0].(*models.MonitoredOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
-}
-
-// GetClusterMonitoredOLMOperators mocks base method
+// GetClusterMonitoredOLMOperators mocks base method.
 func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string) ([]models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion)
@@ -176,27 +129,43 @@ func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Contex
 	return ret0, ret1
 }
 
-// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators
+// GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators.
 func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion)
 }
 
-// CompleteInstallation mocks base method
-func (m *MockInventoryClient) CompleteInstallation(ctx context.Context, clusterId string, isSuccess bool, errorInfo string) error {
+// GetClusterMonitoredOperator mocks base method.
+func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, clusterId, isSuccess, errorInfo)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
+	ret0, _ := ret[0].(*models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// CompleteInstallation indicates an expected call of CompleteInstallation
-func (mr *MockInventoryClientMockRecorder) CompleteInstallation(ctx, clusterId, isSuccess, errorInfo interface{}) *gomock.Call {
+// GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator.
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockInventoryClient)(nil).CompleteInstallation), ctx, clusterId, isSuccess, errorInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
 }
 
-// GetHosts mocks base method
+// GetEnabledHostsNamesHosts mocks base method.
+func (m *MockInventoryClient) GetEnabledHostsNamesHosts(ctx context.Context, log logrus.FieldLogger) (map[string]HostData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnabledHostsNamesHosts", ctx, log)
+	ret0, _ := ret[0].(map[string]HostData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEnabledHostsNamesHosts indicates an expected call of GetEnabledHostsNamesHosts.
+func (mr *MockInventoryClientMockRecorder) GetEnabledHostsNamesHosts(ctx, log interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledHostsNamesHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetEnabledHostsNamesHosts), ctx, log)
+}
+
+// GetHosts mocks base method.
 func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogger, skippedStatuses []string) (map[string]HostData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHosts", ctx, log, skippedStatuses)
@@ -205,51 +174,40 @@ func (m *MockInventoryClient) GetHosts(ctx context.Context, log logrus.FieldLogg
 	return ret0, ret1
 }
 
-// GetHosts indicates an expected call of GetHosts
+// GetHosts indicates an expected call of GetHosts.
 func (mr *MockInventoryClientMockRecorder) GetHosts(ctx, log, skippedStatuses interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockInventoryClient)(nil).GetHosts), ctx, log, skippedStatuses)
 }
 
-// UploadLogs mocks base method
-func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadLogs indicates an expected call of UploadLogs
-func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
-}
-
-// ClusterLogProgressReport mocks base method
-func (m *MockInventoryClient) ClusterLogProgressReport(ctx context.Context, clusterId string, progress models.LogsState) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterLogProgressReport", ctx, clusterId, progress)
-}
-
-// ClusterLogProgressReport indicates an expected call of ClusterLogProgressReport
-func (mr *MockInventoryClientMockRecorder) ClusterLogProgressReport(ctx, clusterId, progress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).ClusterLogProgressReport), ctx, clusterId, progress)
-}
-
-// HostLogProgressReport mocks base method
+// HostLogProgressReport mocks base method.
 func (m *MockInventoryClient) HostLogProgressReport(ctx context.Context, infraEnvId, hostId string, progress models.LogsState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HostLogProgressReport", ctx, infraEnvId, hostId, progress)
 }
 
-// HostLogProgressReport indicates an expected call of HostLogProgressReport
+// HostLogProgressReport indicates an expected call of HostLogProgressReport.
 func (mr *MockInventoryClientMockRecorder) HostLogProgressReport(ctx, infraEnvId, hostId, progress interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostLogProgressReport", reflect.TypeOf((*MockInventoryClient)(nil).HostLogProgressReport), ctx, infraEnvId, hostId, progress)
 }
 
-// UpdateClusterOperator mocks base method
+// ListsHostsForRole mocks base method.
+func (m *MockInventoryClient) ListsHostsForRole(ctx context.Context, role string) (models.HostList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListsHostsForRole", ctx, role)
+	ret0, _ := ret[0].(models.HostList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListsHostsForRole indicates an expected call of ListsHostsForRole.
+func (mr *MockInventoryClientMockRecorder) ListsHostsForRole(ctx, role interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListsHostsForRole", reflect.TypeOf((*MockInventoryClient)(nil).ListsHostsForRole), ctx, role)
+}
+
+// UpdateClusterOperator mocks base method.
 func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, clusterId, operatorName string, operatorStatus models.OperatorStatus, operatorStatusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterOperator", ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
@@ -257,8 +215,50 @@ func (m *MockInventoryClient) UpdateClusterOperator(ctx context.Context, cluster
 	return ret0
 }
 
-// UpdateClusterOperator indicates an expected call of UpdateClusterOperator
+// UpdateClusterOperator indicates an expected call of UpdateClusterOperator.
 func (mr *MockInventoryClientMockRecorder) UpdateClusterOperator(ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterOperator", reflect.TypeOf((*MockInventoryClient)(nil).UpdateClusterOperator), ctx, clusterId, operatorName, operatorStatus, operatorStatusInfo)
+}
+
+// UpdateHostInstallProgress mocks base method.
+func (m *MockInventoryClient) UpdateHostInstallProgress(ctx context.Context, infraEnvId, hostId string, newStage models.HostStage, info string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostInstallProgress", ctx, infraEnvId, hostId, newStage, info)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateHostInstallProgress indicates an expected call of UpdateHostInstallProgress.
+func (mr *MockInventoryClientMockRecorder) UpdateHostInstallProgress(ctx, infraEnvId, hostId, newStage, info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallProgress", reflect.TypeOf((*MockInventoryClient)(nil).UpdateHostInstallProgress), ctx, infraEnvId, hostId, newStage, info)
+}
+
+// UploadIngressCa mocks base method.
+func (m *MockInventoryClient) UploadIngressCa(ctx context.Context, ingressCA, clusterId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadIngressCa", ctx, ingressCA, clusterId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadIngressCa indicates an expected call of UploadIngressCa.
+func (mr *MockInventoryClientMockRecorder) UploadIngressCa(ctx, ingressCA, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCa", reflect.TypeOf((*MockInventoryClient)(nil).UploadIngressCa), ctx, ingressCA, clusterId)
+}
+
+// UploadLogs mocks base method.
+func (m *MockInventoryClient) UploadLogs(ctx context.Context, clusterId string, logsType models.LogsType, upfile io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadLogs", ctx, clusterId, logsType, upfile)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadLogs indicates an expected call of UploadLogs.
+func (mr *MockInventoryClientMockRecorder) UploadLogs(ctx, clusterId, logsType, upfile interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLogs", reflect.TypeOf((*MockInventoryClient)(nil).UploadLogs), ctx, clusterId, logsType, upfile)
 }

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -20,104 +20,30 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 )
 
-// MockK8SClient is a mock of K8SClient interface
+// MockK8SClient is a mock of K8SClient interface.
 type MockK8SClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockK8SClientMockRecorder
 }
 
-// MockK8SClientMockRecorder is the mock recorder for MockK8SClient
+// MockK8SClientMockRecorder is the mock recorder for MockK8SClient.
 type MockK8SClientMockRecorder struct {
 	mock *MockK8SClient
 }
 
-// NewMockK8SClient creates a new mock instance
+// NewMockK8SClient creates a new mock instance.
 func NewMockK8SClient(ctrl *gomock.Controller) *MockK8SClient {
 	mock := &MockK8SClient{ctrl: ctrl}
 	mock.recorder = &MockK8SClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockK8SClient) EXPECT() *MockK8SClientMockRecorder {
 	return m.recorder
 }
 
-// ListMasterNodes mocks base method
-func (m *MockK8SClient) ListMasterNodes() (*v12.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMasterNodes")
-	ret0, _ := ret[0].(*v12.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListMasterNodes indicates an expected call of ListMasterNodes
-func (mr *MockK8SClientMockRecorder) ListMasterNodes() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMasterNodes", reflect.TypeOf((*MockK8SClient)(nil).ListMasterNodes))
-}
-
-// EnableRouterAccessLogs mocks base method
-func (m *MockK8SClient) EnableRouterAccessLogs() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableRouterAccessLogs")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnableRouterAccessLogs indicates an expected call of EnableRouterAccessLogs
-func (mr *MockK8SClientMockRecorder) EnableRouterAccessLogs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableRouterAccessLogs", reflect.TypeOf((*MockK8SClient)(nil).EnableRouterAccessLogs))
-}
-
-// ListNodes mocks base method
-func (m *MockK8SClient) ListNodes() (*v12.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes")
-	ret0, _ := ret[0].(*v12.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes
-func (mr *MockK8SClientMockRecorder) ListNodes() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockK8SClient)(nil).ListNodes))
-}
-
-// ListMachines mocks base method
-func (m *MockK8SClient) ListMachines() (*v1beta1.MachineList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMachines")
-	ret0, _ := ret[0].(*v1beta1.MachineList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListMachines indicates an expected call of ListMachines
-func (mr *MockK8SClientMockRecorder) ListMachines() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMachines", reflect.TypeOf((*MockK8SClient)(nil).ListMachines))
-}
-
-// RunOCctlCommand mocks base method
-func (m *MockK8SClient) RunOCctlCommand(args []string, kubeconfigPath string, o ops.Ops) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunOCctlCommand", args, kubeconfigPath, o)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunOCctlCommand indicates an expected call of RunOCctlCommand
-func (mr *MockK8SClientMockRecorder) RunOCctlCommand(args, kubeconfigPath, o interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunOCctlCommand", reflect.TypeOf((*MockK8SClient)(nil).RunOCctlCommand), args, kubeconfigPath, o)
-}
-
-// ApproveCsr mocks base method
+// ApproveCsr mocks base method.
 func (m *MockK8SClient) ApproveCsr(csr *v11.CertificateSigningRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApproveCsr", csr)
@@ -125,354 +51,13 @@ func (m *MockK8SClient) ApproveCsr(csr *v11.CertificateSigningRequest) error {
 	return ret0
 }
 
-// ApproveCsr indicates an expected call of ApproveCsr
+// ApproveCsr indicates an expected call of ApproveCsr.
 func (mr *MockK8SClientMockRecorder) ApproveCsr(csr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApproveCsr", reflect.TypeOf((*MockK8SClient)(nil).ApproveCsr), csr)
 }
 
-// ListCsrs mocks base method
-func (m *MockK8SClient) ListCsrs() (*v11.CertificateSigningRequestList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCsrs")
-	ret0, _ := ret[0].(*v11.CertificateSigningRequestList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCsrs indicates an expected call of ListCsrs
-func (mr *MockK8SClientMockRecorder) ListCsrs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCsrs", reflect.TypeOf((*MockK8SClient)(nil).ListCsrs))
-}
-
-// GetConfigMap mocks base method
-func (m *MockK8SClient) GetConfigMap(namespace, name string) (*v12.ConfigMap, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigMap", namespace, name)
-	ret0, _ := ret[0].(*v12.ConfigMap)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConfigMap indicates an expected call of GetConfigMap
-func (mr *MockK8SClientMockRecorder) GetConfigMap(namespace, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockK8SClient)(nil).GetConfigMap), namespace, name)
-}
-
-// GetPodLogs mocks base method
-func (m *MockK8SClient) GetPodLogs(namespace, podName string, sinceSeconds int64) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPodLogs", namespace, podName, sinceSeconds)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPodLogs indicates an expected call of GetPodLogs
-func (mr *MockK8SClientMockRecorder) GetPodLogs(namespace, podName, sinceSeconds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockK8SClient)(nil).GetPodLogs), namespace, podName, sinceSeconds)
-}
-
-// GetPodLogsAsBuffer mocks base method
-func (m *MockK8SClient) GetPodLogsAsBuffer(namespace, podName string, sinceSeconds int64) (*bytes.Buffer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPodLogsAsBuffer", namespace, podName, sinceSeconds)
-	ret0, _ := ret[0].(*bytes.Buffer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPodLogsAsBuffer indicates an expected call of GetPodLogsAsBuffer
-func (mr *MockK8SClientMockRecorder) GetPodLogsAsBuffer(namespace, podName, sinceSeconds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogsAsBuffer", reflect.TypeOf((*MockK8SClient)(nil).GetPodLogsAsBuffer), namespace, podName, sinceSeconds)
-}
-
-// GetPods mocks base method
-func (m *MockK8SClient) GetPods(namespace string, labelMatch map[string]string, fieldSelector string) ([]v12.Pod, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPods", namespace, labelMatch, fieldSelector)
-	ret0, _ := ret[0].([]v12.Pod)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPods indicates an expected call of GetPods
-func (mr *MockK8SClientMockRecorder) GetPods(namespace, labelMatch, fieldSelector interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockK8SClient)(nil).GetPods), namespace, labelMatch, fieldSelector)
-}
-
-// GetCSV mocks base method
-func (m *MockK8SClient) GetCSV(namespace, name string) (*v1alpha10.ClusterServiceVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCSV", namespace, name)
-	ret0, _ := ret[0].(*v1alpha10.ClusterServiceVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCSV indicates an expected call of GetCSV
-func (mr *MockK8SClientMockRecorder) GetCSV(namespace, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSV", reflect.TypeOf((*MockK8SClient)(nil).GetCSV), namespace, name)
-}
-
-// GetCSVFromSubscription mocks base method
-func (m *MockK8SClient) GetCSVFromSubscription(namespace, name string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCSVFromSubscription", namespace, name)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCSVFromSubscription indicates an expected call of GetCSVFromSubscription
-func (mr *MockK8SClientMockRecorder) GetCSVFromSubscription(namespace, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSVFromSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetCSVFromSubscription), namespace, name)
-}
-
-// GetSubscription mocks base method
-func (m *MockK8SClient) GetSubscription(subscription types.NamespacedName) (*v1alpha10.Subscription, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubscription", subscription)
-	ret0, _ := ret[0].(*v1alpha10.Subscription)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubscription indicates an expected call of GetSubscription
-func (mr *MockK8SClientMockRecorder) GetSubscription(subscription interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetSubscription), subscription)
-}
-
-// GetAllInstallPlansOfSubscription mocks base method
-func (m *MockK8SClient) GetAllInstallPlansOfSubscription(subscription types.NamespacedName) ([]v1alpha10.InstallPlan, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllInstallPlansOfSubscription", subscription)
-	ret0, _ := ret[0].([]v1alpha10.InstallPlan)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllInstallPlansOfSubscription indicates an expected call of GetAllInstallPlansOfSubscription
-func (mr *MockK8SClientMockRecorder) GetAllInstallPlansOfSubscription(subscription interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllInstallPlansOfSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetAllInstallPlansOfSubscription), subscription)
-}
-
-// DeleteInstallPlan mocks base method
-func (m *MockK8SClient) DeleteInstallPlan(installPlan types.NamespacedName) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInstallPlan", installPlan)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteInstallPlan indicates an expected call of DeleteInstallPlan
-func (mr *MockK8SClientMockRecorder) DeleteInstallPlan(installPlan interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstallPlan", reflect.TypeOf((*MockK8SClient)(nil).DeleteInstallPlan), installPlan)
-}
-
-// IsMetalProvisioningExists mocks base method
-func (m *MockK8SClient) IsMetalProvisioningExists() (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsMetalProvisioningExists")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsMetalProvisioningExists indicates an expected call of IsMetalProvisioningExists
-func (mr *MockK8SClientMockRecorder) IsMetalProvisioningExists() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetalProvisioningExists", reflect.TypeOf((*MockK8SClient)(nil).IsMetalProvisioningExists))
-}
-
-// ListBMHs mocks base method
-func (m *MockK8SClient) ListBMHs() (v1alpha1.BareMetalHostList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBMHs")
-	ret0, _ := ret[0].(v1alpha1.BareMetalHostList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBMHs indicates an expected call of ListBMHs
-func (mr *MockK8SClientMockRecorder) ListBMHs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBMHs", reflect.TypeOf((*MockK8SClient)(nil).ListBMHs))
-}
-
-// GetBMH mocks base method
-func (m *MockK8SClient) GetBMH(name string) (*v1alpha1.BareMetalHost, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBMH", name)
-	ret0, _ := ret[0].(*v1alpha1.BareMetalHost)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBMH indicates an expected call of GetBMH
-func (mr *MockK8SClientMockRecorder) GetBMH(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBMH", reflect.TypeOf((*MockK8SClient)(nil).GetBMH), name)
-}
-
-// UpdateBMHStatus mocks base method
-func (m *MockK8SClient) UpdateBMHStatus(bmh *v1alpha1.BareMetalHost) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBMHStatus", bmh)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateBMHStatus indicates an expected call of UpdateBMHStatus
-func (mr *MockK8SClientMockRecorder) UpdateBMHStatus(bmh interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBMHStatus", reflect.TypeOf((*MockK8SClient)(nil).UpdateBMHStatus), bmh)
-}
-
-// UpdateBMH mocks base method
-func (m *MockK8SClient) UpdateBMH(bmh *v1alpha1.BareMetalHost) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBMH", bmh)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateBMH indicates an expected call of UpdateBMH
-func (mr *MockK8SClientMockRecorder) UpdateBMH(bmh interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBMH", reflect.TypeOf((*MockK8SClient)(nil).UpdateBMH), bmh)
-}
-
-// SetProxyEnvVars mocks base method
-func (m *MockK8SClient) SetProxyEnvVars() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetProxyEnvVars")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetProxyEnvVars indicates an expected call of SetProxyEnvVars
-func (mr *MockK8SClientMockRecorder) SetProxyEnvVars() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProxyEnvVars", reflect.TypeOf((*MockK8SClient)(nil).SetProxyEnvVars))
-}
-
-// GetClusterVersion mocks base method
-func (m *MockK8SClient) GetClusterVersion() (*v1.ClusterVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterVersion")
-	ret0, _ := ret[0].(*v1.ClusterVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterVersion indicates an expected call of GetClusterVersion
-func (mr *MockK8SClientMockRecorder) GetClusterVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterVersion", reflect.TypeOf((*MockK8SClient)(nil).GetClusterVersion))
-}
-
-// GetServiceNetworks mocks base method
-func (m *MockK8SClient) GetServiceNetworks() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceNetworks")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServiceNetworks indicates an expected call of GetServiceNetworks
-func (mr *MockK8SClientMockRecorder) GetServiceNetworks() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceNetworks", reflect.TypeOf((*MockK8SClient)(nil).GetServiceNetworks))
-}
-
-// GetControlPlaneReplicas mocks base method
-func (m *MockK8SClient) GetControlPlaneReplicas() (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetControlPlaneReplicas")
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetControlPlaneReplicas indicates an expected call of GetControlPlaneReplicas
-func (mr *MockK8SClientMockRecorder) GetControlPlaneReplicas() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneReplicas", reflect.TypeOf((*MockK8SClient)(nil).GetControlPlaneReplicas))
-}
-
-// ListServices mocks base method
-func (m *MockK8SClient) ListServices(namespace string) (*v12.ServiceList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServices", namespace)
-	ret0, _ := ret[0].(*v12.ServiceList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListServices indicates an expected call of ListServices
-func (mr *MockK8SClientMockRecorder) ListServices(namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockK8SClient)(nil).ListServices), namespace)
-}
-
-// ListEvents mocks base method
-func (m *MockK8SClient) ListEvents(namespace string) (*v12.EventList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEvents", namespace)
-	ret0, _ := ret[0].(*v12.EventList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEvents indicates an expected call of ListEvents
-func (mr *MockK8SClientMockRecorder) ListEvents(namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockK8SClient)(nil).ListEvents), namespace)
-}
-
-// ListClusterOperators mocks base method
-func (m *MockK8SClient) ListClusterOperators() (*v1.ClusterOperatorList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterOperators")
-	ret0, _ := ret[0].(*v1.ClusterOperatorList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterOperators indicates an expected call of ListClusterOperators
-func (mr *MockK8SClientMockRecorder) ListClusterOperators() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterOperators", reflect.TypeOf((*MockK8SClient)(nil).ListClusterOperators))
-}
-
-// GetClusterOperator mocks base method
-func (m *MockK8SClient) GetClusterOperator(name string) (*v1.ClusterOperator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterOperator", name)
-	ret0, _ := ret[0].(*v1.ClusterOperator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterOperator indicates an expected call of GetClusterOperator
-func (mr *MockK8SClientMockRecorder) GetClusterOperator(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterOperator", reflect.TypeOf((*MockK8SClient)(nil).GetClusterOperator), name)
-}
-
-// CreateEvent mocks base method
+// CreateEvent mocks base method.
 func (m *MockK8SClient) CreateEvent(namespace, name, message, component string) (*v12.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEvent", namespace, name, message, component)
@@ -481,27 +66,41 @@ func (m *MockK8SClient) CreateEvent(namespace, name, message, component string) 
 	return ret0, ret1
 }
 
-// CreateEvent indicates an expected call of CreateEvent
+// CreateEvent indicates an expected call of CreateEvent.
 func (mr *MockK8SClientMockRecorder) CreateEvent(namespace, name, message, component interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEvent", reflect.TypeOf((*MockK8SClient)(nil).CreateEvent), namespace, name, message, component)
 }
 
-// DeleteService mocks base method
-func (m *MockK8SClient) DeleteService(namespace, name string) error {
+// DeleteInstallPlan mocks base method.
+func (m *MockK8SClient) DeleteInstallPlan(installPlan types.NamespacedName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteService", namespace, name)
+	ret := m.ctrl.Call(m, "DeleteInstallPlan", installPlan)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteService indicates an expected call of DeleteService
-func (mr *MockK8SClientMockRecorder) DeleteService(namespace, name interface{}) *gomock.Call {
+// DeleteInstallPlan indicates an expected call of DeleteInstallPlan.
+func (mr *MockK8SClientMockRecorder) DeleteInstallPlan(installPlan interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockK8SClient)(nil).DeleteService), namespace, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstallPlan", reflect.TypeOf((*MockK8SClient)(nil).DeleteInstallPlan), installPlan)
 }
 
-// DeletePods mocks base method
+// DeleteJob mocks base method.
+func (m *MockK8SClient) DeleteJob(job types.NamespacedName) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteJob", job)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteJob indicates an expected call of DeleteJob.
+func (mr *MockK8SClientMockRecorder) DeleteJob(job interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockK8SClient)(nil).DeleteJob), job)
+}
+
+// DeletePods mocks base method.
 func (m *MockK8SClient) DeletePods(namespace string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePods", namespace)
@@ -509,27 +108,161 @@ func (m *MockK8SClient) DeletePods(namespace string) error {
 	return ret0
 }
 
-// DeletePods indicates an expected call of DeletePods
+// DeletePods indicates an expected call of DeletePods.
 func (mr *MockK8SClientMockRecorder) DeletePods(namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePods", reflect.TypeOf((*MockK8SClient)(nil).DeletePods), namespace)
 }
 
-// PatchNamespace mocks base method
-func (m *MockK8SClient) PatchNamespace(namespace string, data []byte) error {
+// DeleteService mocks base method.
+func (m *MockK8SClient) DeleteService(namespace, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchNamespace", namespace, data)
+	ret := m.ctrl.Call(m, "DeleteService", namespace, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// PatchNamespace indicates an expected call of PatchNamespace
-func (mr *MockK8SClientMockRecorder) PatchNamespace(namespace, data interface{}) *gomock.Call {
+// DeleteService indicates an expected call of DeleteService.
+func (mr *MockK8SClientMockRecorder) DeleteService(namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNamespace", reflect.TypeOf((*MockK8SClient)(nil).PatchNamespace), namespace, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockK8SClient)(nil).DeleteService), namespace, name)
 }
 
-// GetNode mocks base method
+// EnableRouterAccessLogs mocks base method.
+func (m *MockK8SClient) EnableRouterAccessLogs() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableRouterAccessLogs")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableRouterAccessLogs indicates an expected call of EnableRouterAccessLogs.
+func (mr *MockK8SClientMockRecorder) EnableRouterAccessLogs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableRouterAccessLogs", reflect.TypeOf((*MockK8SClient)(nil).EnableRouterAccessLogs))
+}
+
+// GetAllInstallPlansOfSubscription mocks base method.
+func (m *MockK8SClient) GetAllInstallPlansOfSubscription(subscription types.NamespacedName) ([]v1alpha10.InstallPlan, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllInstallPlansOfSubscription", subscription)
+	ret0, _ := ret[0].([]v1alpha10.InstallPlan)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllInstallPlansOfSubscription indicates an expected call of GetAllInstallPlansOfSubscription.
+func (mr *MockK8SClientMockRecorder) GetAllInstallPlansOfSubscription(subscription interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllInstallPlansOfSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetAllInstallPlansOfSubscription), subscription)
+}
+
+// GetBMH mocks base method.
+func (m *MockK8SClient) GetBMH(name string) (*v1alpha1.BareMetalHost, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBMH", name)
+	ret0, _ := ret[0].(*v1alpha1.BareMetalHost)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBMH indicates an expected call of GetBMH.
+func (mr *MockK8SClientMockRecorder) GetBMH(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBMH", reflect.TypeOf((*MockK8SClient)(nil).GetBMH), name)
+}
+
+// GetCSV mocks base method.
+func (m *MockK8SClient) GetCSV(namespace, name string) (*v1alpha10.ClusterServiceVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCSV", namespace, name)
+	ret0, _ := ret[0].(*v1alpha10.ClusterServiceVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCSV indicates an expected call of GetCSV.
+func (mr *MockK8SClientMockRecorder) GetCSV(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSV", reflect.TypeOf((*MockK8SClient)(nil).GetCSV), namespace, name)
+}
+
+// GetCSVFromSubscription mocks base method.
+func (m *MockK8SClient) GetCSVFromSubscription(namespace, name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCSVFromSubscription", namespace, name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCSVFromSubscription indicates an expected call of GetCSVFromSubscription.
+func (mr *MockK8SClientMockRecorder) GetCSVFromSubscription(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSVFromSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetCSVFromSubscription), namespace, name)
+}
+
+// GetClusterOperator mocks base method.
+func (m *MockK8SClient) GetClusterOperator(name string) (*v1.ClusterOperator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterOperator", name)
+	ret0, _ := ret[0].(*v1.ClusterOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterOperator indicates an expected call of GetClusterOperator.
+func (mr *MockK8SClientMockRecorder) GetClusterOperator(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterOperator", reflect.TypeOf((*MockK8SClient)(nil).GetClusterOperator), name)
+}
+
+// GetClusterVersion mocks base method.
+func (m *MockK8SClient) GetClusterVersion() (*v1.ClusterVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterVersion")
+	ret0, _ := ret[0].(*v1.ClusterVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterVersion indicates an expected call of GetClusterVersion.
+func (mr *MockK8SClientMockRecorder) GetClusterVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterVersion", reflect.TypeOf((*MockK8SClient)(nil).GetClusterVersion))
+}
+
+// GetConfigMap mocks base method.
+func (m *MockK8SClient) GetConfigMap(namespace, name string) (*v12.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigMap", namespace, name)
+	ret0, _ := ret[0].(*v12.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfigMap indicates an expected call of GetConfigMap.
+func (mr *MockK8SClientMockRecorder) GetConfigMap(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockK8SClient)(nil).GetConfigMap), namespace, name)
+}
+
+// GetControlPlaneReplicas mocks base method.
+func (m *MockK8SClient) GetControlPlaneReplicas() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControlPlaneReplicas")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControlPlaneReplicas indicates an expected call of GetControlPlaneReplicas.
+func (mr *MockK8SClientMockRecorder) GetControlPlaneReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneReplicas", reflect.TypeOf((*MockK8SClient)(nil).GetControlPlaneReplicas))
+}
+
+// GetNode mocks base method.
 func (m *MockK8SClient) GetNode(name string) (*v12.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNode", name)
@@ -538,56 +271,88 @@ func (m *MockK8SClient) GetNode(name string) (*v12.Node, error) {
 	return ret0, ret1
 }
 
-// GetNode indicates an expected call of GetNode
+// GetNode indicates an expected call of GetNode.
 func (mr *MockK8SClientMockRecorder) GetNode(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockK8SClient)(nil).GetNode), name)
 }
 
-// PatchNodeLabels mocks base method
-func (m *MockK8SClient) PatchNodeLabels(nodeName, nodeLabels string) error {
+// GetPodLogs mocks base method.
+func (m *MockK8SClient) GetPodLogs(namespace, podName string, sinceSeconds int64) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchNodeLabels", nodeName, nodeLabels)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PatchNodeLabels indicates an expected call of PatchNodeLabels
-func (mr *MockK8SClientMockRecorder) PatchNodeLabels(nodeName, nodeLabels interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNodeLabels", reflect.TypeOf((*MockK8SClient)(nil).PatchNodeLabels), nodeName, nodeLabels)
-}
-
-// ListJobs mocks base method
-func (m *MockK8SClient) ListJobs(namespace string) (*v10.JobList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListJobs", namespace)
-	ret0, _ := ret[0].(*v10.JobList)
+	ret := m.ctrl.Call(m, "GetPodLogs", namespace, podName, sinceSeconds)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListJobs indicates an expected call of ListJobs
-func (mr *MockK8SClientMockRecorder) ListJobs(namespace interface{}) *gomock.Call {
+// GetPodLogs indicates an expected call of GetPodLogs.
+func (mr *MockK8SClientMockRecorder) GetPodLogs(namespace, podName, sinceSeconds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockK8SClient)(nil).ListJobs), namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockK8SClient)(nil).GetPodLogs), namespace, podName, sinceSeconds)
 }
 
-// DeleteJob mocks base method
-func (m *MockK8SClient) DeleteJob(job types.NamespacedName) error {
+// GetPodLogsAsBuffer mocks base method.
+func (m *MockK8SClient) GetPodLogsAsBuffer(namespace, podName string, sinceSeconds int64) (*bytes.Buffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteJob", job)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetPodLogsAsBuffer", namespace, podName, sinceSeconds)
+	ret0, _ := ret[0].(*bytes.Buffer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// DeleteJob indicates an expected call of DeleteJob
-func (mr *MockK8SClientMockRecorder) DeleteJob(job interface{}) *gomock.Call {
+// GetPodLogsAsBuffer indicates an expected call of GetPodLogsAsBuffer.
+func (mr *MockK8SClientMockRecorder) GetPodLogsAsBuffer(namespace, podName, sinceSeconds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockK8SClient)(nil).DeleteJob), job)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogsAsBuffer", reflect.TypeOf((*MockK8SClient)(nil).GetPodLogsAsBuffer), namespace, podName, sinceSeconds)
 }
 
-// IsClusterCapabilityEnabled mocks base method
+// GetPods mocks base method.
+func (m *MockK8SClient) GetPods(namespace string, labelMatch map[string]string, fieldSelector string) ([]v12.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPods", namespace, labelMatch, fieldSelector)
+	ret0, _ := ret[0].([]v12.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPods indicates an expected call of GetPods.
+func (mr *MockK8SClientMockRecorder) GetPods(namespace, labelMatch, fieldSelector interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPods", reflect.TypeOf((*MockK8SClient)(nil).GetPods), namespace, labelMatch, fieldSelector)
+}
+
+// GetServiceNetworks mocks base method.
+func (m *MockK8SClient) GetServiceNetworks() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceNetworks")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceNetworks indicates an expected call of GetServiceNetworks.
+func (mr *MockK8SClientMockRecorder) GetServiceNetworks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceNetworks", reflect.TypeOf((*MockK8SClient)(nil).GetServiceNetworks))
+}
+
+// GetSubscription mocks base method.
+func (m *MockK8SClient) GetSubscription(subscription types.NamespacedName) (*v1alpha10.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubscription", subscription)
+	ret0, _ := ret[0].(*v1alpha10.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubscription indicates an expected call of GetSubscription.
+func (mr *MockK8SClientMockRecorder) GetSubscription(subscription interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscription", reflect.TypeOf((*MockK8SClient)(nil).GetSubscription), subscription)
+}
+
+// IsClusterCapabilityEnabled mocks base method.
 func (m *MockK8SClient) IsClusterCapabilityEnabled(arg0 v1.ClusterVersionCapability) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsClusterCapabilityEnabled", arg0)
@@ -596,8 +361,243 @@ func (m *MockK8SClient) IsClusterCapabilityEnabled(arg0 v1.ClusterVersionCapabil
 	return ret0, ret1
 }
 
-// IsClusterCapabilityEnabled indicates an expected call of IsClusterCapabilityEnabled
+// IsClusterCapabilityEnabled indicates an expected call of IsClusterCapabilityEnabled.
 func (mr *MockK8SClientMockRecorder) IsClusterCapabilityEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterCapabilityEnabled", reflect.TypeOf((*MockK8SClient)(nil).IsClusterCapabilityEnabled), arg0)
+}
+
+// IsMetalProvisioningExists mocks base method.
+func (m *MockK8SClient) IsMetalProvisioningExists() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMetalProvisioningExists")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsMetalProvisioningExists indicates an expected call of IsMetalProvisioningExists.
+func (mr *MockK8SClientMockRecorder) IsMetalProvisioningExists() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetalProvisioningExists", reflect.TypeOf((*MockK8SClient)(nil).IsMetalProvisioningExists))
+}
+
+// ListBMHs mocks base method.
+func (m *MockK8SClient) ListBMHs() (v1alpha1.BareMetalHostList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBMHs")
+	ret0, _ := ret[0].(v1alpha1.BareMetalHostList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBMHs indicates an expected call of ListBMHs.
+func (mr *MockK8SClientMockRecorder) ListBMHs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBMHs", reflect.TypeOf((*MockK8SClient)(nil).ListBMHs))
+}
+
+// ListClusterOperators mocks base method.
+func (m *MockK8SClient) ListClusterOperators() (*v1.ClusterOperatorList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterOperators")
+	ret0, _ := ret[0].(*v1.ClusterOperatorList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterOperators indicates an expected call of ListClusterOperators.
+func (mr *MockK8SClientMockRecorder) ListClusterOperators() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterOperators", reflect.TypeOf((*MockK8SClient)(nil).ListClusterOperators))
+}
+
+// ListCsrs mocks base method.
+func (m *MockK8SClient) ListCsrs() (*v11.CertificateSigningRequestList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCsrs")
+	ret0, _ := ret[0].(*v11.CertificateSigningRequestList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCsrs indicates an expected call of ListCsrs.
+func (mr *MockK8SClientMockRecorder) ListCsrs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCsrs", reflect.TypeOf((*MockK8SClient)(nil).ListCsrs))
+}
+
+// ListEvents mocks base method.
+func (m *MockK8SClient) ListEvents(namespace string) (*v12.EventList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEvents", namespace)
+	ret0, _ := ret[0].(*v12.EventList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEvents indicates an expected call of ListEvents.
+func (mr *MockK8SClientMockRecorder) ListEvents(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockK8SClient)(nil).ListEvents), namespace)
+}
+
+// ListJobs mocks base method.
+func (m *MockK8SClient) ListJobs(namespace string) (*v10.JobList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", namespace)
+	ret0, _ := ret[0].(*v10.JobList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockK8SClientMockRecorder) ListJobs(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockK8SClient)(nil).ListJobs), namespace)
+}
+
+// ListMachines mocks base method.
+func (m *MockK8SClient) ListMachines() (*v1beta1.MachineList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMachines")
+	ret0, _ := ret[0].(*v1beta1.MachineList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMachines indicates an expected call of ListMachines.
+func (mr *MockK8SClientMockRecorder) ListMachines() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMachines", reflect.TypeOf((*MockK8SClient)(nil).ListMachines))
+}
+
+// ListMasterNodes mocks base method.
+func (m *MockK8SClient) ListMasterNodes() (*v12.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMasterNodes")
+	ret0, _ := ret[0].(*v12.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMasterNodes indicates an expected call of ListMasterNodes.
+func (mr *MockK8SClientMockRecorder) ListMasterNodes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMasterNodes", reflect.TypeOf((*MockK8SClient)(nil).ListMasterNodes))
+}
+
+// ListNodes mocks base method.
+func (m *MockK8SClient) ListNodes() (*v12.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes")
+	ret0, _ := ret[0].(*v12.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes.
+func (mr *MockK8SClientMockRecorder) ListNodes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockK8SClient)(nil).ListNodes))
+}
+
+// ListServices mocks base method.
+func (m *MockK8SClient) ListServices(namespace string) (*v12.ServiceList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServices", namespace)
+	ret0, _ := ret[0].(*v12.ServiceList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices.
+func (mr *MockK8SClientMockRecorder) ListServices(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockK8SClient)(nil).ListServices), namespace)
+}
+
+// PatchNamespace mocks base method.
+func (m *MockK8SClient) PatchNamespace(namespace string, data []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchNamespace", namespace, data)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchNamespace indicates an expected call of PatchNamespace.
+func (mr *MockK8SClientMockRecorder) PatchNamespace(namespace, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNamespace", reflect.TypeOf((*MockK8SClient)(nil).PatchNamespace), namespace, data)
+}
+
+// PatchNodeLabels mocks base method.
+func (m *MockK8SClient) PatchNodeLabels(nodeName, nodeLabels string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchNodeLabels", nodeName, nodeLabels)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchNodeLabels indicates an expected call of PatchNodeLabels.
+func (mr *MockK8SClientMockRecorder) PatchNodeLabels(nodeName, nodeLabels interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNodeLabels", reflect.TypeOf((*MockK8SClient)(nil).PatchNodeLabels), nodeName, nodeLabels)
+}
+
+// RunOCctlCommand mocks base method.
+func (m *MockK8SClient) RunOCctlCommand(args []string, kubeconfigPath string, o ops.Ops) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunOCctlCommand", args, kubeconfigPath, o)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunOCctlCommand indicates an expected call of RunOCctlCommand.
+func (mr *MockK8SClientMockRecorder) RunOCctlCommand(args, kubeconfigPath, o interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunOCctlCommand", reflect.TypeOf((*MockK8SClient)(nil).RunOCctlCommand), args, kubeconfigPath, o)
+}
+
+// SetProxyEnvVars mocks base method.
+func (m *MockK8SClient) SetProxyEnvVars() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetProxyEnvVars")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetProxyEnvVars indicates an expected call of SetProxyEnvVars.
+func (mr *MockK8SClientMockRecorder) SetProxyEnvVars() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProxyEnvVars", reflect.TypeOf((*MockK8SClient)(nil).SetProxyEnvVars))
+}
+
+// UpdateBMH mocks base method.
+func (m *MockK8SClient) UpdateBMH(bmh *v1alpha1.BareMetalHost) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBMH", bmh)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBMH indicates an expected call of UpdateBMH.
+func (mr *MockK8SClientMockRecorder) UpdateBMH(bmh interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBMH", reflect.TypeOf((*MockK8SClient)(nil).UpdateBMH), bmh)
+}
+
+// UpdateBMHStatus mocks base method.
+func (m *MockK8SClient) UpdateBMHStatus(bmh *v1alpha1.BareMetalHost) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBMHStatus", bmh)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBMHStatus indicates an expected call of UpdateBMHStatus.
+func (mr *MockK8SClientMockRecorder) UpdateBMHStatus(bmh interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBMHStatus", reflect.TypeOf((*MockK8SClient)(nil).UpdateBMHStatus), bmh)
 }

--- a/src/ops/execute/mock_execute.go
+++ b/src/ops/execute/mock_execute.go
@@ -11,30 +11,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockExecute is a mock of Execute interface
+// MockExecute is a mock of Execute interface.
 type MockExecute struct {
 	ctrl     *gomock.Controller
 	recorder *MockExecuteMockRecorder
 }
 
-// MockExecuteMockRecorder is the mock recorder for MockExecute
+// MockExecuteMockRecorder is the mock recorder for MockExecute.
 type MockExecuteMockRecorder struct {
 	mock *MockExecute
 }
 
-// NewMockExecute creates a new mock instance
+// NewMockExecute creates a new mock instance.
 func NewMockExecute(ctrl *gomock.Controller) *MockExecute {
 	mock := &MockExecute{ctrl: ctrl}
 	mock.recorder = &MockExecuteMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExecute) EXPECT() *MockExecuteMockRecorder {
 	return m.recorder
 }
 
-// ExecCommand mocks base method
+// ExecCommand mocks base method.
 func (m *MockExecute) ExecCommand(liveLogger io.Writer, command string, args ...string) (string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{liveLogger, command}
@@ -47,7 +47,7 @@ func (m *MockExecute) ExecCommand(liveLogger io.Writer, command string, args ...
 	return ret0, ret1
 }
 
-// ExecCommand indicates an expected call of ExecCommand
+// ExecCommand indicates an expected call of ExecCommand.
 func (mr *MockExecuteMockRecorder) ExecCommand(liveLogger, command interface{}, args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{liveLogger, command}, args...)

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -12,233 +12,30 @@ import (
 	inventory_client "github.com/openshift/assisted-installer/src/inventory_client"
 )
 
-// MockOps is a mock of Ops interface
+// MockOps is a mock of Ops interface.
 type MockOps struct {
 	ctrl     *gomock.Controller
 	recorder *MockOpsMockRecorder
 }
 
-// MockOpsMockRecorder is the mock recorder for MockOps
+// MockOpsMockRecorder is the mock recorder for MockOps.
 type MockOpsMockRecorder struct {
 	mock *MockOps
 }
 
-// NewMockOps creates a new mock instance
+// NewMockOps creates a new mock instance.
 func NewMockOps(ctrl *gomock.Controller) *MockOps {
 	mock := &MockOps{ctrl: ctrl}
 	mock.recorder = &MockOpsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOps) EXPECT() *MockOpsMockRecorder {
 	return m.recorder
 }
 
-// Mkdir mocks base method
-func (m *MockOps) Mkdir(dirName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Mkdir", dirName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Mkdir indicates an expected call of Mkdir
-func (mr *MockOpsMockRecorder) Mkdir(dirName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockOps)(nil).Mkdir), dirName)
-}
-
-// WriteImageToDisk mocks base method
-func (m *MockOps) WriteImageToDisk(ignitionPath, device string, progressReporter inventory_client.InventoryClient, extra []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, progressReporter, extra)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WriteImageToDisk indicates an expected call of WriteImageToDisk
-func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, progressReporter, extra interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, progressReporter, extra)
-}
-
-// Reboot mocks base method
-func (m *MockOps) Reboot() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reboot")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Reboot indicates an expected call of Reboot
-func (mr *MockOpsMockRecorder) Reboot() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reboot", reflect.TypeOf((*MockOps)(nil).Reboot))
-}
-
-// SetBootOrder mocks base method
-func (m *MockOps) SetBootOrder(device string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetBootOrder", device)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetBootOrder indicates an expected call of SetBootOrder
-func (mr *MockOpsMockRecorder) SetBootOrder(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootOrder", reflect.TypeOf((*MockOps)(nil).SetBootOrder), device)
-}
-
-// ExtractFromIgnition mocks base method
-func (m *MockOps) ExtractFromIgnition(ignitionPath, fileToExtract string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtractFromIgnition", ignitionPath, fileToExtract)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ExtractFromIgnition indicates an expected call of ExtractFromIgnition
-func (mr *MockOpsMockRecorder) ExtractFromIgnition(ignitionPath, fileToExtract interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFromIgnition", reflect.TypeOf((*MockOps)(nil).ExtractFromIgnition), ignitionPath, fileToExtract)
-}
-
-// SystemctlAction mocks base method
-func (m *MockOps) SystemctlAction(action string, args ...string) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{action}
-	for _, a := range args {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "SystemctlAction", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SystemctlAction indicates an expected call of SystemctlAction
-func (mr *MockOpsMockRecorder) SystemctlAction(action interface{}, args ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{action}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemctlAction", reflect.TypeOf((*MockOps)(nil).SystemctlAction), varargs...)
-}
-
-// PrepareController mocks base method
-func (m *MockOps) PrepareController() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareController")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PrepareController indicates an expected call of PrepareController
-func (mr *MockOpsMockRecorder) PrepareController() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareController", reflect.TypeOf((*MockOps)(nil).PrepareController))
-}
-
-// GetVolumeGroupsByDisk mocks base method
-func (m *MockOps) GetVolumeGroupsByDisk(diskName string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVolumeGroupsByDisk", diskName)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVolumeGroupsByDisk indicates an expected call of GetVolumeGroupsByDisk
-func (mr *MockOpsMockRecorder) GetVolumeGroupsByDisk(diskName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeGroupsByDisk", reflect.TypeOf((*MockOps)(nil).GetVolumeGroupsByDisk), diskName)
-}
-
-// RemoveAllPVsOnDevice mocks base method
-func (m *MockOps) RemoveAllPVsOnDevice(diskName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveAllPVsOnDevice", diskName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveAllPVsOnDevice indicates an expected call of RemoveAllPVsOnDevice
-func (mr *MockOpsMockRecorder) RemoveAllPVsOnDevice(diskName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllPVsOnDevice", reflect.TypeOf((*MockOps)(nil).RemoveAllPVsOnDevice), diskName)
-}
-
-// RemoveVG mocks base method
-func (m *MockOps) RemoveVG(vgName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveVG", vgName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveVG indicates an expected call of RemoveVG
-func (mr *MockOpsMockRecorder) RemoveVG(vgName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVG", reflect.TypeOf((*MockOps)(nil).RemoveVG), vgName)
-}
-
-// RemovePV mocks base method
-func (m *MockOps) RemovePV(pvName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemovePV", pvName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemovePV indicates an expected call of RemovePV
-func (mr *MockOpsMockRecorder) RemovePV(pvName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePV", reflect.TypeOf((*MockOps)(nil).RemovePV), pvName)
-}
-
-// Wipefs mocks base method
-func (m *MockOps) Wipefs(device string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Wipefs", device)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Wipefs indicates an expected call of Wipefs
-func (mr *MockOpsMockRecorder) Wipefs(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wipefs", reflect.TypeOf((*MockOps)(nil).Wipefs), device)
-}
-
-// IsRaidMember mocks base method
-func (m *MockOps) IsRaidMember(device string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRaidMember", device)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsRaidMember indicates an expected call of IsRaidMember
-func (mr *MockOpsMockRecorder) IsRaidMember(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRaidMember", reflect.TypeOf((*MockOps)(nil).IsRaidMember), device)
-}
-
-// GetRaidDevices mocks base method
-func (m *MockOps) GetRaidDevices(device string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRaidDevices", device)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRaidDevices indicates an expected call of GetRaidDevices
-func (mr *MockOpsMockRecorder) GetRaidDevices(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRaidDevices", reflect.TypeOf((*MockOps)(nil).GetRaidDevices), device)
-}
-
-// CleanRaidMembership mocks base method
+// CleanRaidMembership mocks base method.
 func (m *MockOps) CleanRaidMembership(device string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanRaidMembership", device)
@@ -246,148 +43,13 @@ func (m *MockOps) CleanRaidMembership(device string) error {
 	return ret0
 }
 
-// CleanRaidMembership indicates an expected call of CleanRaidMembership
+// CleanRaidMembership indicates an expected call of CleanRaidMembership.
 func (mr *MockOpsMockRecorder) CleanRaidMembership(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRaidMembership", reflect.TypeOf((*MockOps)(nil).CleanRaidMembership), device)
 }
 
-// GetMCSLogs mocks base method
-func (m *MockOps) GetMCSLogs() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMCSLogs")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMCSLogs indicates an expected call of GetMCSLogs
-func (mr *MockOpsMockRecorder) GetMCSLogs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMCSLogs", reflect.TypeOf((*MockOps)(nil).GetMCSLogs))
-}
-
-// UploadInstallationLogs mocks base method
-func (m *MockOps) UploadInstallationLogs(isBootstrap bool) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadInstallationLogs", isBootstrap)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UploadInstallationLogs indicates an expected call of UploadInstallationLogs
-func (mr *MockOpsMockRecorder) UploadInstallationLogs(isBootstrap interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadInstallationLogs", reflect.TypeOf((*MockOps)(nil).UploadInstallationLogs), isBootstrap)
-}
-
-// ReloadHostFile mocks base method
-func (m *MockOps) ReloadHostFile(filepath string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReloadHostFile", filepath)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReloadHostFile indicates an expected call of ReloadHostFile
-func (mr *MockOpsMockRecorder) ReloadHostFile(filepath interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadHostFile", reflect.TypeOf((*MockOps)(nil).ReloadHostFile), filepath)
-}
-
-// CreateOpenshiftSshManifest mocks base method
-func (m *MockOps) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOpenshiftSshManifest", filePath, template, sshPubKeyPath)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOpenshiftSshManifest indicates an expected call of CreateOpenshiftSshManifest
-func (mr *MockOpsMockRecorder) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenshiftSshManifest", reflect.TypeOf((*MockOps)(nil).CreateOpenshiftSshManifest), filePath, template, sshPubKeyPath)
-}
-
-// GetMustGatherLogs mocks base method
-func (m *MockOps) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string) (string, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{workDir, kubeconfigPath}
-	for _, a := range images {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetMustGatherLogs", varargs...)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMustGatherLogs indicates an expected call of GetMustGatherLogs
-func (mr *MockOpsMockRecorder) GetMustGatherLogs(workDir, kubeconfigPath interface{}, images ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{workDir, kubeconfigPath}, images...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherLogs", reflect.TypeOf((*MockOps)(nil).GetMustGatherLogs), varargs...)
-}
-
-// CreateRandomHostname mocks base method
-func (m *MockOps) CreateRandomHostname(hostname string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRandomHostname", hostname)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateRandomHostname indicates an expected call of CreateRandomHostname
-func (mr *MockOpsMockRecorder) CreateRandomHostname(hostname interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRandomHostname", reflect.TypeOf((*MockOps)(nil).CreateRandomHostname), hostname)
-}
-
-// GetHostname mocks base method
-func (m *MockOps) GetHostname() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostname")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHostname indicates an expected call of GetHostname
-func (mr *MockOpsMockRecorder) GetHostname() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockOps)(nil).GetHostname))
-}
-
-// EvaluateDiskSymlink mocks base method
-func (m *MockOps) EvaluateDiskSymlink(arg0 string) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EvaluateDiskSymlink", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// EvaluateDiskSymlink indicates an expected call of EvaluateDiskSymlink
-func (mr *MockOpsMockRecorder) EvaluateDiskSymlink(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDiskSymlink", reflect.TypeOf((*MockOps)(nil).EvaluateDiskSymlink), arg0)
-}
-
-// FormatDisk mocks base method
-func (m *MockOps) FormatDisk(arg0 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatDisk", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// FormatDisk indicates an expected call of FormatDisk
-func (mr *MockOpsMockRecorder) FormatDisk(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatDisk", reflect.TypeOf((*MockOps)(nil).FormatDisk), arg0)
-}
-
-// CreateManifests mocks base method
+// CreateManifests mocks base method.
 func (m *MockOps) CreateManifests(arg0 string, arg1 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateManifests", arg0, arg1)
@@ -395,13 +57,41 @@ func (m *MockOps) CreateManifests(arg0 string, arg1 []byte) error {
 	return ret0
 }
 
-// CreateManifests indicates an expected call of CreateManifests
+// CreateManifests indicates an expected call of CreateManifests.
 func (mr *MockOpsMockRecorder) CreateManifests(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManifests", reflect.TypeOf((*MockOps)(nil).CreateManifests), arg0, arg1)
 }
 
-// DryRebootHappened mocks base method
+// CreateOpenshiftSshManifest mocks base method.
+func (m *MockOps) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOpenshiftSshManifest", filePath, template, sshPubKeyPath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOpenshiftSshManifest indicates an expected call of CreateOpenshiftSshManifest.
+func (mr *MockOpsMockRecorder) CreateOpenshiftSshManifest(filePath, template, sshPubKeyPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenshiftSshManifest", reflect.TypeOf((*MockOps)(nil).CreateOpenshiftSshManifest), filePath, template, sshPubKeyPath)
+}
+
+// CreateRandomHostname mocks base method.
+func (m *MockOps) CreateRandomHostname(hostname string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRandomHostname", hostname)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateRandomHostname indicates an expected call of CreateRandomHostname.
+func (mr *MockOpsMockRecorder) CreateRandomHostname(hostname interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRandomHostname", reflect.TypeOf((*MockOps)(nil).CreateRandomHostname), hostname)
+}
+
+// DryRebootHappened mocks base method.
 func (m *MockOps) DryRebootHappened(markerPath string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DryRebootHappened", markerPath)
@@ -409,13 +99,27 @@ func (m *MockOps) DryRebootHappened(markerPath string) bool {
 	return ret0
 }
 
-// DryRebootHappened indicates an expected call of DryRebootHappened
+// DryRebootHappened indicates an expected call of DryRebootHappened.
 func (mr *MockOpsMockRecorder) DryRebootHappened(markerPath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRebootHappened", reflect.TypeOf((*MockOps)(nil).DryRebootHappened), markerPath)
 }
 
-// ExecPrivilegeCommand mocks base method
+// EvaluateDiskSymlink mocks base method.
+func (m *MockOps) EvaluateDiskSymlink(arg0 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvaluateDiskSymlink", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// EvaluateDiskSymlink indicates an expected call of EvaluateDiskSymlink.
+func (mr *MockOpsMockRecorder) EvaluateDiskSymlink(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDiskSymlink", reflect.TypeOf((*MockOps)(nil).EvaluateDiskSymlink), arg0)
+}
+
+// ExecPrivilegeCommand mocks base method.
 func (m *MockOps) ExecPrivilegeCommand(liveLogger io.Writer, command string, args ...string) (string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{liveLogger, command}
@@ -428,14 +132,164 @@ func (m *MockOps) ExecPrivilegeCommand(liveLogger io.Writer, command string, arg
 	return ret0, ret1
 }
 
-// ExecPrivilegeCommand indicates an expected call of ExecPrivilegeCommand
+// ExecPrivilegeCommand indicates an expected call of ExecPrivilegeCommand.
 func (mr *MockOpsMockRecorder) ExecPrivilegeCommand(liveLogger, command interface{}, args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{liveLogger, command}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecPrivilegeCommand", reflect.TypeOf((*MockOps)(nil).ExecPrivilegeCommand), varargs...)
 }
 
-// ReadFile mocks base method
+// ExtractFromIgnition mocks base method.
+func (m *MockOps) ExtractFromIgnition(ignitionPath, fileToExtract string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractFromIgnition", ignitionPath, fileToExtract)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExtractFromIgnition indicates an expected call of ExtractFromIgnition.
+func (mr *MockOpsMockRecorder) ExtractFromIgnition(ignitionPath, fileToExtract interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFromIgnition", reflect.TypeOf((*MockOps)(nil).ExtractFromIgnition), ignitionPath, fileToExtract)
+}
+
+// FormatDisk mocks base method.
+func (m *MockOps) FormatDisk(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FormatDisk", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FormatDisk indicates an expected call of FormatDisk.
+func (mr *MockOpsMockRecorder) FormatDisk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatDisk", reflect.TypeOf((*MockOps)(nil).FormatDisk), arg0)
+}
+
+// GetHostname mocks base method.
+func (m *MockOps) GetHostname() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostname")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostname indicates an expected call of GetHostname.
+func (mr *MockOpsMockRecorder) GetHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockOps)(nil).GetHostname))
+}
+
+// GetMCSLogs mocks base method.
+func (m *MockOps) GetMCSLogs() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMCSLogs")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMCSLogs indicates an expected call of GetMCSLogs.
+func (mr *MockOpsMockRecorder) GetMCSLogs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMCSLogs", reflect.TypeOf((*MockOps)(nil).GetMCSLogs))
+}
+
+// GetMustGatherLogs mocks base method.
+func (m *MockOps) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{workDir, kubeconfigPath}
+	for _, a := range images {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetMustGatherLogs", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMustGatherLogs indicates an expected call of GetMustGatherLogs.
+func (mr *MockOpsMockRecorder) GetMustGatherLogs(workDir, kubeconfigPath interface{}, images ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{workDir, kubeconfigPath}, images...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherLogs", reflect.TypeOf((*MockOps)(nil).GetMustGatherLogs), varargs...)
+}
+
+// GetRaidDevices mocks base method.
+func (m *MockOps) GetRaidDevices(device string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRaidDevices", device)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRaidDevices indicates an expected call of GetRaidDevices.
+func (mr *MockOpsMockRecorder) GetRaidDevices(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRaidDevices", reflect.TypeOf((*MockOps)(nil).GetRaidDevices), device)
+}
+
+// GetVolumeGroupsByDisk mocks base method.
+func (m *MockOps) GetVolumeGroupsByDisk(diskName string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeGroupsByDisk", diskName)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeGroupsByDisk indicates an expected call of GetVolumeGroupsByDisk.
+func (mr *MockOpsMockRecorder) GetVolumeGroupsByDisk(diskName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeGroupsByDisk", reflect.TypeOf((*MockOps)(nil).GetVolumeGroupsByDisk), diskName)
+}
+
+// IsRaidMember mocks base method.
+func (m *MockOps) IsRaidMember(device string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRaidMember", device)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRaidMember indicates an expected call of IsRaidMember.
+func (mr *MockOpsMockRecorder) IsRaidMember(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRaidMember", reflect.TypeOf((*MockOps)(nil).IsRaidMember), device)
+}
+
+// Mkdir mocks base method.
+func (m *MockOps) Mkdir(dirName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Mkdir", dirName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Mkdir indicates an expected call of Mkdir.
+func (mr *MockOpsMockRecorder) Mkdir(dirName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockOps)(nil).Mkdir), dirName)
+}
+
+// PrepareController mocks base method.
+func (m *MockOps) PrepareController() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareController")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareController indicates an expected call of PrepareController.
+func (mr *MockOpsMockRecorder) PrepareController() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareController", reflect.TypeOf((*MockOps)(nil).PrepareController))
+}
+
+// ReadFile mocks base method.
 func (m *MockOps) ReadFile(filePath string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", filePath)
@@ -444,8 +298,154 @@ func (m *MockOps) ReadFile(filePath string) ([]byte, error) {
 	return ret0, ret1
 }
 
-// ReadFile indicates an expected call of ReadFile
+// ReadFile indicates an expected call of ReadFile.
 func (mr *MockOpsMockRecorder) ReadFile(filePath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockOps)(nil).ReadFile), filePath)
+}
+
+// Reboot mocks base method.
+func (m *MockOps) Reboot() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reboot")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reboot indicates an expected call of Reboot.
+func (mr *MockOpsMockRecorder) Reboot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reboot", reflect.TypeOf((*MockOps)(nil).Reboot))
+}
+
+// ReloadHostFile mocks base method.
+func (m *MockOps) ReloadHostFile(filepath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReloadHostFile", filepath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReloadHostFile indicates an expected call of ReloadHostFile.
+func (mr *MockOpsMockRecorder) ReloadHostFile(filepath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadHostFile", reflect.TypeOf((*MockOps)(nil).ReloadHostFile), filepath)
+}
+
+// RemoveAllPVsOnDevice mocks base method.
+func (m *MockOps) RemoveAllPVsOnDevice(diskName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAllPVsOnDevice", diskName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAllPVsOnDevice indicates an expected call of RemoveAllPVsOnDevice.
+func (mr *MockOpsMockRecorder) RemoveAllPVsOnDevice(diskName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllPVsOnDevice", reflect.TypeOf((*MockOps)(nil).RemoveAllPVsOnDevice), diskName)
+}
+
+// RemovePV mocks base method.
+func (m *MockOps) RemovePV(pvName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePV", pvName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePV indicates an expected call of RemovePV.
+func (mr *MockOpsMockRecorder) RemovePV(pvName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePV", reflect.TypeOf((*MockOps)(nil).RemovePV), pvName)
+}
+
+// RemoveVG mocks base method.
+func (m *MockOps) RemoveVG(vgName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveVG", vgName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveVG indicates an expected call of RemoveVG.
+func (mr *MockOpsMockRecorder) RemoveVG(vgName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVG", reflect.TypeOf((*MockOps)(nil).RemoveVG), vgName)
+}
+
+// SetBootOrder mocks base method.
+func (m *MockOps) SetBootOrder(device string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBootOrder", device)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBootOrder indicates an expected call of SetBootOrder.
+func (mr *MockOpsMockRecorder) SetBootOrder(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootOrder", reflect.TypeOf((*MockOps)(nil).SetBootOrder), device)
+}
+
+// SystemctlAction mocks base method.
+func (m *MockOps) SystemctlAction(action string, args ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{action}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SystemctlAction", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SystemctlAction indicates an expected call of SystemctlAction.
+func (mr *MockOpsMockRecorder) SystemctlAction(action interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{action}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemctlAction", reflect.TypeOf((*MockOps)(nil).SystemctlAction), varargs...)
+}
+
+// UploadInstallationLogs mocks base method.
+func (m *MockOps) UploadInstallationLogs(isBootstrap bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadInstallationLogs", isBootstrap)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UploadInstallationLogs indicates an expected call of UploadInstallationLogs.
+func (mr *MockOpsMockRecorder) UploadInstallationLogs(isBootstrap interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadInstallationLogs", reflect.TypeOf((*MockOps)(nil).UploadInstallationLogs), isBootstrap)
+}
+
+// Wipefs mocks base method.
+func (m *MockOps) Wipefs(device string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Wipefs", device)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Wipefs indicates an expected call of Wipefs.
+func (mr *MockOpsMockRecorder) Wipefs(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wipefs", reflect.TypeOf((*MockOps)(nil).Wipefs), device)
+}
+
+// WriteImageToDisk mocks base method.
+func (m *MockOps) WriteImageToDisk(ignitionPath, device string, progressReporter inventory_client.InventoryClient, extra []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteImageToDisk", ignitionPath, device, progressReporter, extra)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteImageToDisk indicates an expected call of WriteImageToDisk.
+func (mr *MockOpsMockRecorder) WriteImageToDisk(ignitionPath, device, progressReporter, extra interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), ignitionPath, device, progressReporter, extra)
 }


### PR DESCRIPTION
Due to several CVE bugs we need to update golang version to >= v1.18.1.
https://bugzilla.redhat.com/show_bug.cgi?id=2077688
https://bugzilla.redhat.com/show_bug.cgi?id=2077689

This PR updates golang version to v1.18.1 and golangci to v1.46.0.

/cc @eliorerz 