### PR TITLE
MGMT-13229: SNO: Start controller when node is not ready, right after joined + sending-logs

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -75,6 +75,10 @@ spec:
               mountPath: /tmp/var-run-resolv.conf
             - name: host-resolv-conf
               mountPath: /tmp/host-resolv.conf
+          {{if .SNO}}
+            - name: sno-bootstrap-kubeconfig
+              mountPath: /tmp/bootstrap-kubeconfig
+          {{end}}
           {{if .CACertPath}}
             - name: service-ca-cert-config
               mountPath: {{.CACertPath}}
@@ -88,6 +92,14 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
         operator: Exists
+      {{if .SNO}}
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/network-unavailable
+        operator: Exists
+      {{end}}
       volumes:
         - name: host-ca-bundle
           hostPath:
@@ -98,6 +110,11 @@ spec:
         - name: host-resolv-conf
           hostPath:
             path: /etc/resolv.conf
+        {{if .SNO}}
+        - name: sno-bootstrap-kubeconfig
+          hostPath:
+            path: /etc/kubernetes/bootstrap-secrets/kubeconfig
+        {{end}}
         {{if .CACertPath}}
         - name: service-ca-cert-config
           hostPath:

--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -16,6 +16,10 @@ spec:
             - "assisted-api.local.openshift.io"{{end}}{{end}}
       containers:
         - name: assisted-installer-controller
+          {{if .SNO}}
+          securityContext:
+            runAsUser: 0
+          {{end}}
           image: {{.ControllerImage}}
           imagePullPolicy: IfNotPresent
           env:
@@ -78,6 +82,10 @@ spec:
           {{if .SNO}}
             - name: sno-bootstrap-kubeconfig
               mountPath: /tmp/bootstrap-kubeconfig
+            - name: pods-logs
+              mountPath: /tmp/node-pod-logs
+            - name: journal
+              mountPath: /tmp/node-journal
           {{end}}
           {{if .CACertPath}}
             - name: service-ca-cert-config
@@ -85,6 +93,9 @@ spec:
           {{end}}
       restartPolicy: OnFailure
       hostNetwork: true
+      {{if .SNO}}
+      privileged: true
+      {{end}}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       serviceAccountName: assisted-installer-controller
@@ -114,6 +125,12 @@ spec:
         - name: sno-bootstrap-kubeconfig
           hostPath:
             path: /etc/kubernetes/bootstrap-secrets/kubeconfig
+        - name: pods-logs
+          hostPath:
+            path: /var/log/pods
+        - name: journal
+          hostPath:
+            path: /var/log/journal
         {{end}}
         {{if .CACertPath}}
         - name: service-ca-cert-config

--- a/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
@@ -190,6 +190,7 @@ rules:
       - "hostnetwork"
       - "hostaccess"
       - "node-exporter"
+      - "privileged"
     resources:
       - securitycontextconstraints
     verbs:

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/thoas/go-funk"
+
 	"github.com/hashicorp/go-version"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -246,7 +248,7 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 		}
 		common.LogIfHostIpChanged(c.log, node, knownIpAddresses)
 
-		if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
+		if funk.Contains([]models.HostStage{models.HostStageConfiguring, models.HostStageRebooting}, host.Host.Progress.CurrentStage) {
 			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
 				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
 			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -304,12 +304,37 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			Expect(exit).Should(Equal(true))
 		})
 
