### PR TITLE
MGMT-12339: Add extra step to force clean disks with LVM volumes

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -722,7 +722,11 @@ func (i *installer) cleanupDevice(device string) error {
 		}
 	}
 
-	return i.ops.RemoveAllPVsOnDevice(device)
+	if err = i.ops.RemoveAllPVsOnDevice(device); err != nil {
+		return err
+	}
+
+	return i.ops.RemoveAllDMDevicesOnDisk(device)
 }
 
 func (i *installer) verifyHostCanMoveToConfigurationStatus(inventoryHostsMapWithIp map[string]inventory_client.HostData) {

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -86,6 +86,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	cleanInstallDevice := func() {
 		mockops.EXPECT().GetVolumeGroupsByDisk(device).Return([]string{}, nil).Times(1)
 		mockops.EXPECT().RemoveAllPVsOnDevice(device).Return(nil).Times(1)
+		mockops.EXPECT().RemoveAllDMDevicesOnDisk(device).Return(nil).Times(1)
 		mockops.EXPECT().IsRaidMember(device).Return(false).Times(1)
 		mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 	}
@@ -175,6 +176,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockops.EXPECT().RemoveVG("vg1").Times(1)
 			mockops.EXPECT().RemoveVG("vg2").Times(1)
 			mockops.EXPECT().RemoveAllPVsOnDevice("/dev/vda").Return(nil).Times(1)
+			mockops.EXPECT().RemoveAllDMDevicesOnDisk("/dev/vda").Return(nil).Times(1)
 			err := installerObj.cleanupDevice("/dev/vda")
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -190,6 +192,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockops.EXPECT().RemoveVG("vg2").Times(1).Return(errors.New(fmt.Sprintf("Failed to remove VG %s, output %s, error %s", "vg2", "some arbitrary output", "some arbitrary error")))
 			mockops.EXPECT().RemoveVG("vg3").Times(0)
 			mockops.EXPECT().RemoveAllPVsOnDevice("/dev/vda").Return(nil).Times(0)
+			mockops.EXPECT().RemoveAllDMDevicesOnDisk("/dev/vda").Return(nil).Times(0)
 			err := installerObj.cleanupDevice("/dev/vda")
 			Expect(err).To(HaveOccurred())
 		})
@@ -596,6 +599,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().IsRaidMember(device).Return(false).Times(1)
 				mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(device).Return(nil).Times(1)
+				mockops.EXPECT().RemoveAllDMDevicesOnDisk(device).Return(nil).Times(1)
 			}
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})
 			cleanInstallDeviceClean()
