### PR TITLE
MGMT-13595: Allow moving node from rebooting to joined

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/thoas/go-funk"
+
 	"github.com/hashicorp/go-version"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -246,7 +248,7 @@ func (c *controller) waitAndUpdateNodesStatus() bool {
 		}
 		common.LogIfHostIpChanged(c.log, node, knownIpAddresses)
 
-		if host.Host.Progress.CurrentStage == models.HostStageConfiguring {
+		if funk.Contains([]models.HostStage{models.HostStageConfiguring, models.HostStageRebooting}, host.Host.Progress.CurrentStage) {
 			log.Infof("Found new joined node %s with inventory id %s, kubernetes id %s, updating its status to %s",
 				node.Name, host.Host.ID.String(), node.Status.NodeInfo.SystemUUID, models.HostStageJoined)
 			if err := c.ic.UpdateHostInstallProgress(ctxReq, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -304,7 +304,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			Expect(exit).Should(Equal(true))
 		})
 
-		It("WaitAndUpdateNodesStatus including joined state", func() {
+		It("WaitAndUpdateNodesStatus including joined state - from configuring", func() {
 			joined := []models.HostStage{models.HostStageJoined,
 				models.HostStageJoined,
 				models.HostStageJoined}
@@ -324,6 +324,31 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
 			updateProgressSuccess(joined, inventoryNamesIds)
 			configuringSuccess()
+
+			exit := assistedController.waitAndUpdateNodesStatus()
+			Expect(exit).Should(Equal(false))
+		})
+
+		It("WaitAndUpdateNodesStatus including joined state from reboot", func() {
+			joined := []models.HostStage{models.HostStageJoined,
+				models.HostStageJoined,
+				models.HostStageJoined}
+
+			hosts := create3Hosts(models.HostStatusInstalling, models.HostStageRebooting, "")
+			mockbmclient.EXPECT().GetHosts(gomock.Any(), gomock.Any(), []string{models.HostStatusDisabled}).
+				Return(hosts, nil).Times(2)
+			// not ready nodes
+			nodes := GetKubeNodes(kubeNamesIds)
+			for _, node := range nodes.Items {
+				for i, cond := range node.Status.Conditions {
+					if cond.Type == v1.NodeReady {
+						node.Status.Conditions[i].Status = v1.ConditionFalse
+					}
+				}
+			}
+			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
+			updateProgressSuccess(joined, inventoryNamesIds)
+			mockk8sclient.EXPECT().GetPods(gomock.Any(), gomock.Any(), "").Return([]v1.Pod{}, nil).AnyTimes()
 
 			exit := assistedController.waitAndUpdateNodesStatus()
 			Expect(exit).Should(Equal(false))


### PR DESCRIPTION
[MGMT-13595](https://issues.redhat.com//browse/MGMT-13595): Allow moving node from rebooting to joined
Sometimes we are missing configuring state due to different issue and installaiton will be blocked, we want to allow controller to move node from rebooting to joined in order to continue