### PR TITLE
MGMT-12967: Create network policy in assisted-installer namespace

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-network-policy.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-network-policy.yaml
@@ -1,0 +1,5 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: assisted-installer-network-policy
+  namespace: assisted-installer


### PR DESCRIPTION
[MGMT-12967](https://issues.redhat.com/browse/MGMT-12967)
Creates an empty network policy for the spoke cluster's assisted-installer namespace. The namespace was created by default and failed the compliance operator's scans due to a lack of a network policy.

### Testing details
1. Used assisted-test-infra, deployed assisted-service and installed a multi-node spoke cluster with the changes in the assisted-installer
2. Checked the spoke cluster to make sure the assisted-installer namespace and the empty network policy existed
3. Deployed the compliance operator ([src](https://docs.openshift.com/container-platform/4.10/security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-cli_compliance-operator-installation))
4. Created 3 PVs for the results
5. Ran the compliance scan ([src](https://docs.openshift.com/container-platform/4.10/security/compliance_operator/compliance-scans.html#running-compliance-scans_compliance-operator-scans))
6. Check the results of the scan
```bash
$ oc --kubeconfig spoke-kubeconfig get ccr -n openshift-compliance | grep configure-network-policies-namespaces
ocp4-cis-configure-network-policies-namespaces                        PASS     high
```

---
PV for reference:
````bash
cat <<EOF | ock create -n openshift-compliance -f -
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv0003
spec:
  capacity:
    storage: 1Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Recycle
  local:
    path: /tmp
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - test-infra-cluster-c5494107-master-0
EOF
````