@@ -619,10 +623,12 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVolumeGroupsByDisk(device).Return([]string{}, nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(device).Return(nil).Times(1)
+				mockops.EXPECT().RemoveAllDMDevicesOnDisk(device).Return(nil).Times(1)
 				mockops.EXPECT().IsRaidMember(device).Return(true).Times(1)
 				mockops.EXPECT().GetRaidDevices(device).Return([]string{raidDevice}, nil).Times(1)
 				mockops.EXPECT().GetVolumeGroupsByDisk(raidDevice).Return([]string{}, nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(raidDevice).Return(nil).Times(1)
+				mockops.EXPECT().RemoveAllDMDevicesOnDisk(raidDevice).Return(nil).Times(1)
 				mockops.EXPECT().CleanRaidMembership(device).Return(nil).Times(1)
 				mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 			}
@@ -639,10 +645,12 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVolumeGroupsByDisk(device).Return([]string{}, nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(device).Return(nil).Times(1)
+				mockops.EXPECT().RemoveAllDMDevicesOnDisk(device).Return(nil).Times(1)
 				mockops.EXPECT().IsRaidMember(device).Return(true).Times(1)
 				mockops.EXPECT().GetRaidDevices(device).Return([]string{raidDevice}, nil).Times(1)
 				mockops.EXPECT().GetVolumeGroupsByDisk(raidDevice).Return([]string{}, nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(raidDevice).Return(nil).Times(1)
+				mockops.EXPECT().RemoveAllDMDevicesOnDisk(raidDevice).Return(nil).Times(1)
 				mockops.EXPECT().CleanRaidMembership(device).Return(err).Times(1)
 			}
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -332,6 +332,20 @@ func (mr *MockOpsMockRecorder) ReloadHostFile(filepath interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadHostFile", reflect.TypeOf((*MockOps)(nil).ReloadHostFile), filepath)
 }
 
+// RemoveAllDMDevicesOnDisk mocks base method.
+func (m *MockOps) RemoveAllDMDevicesOnDisk(diskName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAllDMDevicesOnDisk", diskName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAllDMDevicesOnDisk indicates an expected call of RemoveAllDMDevicesOnDisk.
+func (mr *MockOpsMockRecorder) RemoveAllDMDevicesOnDisk(diskName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllDMDevicesOnDisk", reflect.TypeOf((*MockOps)(nil).RemoveAllDMDevicesOnDisk), diskName)
+}
+
 // RemoveAllPVsOnDevice mocks base method.
 func (m *MockOps) RemoveAllPVsOnDevice(diskName string) error {
 	m.ctrl.T.Helper()

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -41,6 +41,7 @@ type Ops interface {
 	PrepareController() error
 	GetVolumeGroupsByDisk(diskName string) ([]string, error)
 	RemoveAllPVsOnDevice(diskName string) error
+	RemoveAllDMDevicesOnDisk(diskName string) error
 	RemoveVG(vgName string) error
 	RemovePV(pvName string) error
 	Wipefs(device string) error
@@ -422,6 +423,58 @@ func (o *ops) RemoveAllPVsOnDevice(diskName string) error {
 		err = o.RemovePV(pv)
 		if err != nil {
 			o.log.Errorf("Failed remove pv %s from disk %s", pv, diskName)
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *ops) getDMDevices(diskName string) ([]string, error) {
+	var dmDevices []string
+	output, err := o.ExecPrivilegeCommand(o.logWriter, "dmsetup", "ls")
+	if err != nil {
+		o.log.Errorf("Failed to list DM devices in the system")
+		return dmDevices, err
+	}
+
+	if strings.TrimSuffix(output, "\n") == "No devices found" {
+		return dmDevices, nil
+	}
+
+	diskBasename := filepath.Base(diskName)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		dmDevice := strings.Split(line, "\t")[0]
+		output, err = o.ExecPrivilegeCommand(o.logWriter, "dmsetup", "deps", "-o", "devname", dmDevice)
+		if err != nil {
+			o.log.Errorf("Failed to get parent device for DM device %s", dmDevice)
+			return dmDevices, err
+		}
+		if strings.Contains(output, "("+diskBasename) {
+			dmDevices = append(dmDevices, dmDevice)
+		}
+	}
+	return dmDevices, nil
+}
+
+func (o *ops) RemoveDMDevice(dmDevice string) error {
+	output, err := o.ExecPrivilegeCommand(o.logWriter, "dmsetup", "remove", "--retry", dmDevice)
+	if err != nil {
+		o.log.Errorf("Failed to remove DM device %s, output %s, error %s", dmDevice, output, err)
+	}
+	return err
+}
+
+func (o *ops) RemoveAllDMDevicesOnDisk(diskName string) error {
+	dmDevices, err := o.getDMDevices(diskName)
+	if err != nil {
+		return err
+	}
+	for _, dmDevice := range dmDevices {
+		o.log.Infof("Removing DM device %s", dmDevice)
+		err = o.RemoveDMDevice(dmDevice)
+		if err != nil {
+			o.log.Errorf("Failed to remove DM device %s", dmDevice)
 			return err
 		}
 	}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -414,6 +414,7 @@ func (o *ops) getDiskPVs(diskName string) ([]string, error) {
 }
 
 func (o *ops) RemoveAllPVsOnDevice(diskName string) error {
+	var ret error
 	pvs, err := o.getDiskPVs(diskName)
 	if err != nil {
 		return err
@@ -423,10 +424,10 @@ func (o *ops) RemoveAllPVsOnDevice(diskName string) error {
 		err = o.RemovePV(pv)
 		if err != nil {
 			o.log.Errorf("Failed remove pv %s from disk %s", pv, diskName)
-			return err
+			ret = utils.CombineErrors(ret, err)
 		}
 	}
-	return nil
+	return ret
 }
 
 func (o *ops) getDMDevices(diskName string) ([]string, error) {
@@ -466,6 +467,7 @@ func (o *ops) RemoveDMDevice(dmDevice string) error {
 }
 
 func (o *ops) RemoveAllDMDevicesOnDisk(diskName string) error {
+	var ret error
 	dmDevices, err := o.getDMDevices(diskName)
 	if err != nil {
 		return err
@@ -475,10 +477,10 @@ func (o *ops) RemoveAllDMDevicesOnDisk(diskName string) error {
 		err = o.RemoveDMDevice(dmDevice)
 		if err != nil {
 			o.log.Errorf("Failed to remove DM device %s", dmDevice)
-			return err
+			ret = utils.CombineErrors(ret, err)
 		}
 	}
-	return nil
+	return ret
 }
 
 func (o *ops) RemoveVG(vgName string) error {

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -308,3 +308,10 @@ func GetOutboundIP() (string, error) {
 
 	return localAddr.(*net.UDPAddr).IP.String(), nil
 }
+
+func CombineErrors(error1 error, error2 error) error {
+	if error1 != nil {
+		return errors.Wrapf(error1, "%s", error2)
+	}
+	return error2
+}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -114,5 +116,26 @@ var _ = Describe("Verify_utils", func() {
 			Expect(callCount).Should(Equal(tries))
 
 		})
+	})
+})
+
+var _ = Describe("CombineErrors", func() {
+	var (
+		error1       = errors.New("One")
+		error2       = errors.New("Two")
+		textCombined = fmt.Sprintf("%s", errors.Wrapf(error1, "%s", error2))
+	)
+	It("When both errors are nil, return nil", func() {
+		err := CombineErrors(nil, nil)
+		Expect(err).Should(BeNil())
+	})
+	It("When error1 is nil, return error2", func() {
+		err := CombineErrors(nil, error2)
+		Expect(err).Should(Equal(error2))
+	})
+	It("When both errors exist, combine them", func() {
+		err := CombineErrors(error1, error2)
+		textErr := fmt.Sprintf("%s", err)
+		Expect(textErr).Should(Equal(textCombined))
 	})
 })


### PR DESCRIPTION
Forcing the removal of affected DeviceMapper devices should fix the problems when properly running disk_speed_check before disk cleanup

/cc @vrutkovs 
/cc @paul-maidment 