### PR TITLE
MGMT-13131: shorten SNO installation duration

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -166,7 +166,7 @@ func (o *ops) FormatDisk(disk string) error {
 
 func (o *ops) Reboot() error {
 	o.log.Info("Rebooting node")
-	_, err := o.ExecPrivilegeCommand(o.logWriter, "shutdown", "-r", "+1", "'Installation completed, server is going to reboot.'")
+	_, err := o.ExecPrivilegeCommand(o.logWriter, "shutdown", "-r", "now", "'Installation completed, server is going to reboot.'")
 	if err != nil {
 		o.log.Errorf("Failed to reboot node, err: %s", err)
 		return err


### PR DESCRIPTION
Execute shutdown -r now instead of 1 minute from now this should save 1 minute during the installation
The side effect of this change is that the agent will not report back the install command result upon success
This side effect can be mitigated by adding inhibit lock on the agent side that will prevent the node from rebooting until the agent allow it.