### PR TITLE
MGMT-12840: set restricted list of approvers for 2.7

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,29 +2,7 @@
 
 aliases:
   approvers:
-    - avishayt
-    - eranco74
-    - filanov
-    - eliorerz
-    - gamli75
-    - ori-amizur
     - romfreiman
-    - tsorya
-    - nmagnezi
-    - carbonin
-    - danielerez
-    - slaviered
+    - filanov
+    - gamli75
     - osherdp
-    - flaper87
-    - mkowalski
-    - omertuc
-    - paul-maidment
-    - rccrdpccl
-    - jhernand
-    - adriengentil
-  emeritus_approvers:
-    - empovit
-    - celebdor
-    - yevgeny-shnaidman
-    - lranjbar
-    - ybettan


### PR DESCRIPTION
Since there are (currently) no label restrictions on attached Jira bugs, we don't have a good way to enforce people are only merging bug-fixes / security-patches.
Setting a smaller approvers list can help us enforce this kind of restriction (list might change later on, if needed)

/cc @filanov @gamli75 @romfreiman 