### PR TITLE
MGMT-15235: Compile with CGO_ENABLED=1 for FIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo
 
 # Multiarch support.  Transform argument passed from docker buidx tool to go build arguments to support cross compiling
 GO_BUILD_ARCHITECTURE_VARS := $(if ${TARGETPLATFORM},$(shell echo ${TARGETPLATFORM} | awk -F / '{printf("GOOS=%s GOARCH=%s", $$1, $$2)}'),)
-GO_BUILD_VARS := CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
+GO_BUILD_VARS := CGO_ENABLED=1 $(GO_BUILD_ARCHITECTURE_VARS)
 
 all: lint format-check build-images unit-test
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
In order to be FIPS compliant, we need to compile
all go code with CGO_ENABLED=1.

/cc @filanov 