-		It("WaitAndUpdateNodesStatus including joined state", func() {
+		It("WaitAndUpdateNodesStatus including joined state from configuring", func() {
 			joined := []models.HostStage{models.HostStageJoined,
 				models.HostStageJoined,
 				models.HostStageJoined}
 
 			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageConfiguring, "")
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+				Return(hosts, nil).Times(2)
+			// not ready nodes
+			nodes := GetKubeNodes(kubeNamesIds)
+			for _, node := range nodes.Items {
+				for i, cond := range node.Status.Conditions {
+					if cond.Type == v1.NodeReady {
+						node.Status.Conditions[i].Status = v1.ConditionFalse
+					}
+				}
+			}
+			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
+			updateProgressSuccess(joined, inventoryNamesIds)
+			configuringSuccess()
+
+			exit := assistedController.waitAndUpdateNodesStatus()
+			Expect(exit).Should(Equal(false))
+		})
+
+		It("WaitAndUpdateNodesStatus including joined state from reboot", func() {
+			joined := []models.HostStage{models.HostStageJoined,
+				models.HostStageJoined,
+				models.HostStageJoined}
+
+			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageRebooting, "")
 			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
 				Return(hosts, nil).Times(2)
 			// not ready nodes

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -40,6 +40,7 @@ var Options struct {
 const (
 	maximumInventoryClientRetries = 15
 	maximumErrorsBeforeExit       = 3
+	bootstrapKubeconfigForSNO     = "/tmp/bootstrap-kubeconfig"
 )
 
 func DryRebootComplete() bool {
@@ -83,7 +84,13 @@ func main() {
 
 	var kc k8s_client.K8SClient
 	if !Options.ControllerConfig.DryRunEnabled {
-		kc, err = k8s_client.NewK8SClient("", logger)
+		// in case of sno we want controller to start as fast as possible,
+		//in that case we want to use kubeconfig from filesystem and not pulling it from api
+		k8sConfigPath := ""
+		if _, errB := os.Stat(bootstrapKubeconfigForSNO); errB == nil {
+			k8sConfigPath = bootstrapKubeconfigForSNO
+		}
+		kc, err = k8s_client.NewK8SClient(k8sConfigPath, logger)
 		if err != nil {
 			log.Fatalf("Failed to create k8 client %v", err)
 		}

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -49,6 +49,21 @@ func (mr *MockOpsMockRecorder) CleanRaidMembership(device interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRaidMembership", reflect.TypeOf((*MockOps)(nil).CleanRaidMembership), device)
 }
 
+// CollectHostLogs mocks base method.
+func (m *MockOps) CollectHostLogs() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CollectHostLogs")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CollectHostLogs indicates an expected call of CollectHostLogs.
+func (mr *MockOpsMockRecorder) CollectHostLogs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectHostLogs", reflect.TypeOf((*MockOps)(nil).CollectHostLogs))
+}
+
 // CreateManifests mocks base method.
 func (m *MockOps) CreateManifests(arg0 string, arg1 []byte) error {
 	m.ctrl.T.Helper()
@@ -419,6 +434,21 @@ func (mr *MockOpsMockRecorder) SystemctlAction(action interface{}, args ...inter
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{action}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemctlAction", reflect.TypeOf((*MockOps)(nil).SystemctlAction), varargs...)
+}
+
+// TarFolder mocks base method.
+func (m *MockOps) TarFolder(pathToFolder, outPutTarName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TarFolder", pathToFolder, outPutTarName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TarFolder indicates an expected call of TarFolder.
+func (mr *MockOpsMockRecorder) TarFolder(pathToFolder, outPutTarName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TarFolder", reflect.TypeOf((*MockOps)(nil).TarFolder), pathToFolder, outPutTarName)
 }
 
 // UploadInstallationLogs mocks base method.

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/openshift/assisted-service/models"
+
 	"github.com/openshift/assisted-installer/src/ops/execute"
 
 	"io/ioutil"
@@ -339,6 +341,10 @@ func (o *ops) renderControllerPod() error {
 
 	if o.installerConfig.ServiceIPs != "" {
 		params["ServiceIPs"] = strings.Split(o.installerConfig.ServiceIPs, ",")
+	}
+
+	if o.installerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+		params["SNO"] = true
 	}
 
 	return o.renderDeploymentFiles(filepath.Join(controllerDeployFolder, controllerDeployPodTemplate),


### PR DESCRIPTION
    MGMT-13229: SNO: Start controller when node is not ready, right after joined
     We want to start controller as fast as possible after reboot and to minimize time when we don't know what is going on.
    This will allow us to start when kubelet will join to itself and we will be able
    to send joined stage to service and wait till node will become ready while controller is running already.
    In order to start running while control plane kube-api doesn't exists yet , going to use bootstrap kubeconfig as it is part of filesystem.

    MGMT-13229: In sno case we want to send host logs.
    Mounting host pods logs and journal to assisted controller, sending them
    in case of failure.
    Ordering logs sending in order not to override previous sended logs in
    case of must gather failure
