### PR TITLE
MGMT-13664: Don't crash if operator isn't monitored by service - ACM 2.7

### DIFF
--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -43,7 +43,7 @@ func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 		return false
 	}
 
-	if operatorStatusInService.Status != operatorStatus || (operatorStatusInService.StatusInfo != operatorMessage && operatorMessage != "") {
+	if operatorStatusInService != nil && (operatorStatusInService.Status != operatorStatus || (operatorStatusInService.StatusInfo != operatorMessage && operatorMessage != "")) {
 		c.log.Infof("Operator <%s> updated, status: %s -> %s, message: %s -> %s.", operatorName, operatorStatusInService.Status, operatorStatus, operatorStatusInService.StatusInfo, operatorMessage)
 		if !handler.OnChange(operatorStatus) {
 			c.log.WithError(err).Warnf("<%s> operator's OnChange() returned false. Will skip an update.", operatorName)


### PR DESCRIPTION
This is a backport of [MGMT-12471](https://issues.redhat.com//browse/MGMT-12471) for ACM 2.7. It includes the changes in pull request #589. The changes in pull request #574 are alse necessary, but they are included in the ACM 2.7 branch already.

Currently the operator handler checks if the operator is available in the service, but it doesn't take into account that the operator may have been removed from the list of managed operators. That results in a nil pointer exception and a crash of the controller. This patch fixes that adding a nil check to the relevant code.

Related: https://issues.redhat.com/browse/MGMT-13664
Related: https://issues.redhat.com/browse/MGMT-12471
Related: https://github.com/openshift/assisted-installer/pull/589
Related: https://github.com/openshift/assisted-installer/pull/574