### PR TITLE
MGMT-13229: SNO: Start controller when node is not ready, right after joined

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -75,6 +75,10 @@ spec:
               mountPath: /tmp/var-run-resolv.conf
             - name: host-resolv-conf
               mountPath: /tmp/host-resolv.conf
+          {{if .SNO}}
+            - name: sno-bootstrap-files
+              mountPath: /tmp/bootstrap-secrets
+          {{end}}
           {{if .CACertPath}}
             - name: service-ca-cert-config
               mountPath: {{.CACertPath}}
@@ -88,6 +92,14 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
         operator: Exists
+      {{if .SNO}}
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/network-unavailable
+        operator: Exists
+      {{end}}
       volumes:
         - name: host-ca-bundle
           hostPath:
@@ -98,6 +110,11 @@ spec:
         - name: host-resolv-conf
           hostPath:
             path: /etc/resolv.conf
+        {{if .SNO}}
+        - name: sno-bootstrap-files
+          hostPath:
+            path: /etc/kubernetes/bootstrap-secrets
+        {{end}}
         {{if .CACertPath}}
         - name: service-ca-cert-config
           hostPath:

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/thoas/go-funk"
+
 	"github.com/hashicorp/go-version"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -246,7 +248,7 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 		}
 		common.LogIfHostIpChanged(c.log, node, knownIpAddresses)
 
-		if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
+		if funk.Contains([]models.HostStage{models.HostStageConfiguring, models.HostStageRebooting}, host.Host.Progress.CurrentStage) {
 			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
 				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
 			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -40,6 +40,7 @@ var Options struct {
 const (
 	maximumInventoryClientRetries = 15
 	maximumErrorsBeforeExit       = 3
+	bootstrapKubeconfigForSNO     = "/tmp/bootstrap-secrets/kubeconfig"
 )
 
 func DryRebootComplete() bool {
@@ -83,7 +84,13 @@ func main() {
 
 	var kc k8s_client.K8SClient
 	if !Options.ControllerConfig.DryRunEnabled {
-		kc, err = k8s_client.NewK8SClient("", logger)
+		// in case of sno we want controller to start as fast as possible,
+		//in that case we want to use kubeconfig from filesystem and not pulling it from api
+		k8sConfigPath := ""
+		if _, errB := os.Stat(bootstrapKubeconfigForSNO); errB == nil {
+			k8sConfigPath = bootstrapKubeconfigForSNO
+		}
+		kc, err = k8s_client.NewK8SClient(k8sConfigPath, logger)
 		if err != nil {
 			log.Fatalf("Failed to create k8 client %v", err)
 		}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/openshift/assisted-service/models"
+
 	"github.com/openshift/assisted-installer/src/ops/execute"
 
 	"io/ioutil"
@@ -339,6 +341,10 @@ func (o *ops) renderControllerPod() error {
 
 	if o.installerConfig.ServiceIPs != "" {
 		params["ServiceIPs"] = strings.Split(o.installerConfig.ServiceIPs, ",")
+	}
+
+	if o.installerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+		params["SNO"] = true
 	}
 
 	return o.renderDeploymentFiles(filepath.Join(controllerDeployFolder, controllerDeployPodTemplate),


### PR DESCRIPTION
[MGMT-13229](https://issues.redhat.com//browse/MGMT-13229): SNO: Start controller when node is not ready, right after joined
     We want to start controller as fast as possible after reboot and to minimize time when we don't know what is going on.
    This will allow us to start when kubelet will join to itself and we will be able
    to send joined stage to service and wait till node will become ready while controller is running already.
    In order to start running while control plane kube-api doesn't exists yet , going to use bootstrap kubeconfig as it is part of filesystem.