### PR TITLE
MGMT-13605: Remove uninitialized taint from vSphere nodes

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -210,7 +210,7 @@ func (i *installer) finalize() error {
 	return nil
 }
 
-//updateSingleNodeIgnition will download the host ignition config and add the files under storage
+// updateSingleNodeIgnition will download the host ignition config and add the files under storage
 func (i *installer) updateSingleNodeIgnition(singleNodeIgnitionPath string) error {
 	if i.DryRunEnabled {
 		return nil
@@ -585,6 +585,14 @@ func (i *installer) waitForMasterNodes(ctx context.Context, minMasterNodes int, 
 		if err != nil {
 			i.log.Warnf("Still waiting for master nodes: %v", err)
 			return false
+		}
+		for _, node := range nodes.Items {
+			if common.IsK8sNodeIsReady(node) {
+				continue
+			}
+			if err = kc.UntaintNode(node.Name); err != nil {
+				i.log.Warnf("Failed to untaint node %s: %v", node.Name, err)
+			}
 		}
 		if err = i.updateReadyMasters(nodes, &readyMasters, inventoryHostsMap); err != nil {
 			i.log.WithError(err).Warnf("Failed to update ready with masters")

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -574,6 +574,20 @@ func (mr *MockK8SClientMockRecorder) SetProxyEnvVars() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProxyEnvVars", reflect.TypeOf((*MockK8SClient)(nil).SetProxyEnvVars))
 }
 
+// UntaintNode mocks base method.
+func (m *MockK8SClient) UntaintNode(name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UntaintNode", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UntaintNode indicates an expected call of UntaintNode.
+func (mr *MockK8SClientMockRecorder) UntaintNode(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntaintNode", reflect.TypeOf((*MockK8SClient)(nil).UntaintNode), name)
+}
+
 // UpdateBMH mocks base method.
 func (m *MockK8SClient) UpdateBMH(bmh *v1alpha1.BareMetalHost) error {
 	m.ctrl.T.Helper()

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -147,7 +147,11 @@ func main() {
 		logger.Infof("Finished all")
 	}()
 
-	go assistedController.WaitAndUpdateNodesStatus(mainContext, &wg)
+	removeUninitializedTaint := false
+	if cluster.Platform != nil && *cluster.Platform.Type == models.PlatformTypeVsphere {
+		removeUninitializedTaint = true
+	}
+	go assistedController.WaitAndUpdateNodesStatus(mainContext, &wg, removeUninitializedTaint)
 	wg.Add(1)
 	go assistedController.PostInstallConfigs(mainContext, &wg)
 	wg.Add(1)


### PR DESCRIPTION
Since 4.13 cloud controller is external and requires valid
vSphere credentials  to remove uninitialized taint, which blocks
bootstrap. This change will make assisted-installer watch nodes and remove
the taint once it appears to complete installation - both on bootstrap and post-control-plane.

Verified that installed no longer gets stuck on latest nightly, needs https://github.com/openshift/release/pull/36133 to make sure it works in CI