### PR TITLE
MGMT-13463: Assisted-controller can fail to send summary logs and we  will not have any logs

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -1220,7 +1220,7 @@ func (c controller) uploadSummaryLogs(podName string, namespace string, sinceSec
 
 	go func() {
 		defer pw.Close()
-		err := utils.WriteToTarGz(pw, tarentries)
+		err := utils.WriteToTarGz(pw, tarentries, c.log)
 		if err != nil {
 			c.log.WithError(err).Warnf("Failed to create tar.gz body of the log uplaod request")
 		}

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -374,7 +374,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 			}
 			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
-			updateProgressSuccess(joined, inventoryNamesIds)
+			updateProgressSuccess(joined, hosts)
 			mockk8sclient.EXPECT().GetPods(gomock.Any(), gomock.Any(), "").Return([]v1.Pod{}, nil).AnyTimes()
 
 			exit := assistedController.waitAndUpdateNodesStatus()

--- a/src/common/common.go
+++ b/src/common/common.go
@@ -130,7 +130,7 @@ func UploadPodLogs(kc k8s_client.K8SClient, ic inventory_client.InventoryClient,
 	go func() {
 		defer pw.Close()
 		tarEntry := utils.NewTarEntry(podLogs, nil, int64(podLogs.Len()), fmt.Sprintf("%s.logs", podName))
-		err := utils.WriteToTarGz(pw, []utils.TarEntry{*tarEntry})
+		err := utils.WriteToTarGz(pw, []utils.TarEntry{*tarEntry}, log)
 		if err != nil {
 			log.WithError(err).Warnf("Failed to create tar.gz")
 		}

--- a/src/utils/tarutil.go
+++ b/src/utils/tarutil.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 type TarEntry struct {
@@ -42,7 +44,8 @@ func NewTarEntryFromFile(path string) (*TarEntry, error) {
 	return NewTarEntry(bufio.NewReader(fd), fd, fi.Size(), fi.Name()), nil
 }
 
-func WriteToTarGz(w io.Writer, entries []TarEntry) error {
+// We should try to send data even if one of the tarEntries fails
+func WriteToTarGz(w io.Writer, entries []TarEntry, log logrus.FieldLogger) error {
 	// now lets create the header as needed for this file within the tarball
 	gw := gzip.NewWriter(w)
 	defer gw.Close()
@@ -53,14 +56,16 @@ func WriteToTarGz(w io.Writer, entries []TarEntry) error {
 		// write the header to the tarball archive
 		header := *tarEntry.Header
 		if err := tw.WriteHeader(&header); err != nil {
-			return err
+			log.WithError(err).Errorf("Failed to write header to %s", tarEntry.Header.Name)
+			continue
 		}
 		// copy the file data to the tarball
 		if tarEntry.Closer != nil {
 			defer tarEntry.Closer.Close()
 		}
 		if _, err := io.Copy(tw, tarEntry.Reader); err != nil {
-			return err
+			log.WithError(err).Errorf("Failed to copy %s", tarEntry.Header.Name)
+			continue
 		}
 	}
 	return nil

--- a/src/utils/tarutil_test.go
+++ b/src/utils/tarutil_test.go
@@ -27,7 +27,7 @@ var _ = Describe("tar_utils", func() {
 			h2, err := NewTarEntryFromFile("../../test_files/tartest.tar.gz")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = WriteToTarGz(&outbuf, []TarEntry{*h1, *h2})
+			err = WriteToTarGz(&outbuf, []TarEntry{*h1, *h2}, l)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verify tar gz structure")


### PR DESCRIPTION
[MGMT-13463](https://issues.redhat.com//browse/MGMT-13463): Assisted-controller can fail to send summary logs and we will not have any logs

Sometimes controller can fail to stream tar.gz of must-gather and no files will be send as we will close write pipe and will not try to stream another tar entry.
This change will log the error but will try to stream all other tar entries we pass to the stream function