### PR TITLE
MGMT-14299: Limit untaint nodes to vsphere/nutanix

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -200,3 +200,11 @@ func HostMatchByNameOrIPAddress(node v1.Node, namesMap, IPAddressMap map[string]
 	}
 	return host, ok
 }
+
+// Returns True when uninitialized taint must be removed.
+// This is required for some external platforms (e.g. VSphere, Nutanix) to proceed
+// with the installation using fake credentials.
+func RemoveUninitializedTaint(platform *models.Platform) bool {
+	removeUninitializedTaintForPlatforms := [...]models.PlatformType{models.PlatformTypeNutanix, models.PlatformTypeVsphere}
+	return platform != nil && funk.Contains(removeUninitializedTaintForPlatforms, *platform.Type)
+}

--- a/src/common/common_test.go
+++ b/src/common/common_test.go
@@ -179,6 +179,52 @@ var _ = Describe("verify common", func() {
 			Expect(match.Host.ID).To(Equal(&node0Id))
 		})
 	})
+
+	Context("Verify RemoveUninitializedTaint", func() {
+		It("nil platform struct should not remove uninitiazed taint", func() {
+			removeUninitializedTaint := RemoveUninitializedTaint(nil)
+			Expect(removeUninitializedTaint).To(BeFalse())
+		})
+
+		for _, test := range []struct {
+			PlatformType                     models.PlatformType
+			ExpectedRemoveUninitializedTaint bool
+		}{
+			{
+				PlatformType:                     models.PlatformTypeNutanix,
+				ExpectedRemoveUninitializedTaint: true,
+			},
+			{
+				PlatformType:                     models.PlatformTypeVsphere,
+				ExpectedRemoveUninitializedTaint: true,
+			},
+			{
+				PlatformType:                     models.PlatformTypeNone,
+				ExpectedRemoveUninitializedTaint: false,
+			},
+			{
+				PlatformType:                     models.PlatformTypeBaremetal,
+				ExpectedRemoveUninitializedTaint: false,
+			},
+		} {
+			platformType := test.PlatformType
+			expectedRemoveUninitializedTaint := test.ExpectedRemoveUninitializedTaint
+
+			Context("by platform", func() {
+				var platform *models.Platform
+				BeforeEach(func() {
+					platform = &models.Platform{
+						Type: &platformType,
+					}
+				})
+
+				It(fmt.Sprintf("%v is expected to remove unitialized taint = %v", platformType, expectedRemoveUninitializedTaint), func() {
+					removeUninitializedTaint := RemoveUninitializedTaint(platform)
+					Expect(removeUninitializedTaint).To(Equal(expectedRemoveUninitializedTaint))
+				})
+			})
+		}
+	})
 })
 
 func GetKubeNodes(kubeNamesIds map[string]string) *v1.NodeList {

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/thoas/go-funk"
-
 	"github.com/openshift/assisted-installer/src/common"
 
 	"github.com/openshift/assisted-installer/src/ops/execute"
@@ -149,12 +147,8 @@ func main() {
 		logger.Infof("Finished all")
 	}()
 
-	removeUninitializedTaint := false
-	if cluster.Platform != nil && funk.Contains([]models.PlatformType{models.PlatformTypeNutanix,
-		models.PlatformTypeVsphere}, *cluster.Platform.Type) {
+	removeUninitializedTaint := common.RemoveUninitializedTaint(cluster.Platform)
 
-		removeUninitializedTaint = true
-	}
 	go assistedController.WaitAndUpdateNodesStatus(mainContext, &wg, removeUninitializedTaint)
 	wg.Add(1)
 	go assistedController.PostInstallConfigs(mainContext, &wg)


### PR DESCRIPTION
In the context of installing OCP on Oracle Cloud, we want to wait for
the Cloud Controller Manager to untaint the nodes, so they get labelled
properly at installation time.

Unlike vsphere and nutanix, the Oracle CCM gets the authentication token
through the instance metadata, it should just work as soon as it is
deployed on the nodes.

This change limits the untaint of the boostrap nodes to vsphere and
nutanix platforms.
