### PR TITLE
MGMT-13507: Apply node labels only when node is Ready

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -1069,6 +1069,9 @@ func (c controller) patchNodesLabels(log logrus.FieldLogger, hostsWithLabels map
 	}
 
 	for _, node := range nodes.Items {
+		if !common.IsK8sNodeIsReady(node) {
+			continue
+		}
 		host, ok := common.HostMatchByNameOrIPAddress(node, hostsWithLabels, knownIpAddresses)
 		if !ok {
 			continue

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -1103,24 +1103,35 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			// 3. Set last node as ready and patch labels for it
 			It("Set label only in when nodes are ready", func() {
 				nodeLabels := `{"node.ocs.openshift.io/storage":""}`
-				notReadyNodeName := ""
-				k8sNodesWith1NotReady := GetKubeNodes(kubeNamesIds)
-				for i, cond := range k8sNodesWith1NotReady.Items[0].Status.Conditions {
+				k8sReadyNodes := GetKubeNodes(kubeNamesIds)
+				k8sNodesWith1NotReady := k8sReadyNodes.DeepCopy()
+				conds := k8sNodesWith1NotReady.Items[0].Status.Conditions
+				for i, cond := range conds {
 					if cond.Type == v1.NodeReady {
-						k8sNodesWith1NotReady.Items[0].Status.Conditions[i].Status = v1.ConditionFalse
+						conds[i].Status = v1.ConditionFalse
 					}
-					notReadyNodeName = k8sNodesWith1NotReady.Items[0].Name
 				}
+				k8sNodesWith1NotReady.Items[0].Status.Conditions = conds
+				notReadyNodeName := k8sNodesWith1NotReady.Items[0].Name
 
 				hosts := create3Hosts(models.HostStatusInstalled, models.HostStageDone, nodeLabels)
 				mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled, models.HostStatusError}).
 					Return(hosts, nil).Times(2)
+
+				// set node labels to k8s object for 2 already patched nodes
+				k8sReadyNodes.Items[1].ObjectMeta.Labels["node.ocs.openshift.io/storage"] = ""
+				k8sReadyNodes.Items[2].ObjectMeta.Labels["node.ocs.openshift.io/storage"] = ""
+
 				// first run with 2 ready nodes
-				mockk8sclient.EXPECT().ListNodes().Return(k8sNodesWith1NotReady, nil).Times(1)
-				// Set 3rd node as ready
-				mockk8sclient.EXPECT().ListNodes().Return(GetKubeNodes(kubeNamesIds), nil).Times(1)
-				mockk8sclient.EXPECT().PatchNodeLabels(gomock.Any(), nodeLabels).Return(nil).Times(2)
-				mockk8sclient.EXPECT().PatchNodeLabels(notReadyNodeName, nodeLabels).Return(nil).Times(1)
+				gomock.InOrder(
+					mockk8sclient.EXPECT().ListNodes().Return(k8sNodesWith1NotReady, nil).Times(1),
+					mockk8sclient.EXPECT().ListNodes().Return(k8sReadyNodes, nil).Times(1),
+				)
+
+				gomock.InOrder(
+					mockk8sclient.EXPECT().PatchNodeLabels(gomock.Any(), nodeLabels).Return(nil).Times(2),
+					mockk8sclient.EXPECT().PatchNodeLabels(notReadyNodeName, nodeLabels).Return(nil).Times(1),
+				)
 
 				wg.Add(1)
 				assistedController.UpdateNodeLabels(context.TODO(), &wg)
@@ -1934,12 +1945,14 @@ var _ = Describe("installer HostRoleMaster role", func() {
 func GetKubeNodes(kubeNamesIds map[string]string) *v1.NodeList {
 	file, _ := ioutil.ReadFile("../../test_files/node.json")
 	var node v1.Node
-	_ = json.Unmarshal(file, &node)
+	err := json.Unmarshal(file, &node)
+	Expect(err).ToNot(HaveOccurred())
 	nodeList := &v1.NodeList{}
 	for name, id := range kubeNamesIds {
 		node.Status.NodeInfo.SystemUUID = id
 		node.Name = name
-		nodeList.Items = append(nodeList.Items, node)
+		newNode := node.DeepCopy()
+		nodeList.Items = append(nodeList.Items, *newNode)
 	}
 	return nodeList
 }


### PR DESCRIPTION
[MGMT-13507](https://issues.redhat.com//browse/MGMT-13507): Apply node labels only when node is Ready
Juniper have a problem with their deployment in case we apply node labels before node is read.
In order to fix it we should apply them only in case node is ready