### PR TITLE
MGMT-12339: Update host install progress on cleanup error

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -95,6 +95,7 @@ func (i *installer) InstallNode() error {
 	i.Config.Device = i.ops.EvaluateDiskSymlink(i.Config.Device)
 	err := i.cleanupInstallDevice()
 	if err != nil {
+		i.UpdateHostInstallProgress(models.HostStageStartingInstallation, fmt.Sprintf("Could not clean install device %s. The installation will continue. If the installation fails, clean the disk and try again", i.Device))
 		// Do not change the phrasing of this error message, as we rely on it in a triage signature
 		i.log.Errorf("failed to prepare install device %s, err %s", i.Device, err)
 	}

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -610,6 +610,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("HostRoleMaster role failed to cleanup disk continues installation", func() {
 			err := fmt.Errorf("Failed to remove vg")
+			cleanupErrorText := fmt.Sprintf("Could not clean install device %s. The installation will continue. If the installation fails, clean the disk and try again", device)
 			cleanInstallDeviceError := func() {
 				mockops.EXPECT().GetVolumeGroupsByDisk(device).Return([]string{"vg1"}, nil).Times(1)
 				mockops.EXPECT().RemoveVG("vg1").Return(err).Times(1)
@@ -619,7 +620,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().Wipefs(device).Times(1)
 				mockops.EXPECT().Mkdir(InstallDir).Return(err).Times(1)
 			}
-			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})
+			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}, {string(models.HostStageStartingInstallation), cleanupErrorText}})
 			cleanInstallDeviceError()
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(err))
@@ -646,7 +647,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("HostRoleMaster role raid cleanup disk - failed continues installation", func() {
 			err := fmt.Errorf("failed cleaning raid device")
-
+			cleanupErrorText := fmt.Sprintf("Could not clean install device %s. The installation will continue. If the installation fails, clean the disk and try again", device)
 			cleanInstallDeviceClean := func() {
 				mockops.EXPECT().GetVolumeGroupsByDisk(device).Return([]string{}, nil).Times(1)
 				mockops.EXPECT().RemoveAllPVsOnDevice(device).Return(nil).Times(1)
@@ -660,7 +661,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().Wipefs(device).Return(nil).Times(1)
 				mockops.EXPECT().Mkdir(InstallDir).Return(err).Times(1)
 			}
-			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}})
+			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role}, {string(models.HostStageStartingInstallation), cleanupErrorText}})
 			cleanInstallDeviceClean()
 			ret := installerObj.InstallNode()
 			Expect(ret).Should(Equal(err))


### PR DESCRIPTION
Update the host install progress with a message if disk cleanup failed. This way we can catch it in assisted-service and emit an event that will ease debugging

/cc @eranco74 