### PR TITLE
MGMT-13657: Don't wait for console if it is disabled - ACM 2.6

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -57,6 +58,8 @@ const (
 	ExitWaiting               = true
 	customManifestsFile       = "custom_manifests.json"
 	kubeconfigFileName        = "kubeconfig-noingress"
+
+	consoleCapabilityName = configv1.ClusterVersionCapability("Console")
 )
 
 var (
@@ -985,12 +988,24 @@ func (c controller) waitingForClusterOperators(ctx context.Context) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, CVOMaxTimeout)
 	defer cancel()
 	isClusterVersionAvailable := func(timer *time.Timer) bool {
-		result := c.isOperatorAvailable(NewClusterOperatorHandler(c.kc, consoleOperatorName))
-
-		if c.WaitForClusterVersion {
-			result = c.isOperatorAvailable(NewClusterVersionHandler(c.kc, timer)) && result
+		clusterOperatorHandler := NewClusterOperatorHandler(c.kc, consoleOperatorName)
+		clusterVersionHandler := NewClusterVersionHandler(c.kc, timer)
+		isConsoleEnabled, err := c.kc.IsClusterCapabilityEnabled(consoleCapabilityName)
+		if err != nil {
+			c.log.WithError(err).Error("Failed to check if console is enabled")
+			return false
 		}
-
+		var result bool
+		if isConsoleEnabled {
+			c.log.Info("Console is enabled, will wait for the console operator to be available")
+			result = c.isOperatorAvailable(clusterOperatorHandler)
+		} else {
+			c.log.Info("Console is disabled, will not wait for the console operator to be available")
+			result = true
+		}
+		if c.WaitForClusterVersion {
+			result = c.isOperatorAvailable(clusterVersionHandler) && result
+		}
 		return result
 	}
 	return utils.WaitForPredicateWithTimer(ctxWithTimeout, WaitTimeout, GeneralProgressUpdateInt, isClusterVersionAvailable)

--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	cvoOperatorName    = "cvo"
-	clusterVersionName = "version"
+	cvoOperatorName = "cvo"
 )
 
 type OperatorHandler interface {
@@ -36,7 +35,7 @@ func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 		return false
 	}
 
-	if operatorStatusInService.Status != operatorStatus || (operatorStatusInService.StatusInfo != operatorMessage && operatorMessage != "") {
+	if operatorStatusInService != nil && (operatorStatusInService.Status != operatorStatus || (operatorStatusInService.StatusInfo != operatorMessage && operatorMessage != "")) {
 		c.log.Infof("Operator <%s> updated, status: %s -> %s, message: %s -> %s.", operatorName, operatorStatusInService.Status, operatorStatus, operatorStatusInService.StatusInfo, operatorMessage)
 		if !handler.OnChange(operatorStatus) {
 			c.log.WithError(err).Warnf("<%s> operator's OnChange() returned false. Will skip an update.", operatorName)
@@ -107,7 +106,7 @@ func (handler ClusterVersionHandler) GetName() string { return cvoOperatorName }
 func (handler ClusterVersionHandler) IsInitialized() bool { return true }
 
 func (handler ClusterVersionHandler) GetStatus() (models.OperatorStatus, string, error) {
-	co, err := handler.kc.GetClusterVersion(clusterVersionName)
+	co, err := handler.kc.GetClusterVersion()
 	if err != nil {
 		return "", "", err
 	}

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -378,18 +378,18 @@ func (mr *MockK8SClientMockRecorder) SetProxyEnvVars() *gomock.Call {
 }
 
 // GetClusterVersion mocks base method
-func (m *MockK8SClient) GetClusterVersion(name string) (*v1.ClusterVersion, error) {
+func (m *MockK8SClient) GetClusterVersion() (*v1.ClusterVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterVersion", name)
+	ret := m.ctrl.Call(m, "GetClusterVersion")
 	ret0, _ := ret[0].(*v1.ClusterVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterVersion indicates an expected call of GetClusterVersion
-func (mr *MockK8SClientMockRecorder) GetClusterVersion(name interface{}) *gomock.Call {
+func (mr *MockK8SClientMockRecorder) GetClusterVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterVersion", reflect.TypeOf((*MockK8SClient)(nil).GetClusterVersion), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterVersion", reflect.TypeOf((*MockK8SClient)(nil).GetClusterVersion))
 }
 
 // GetNetworkType mocks base method
@@ -581,4 +581,19 @@ func (m *MockK8SClient) PatchNodeLabels(nodeName, nodeLabels string) error {
 func (mr *MockK8SClientMockRecorder) PatchNodeLabels(nodeName, nodeLabels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchNodeLabels", reflect.TypeOf((*MockK8SClient)(nil).PatchNodeLabels), nodeName, nodeLabels)
+}
+
+// IsClusterCapabilityEnabled mocks base method
+func (m *MockK8SClient) IsClusterCapabilityEnabled(arg0 v1.ClusterVersionCapability) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsClusterCapabilityEnabled", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsClusterCapabilityEnabled indicates an expected call of IsClusterCapabilityEnabled
+func (mr *MockK8SClientMockRecorder) IsClusterCapabilityEnabled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterCapabilityEnabled", reflect.TypeOf((*MockK8SClient)(nil).IsClusterCapabilityEnabled), arg0)
 }

--- a/src/main/drymock/dry_mode_k8s_mock.go
+++ b/src/main/drymock/dry_mode_k8s_mock.go
@@ -150,7 +150,7 @@ func PrepareControllerDryMock(mockk8sclient *k8s_client.MockK8SClient, logger *l
 			Conditions: availableConditions,
 		},
 	}
-	mockk8sclient.EXPECT().GetClusterVersion(gomock.Any()).Return(&clusterVersion, nil).AnyTimes()
+	mockk8sclient.EXPECT().GetClusterVersion().Return(&clusterVersion, nil).AnyTimes()
 
 	configMap := v1.ConfigMap{
 		Data: map[string]string{
@@ -273,6 +273,8 @@ dEFgad6P3hMZTOg7yVkMOd3QtgVQ9I8dXqS2nG9EMEh97WIhi6f5ztvcQvQ5tXjh
 	}
 
 	mockk8sclient.EXPECT().ListClusterOperators().Return(clusterOperatorList, nil).AnyTimes()
+
+	mockk8sclient.EXPECT().IsClusterCapabilityEnabled(gomock.Any()).Return(true, nil).AnyTimes()
 }
 
 // PrepareInstallerDryK8sMock utilizes k8s_client.MockK8SClient to fake the k8s API to make the


### PR DESCRIPTION
This is a backport of [MGMT-12471](https://issues.redhat.com//browse/MGMT-12471) for ACM 2.6. It contains the changes in pull requests #574 and #589.

This patch changes the controller so that it doesn't wait for the console operator when the console capability is explicitly disabled.

Related: https://issues.redhat.com/browse/MGMT-13657
Related: https://issues.redhat.com/browse/MGMT-12471
Related: https://github.com/openshift/assisted-installer/pull/574
Related: https://github.com/openshift/assisted-installer/pull/589
