### PR TITLE
MGMT-13710: assisted-installer-controller hangs for 2 minutes before uploading the ingress CA

### DIFF
--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -31,7 +31,6 @@ type OperatorHandler interface {
 func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 	operatorName := handler.GetName()
 	c.log.Infof("Checking <%s> operator availability status", operatorName)
-
 	operatorStatusInService, isAvailable := c.isOperatorAvailableInService(operatorName, c.OpenshiftVersion)
 	if isAvailable {
 		return true
@@ -55,9 +54,12 @@ func (c controller) isOperatorAvailable(handler OperatorHandler) bool {
 			c.log.WithError(err).Warnf("Failed to update %s operator status %s with message %s", operatorName, operatorStatus, operatorMessage)
 			return false
 		}
+		// In case operator was available we should return ealier in order finish quicker.
+		c.log.Infof("Operator %s, status %s", operatorName, operatorStatus)
+		isAvailable = operatorStatus == models.OperatorStatusAvailable
 	}
 
-	return false
+	return isAvailable
 }
 
 func (c controller) isOperatorAvailableInService(operatorName string, openshiftVersion string) (*models.MonitoredOperator, bool) {

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -74,12 +74,6 @@ type HostData struct {
 	Host      *models.Host
 }
 
-func CreateInventoryClient(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,
-	logger *logrus.Logger, proxyFunc func(*http.Request) (*url.URL, error)) (*inventoryClient, error) {
-	return CreateInventoryClientWithDelay(clusterId, inventoryURL, pullSecret, insecure, caPath,
-		logger, proxyFunc, DefaultRetryMinDelay, DefaultRetryMaxDelay, DefaultMaxRetries, DefaultMinRetries)
-}
-
 func CreateInventoryClientWithDelay(clusterId string, inventoryURL string, pullSecret string, insecure bool, caPath string,
 	logger logrus.FieldLogger, proxyFunc func(*http.Request) (*url.URL, error),
 	retryMinDelay, retryMaxDelay time.Duration, maxRetries int, minRetries int) (*inventoryClient, error) {

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -202,6 +202,9 @@ func WaitForPredicateWithTimer(ctx context.Context, timeout time.Duration, inter
 
 	// Keep trying until we're time out or get true
 	for {
+		if predicate(timeoutTimer) {
+			return nil
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -210,9 +213,7 @@ func WaitForPredicateWithTimer(ctx context.Context, timeout time.Duration, inter
 			return errors.New("timed out")
 		// Got a tick, we should check on checkSomething()
 		case <-ticker.C:
-			if predicate(timeoutTimer) {
-				return nil
-			}
+			continue
 		}
 	}
 }


### PR DESCRIPTION
[MGMT-13710](https://issues.redhat.com//browse/MGMT-13710): assisted-installer-controller hangs for 2 minutes before uploading the ingress CA

Optimizing WaitForPredicateWithTimer first to run function and only then wait for interval.
Ingress CA upload should retry quickly.
Optimizing wait for operator is available by rechecking operator status in service right after update operator status to available