### PR TITLE
MULTIARCH-3387: Set boot device to target disk for powervm

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -182,7 +182,8 @@ func (o *ops) SetBootOrder(device string) error {
 	}
 
 	o.log.Infof("SetBootOrder, runtime.GOARCH: %s, device: %s", runtime.GOARCH, device)
-	if runtime.GOARCH == "ppc64le" {
+	_, err := o.ExecPrivilegeCommand(nil, "test", "-f", "/usr/sbin/bootlist")
+	if err == nil {
 		_, err := o.ExecPrivilegeCommand(o.logWriter, "bootlist", "-m", "normal", "-o", device)
 		if err != nil {
 			o.log.WithError(err).Errorf("Failed to set boot disk with bootlist. Skipping...")
@@ -190,7 +191,7 @@ func (o *ops) SetBootOrder(device string) error {
 		return nil
 	}
 
-	_, err := o.ExecPrivilegeCommand(nil, "test", "-d", "/sys/firmware/efi")
+	_, err = o.ExecPrivilegeCommand(nil, "test", "-d", "/sys/firmware/efi")
 	if err != nil {
 		o.log.Info("setting the boot order on BIOS systems is not supported. Skipping...")
 		return nil

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -184,7 +184,7 @@ func (o *ops) SetBootOrder(device string) error {
 	o.log.Infof("SetBootOrder, runtime.GOARCH: %s, device: %s", runtime.GOARCH, device)
 	_, err := o.ExecPrivilegeCommand(nil, "test", "-f", "/usr/sbin/bootlist")
 	if err == nil {
-		_, err := o.ExecPrivilegeCommand(o.logWriter, "bootlist", "-m", "normal", "-o", device)
+		_, err = o.ExecPrivilegeCommand(o.logWriter, "bootlist", "-m", "normal", "-o", device)
 		if err != nil {
 			o.log.WithError(err).Errorf("Failed to set boot disk with bootlist. Skipping...")
 		}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -181,6 +181,15 @@ func (o *ops) SetBootOrder(device string) error {
 		return nil
 	}
 
+	o.log.Infof("SetBootOrder, runtime.GOARCH: %s, device: %s", runtime.GOARCH, device)
+	if runtime.GOARCH == "ppc64le" {
+		_, err := o.ExecPrivilegeCommand(o.logWriter, "bootlist", "-m", "normal", "-o", device)
+		if err != nil {
+			o.log.WithError(err).Errorf("Failed to set boot disk with bootlist. Skipping...")
+		}
+		return nil
+	}
+
 	_, err := o.ExecPrivilegeCommand(nil, "test", "-d", "/sys/firmware/efi")
 	if err != nil {
 		o.log.Info("setting the boot order on BIOS systems is not supported. Skipping...")

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -313,6 +313,7 @@ var _ = Describe("RemoveAllDMDevicesOnDisk", func() {
 	})
 
 })
+
 var _ = Describe("Set Boot Order", func() {
 	var (
 		l        = logrus.New()
@@ -350,4 +351,5 @@ var _ = Describe("Set Boot Order", func() {
 		err := o.SetBootOrder("/dev/sda")
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 })

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"reflect"
+	"runtime"
 
 	"errors"
 
@@ -312,4 +313,26 @@ var _ = Describe("RemoveAllDMDevicesOnDisk", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+})
+var _ = Describe("Set Boot Order", func() {
+	var (
+		l        = logrus.New()
+		ctrl     *gomock.Controller
+		execMock *execute.MockExecute
+		conf     *config.Config
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		execMock = execute.NewMockExecute(ctrl)
+		conf = &config.Config{}
+	})
+
+	It("Set boot order", func() {
+		m := MatcherContainsStringElements{[]string{"bootlist"}, runtime.GOARCH == "ppc64le"}
+		o := NewOpsWithConfig(conf, l, execMock)
+		execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m).Times(3)
+		err := o.SetBootOrder("/dev/sda")
+		Expect(err).ToNot(HaveOccurred())
+	})
 })


### PR DESCRIPTION
For powervm, using the bootlist to set target disk as boot device.

Signed-off-by: CS Zhang <zhangcho@us.ibm.com>