### PR TITLE
[release-ocm-2.6] MGMT-15235: Compile with CGO_ENABLED=1 for FIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ endif
 build: installer controller
 
 installer:
-	CGO_ENABLED=0 go build -o build/installer src/main/main.go
+	CGO_ENABLED=1 go build -o build/installer src/main/main.go
 
 controller:
-	CGO_ENABLED=0 go build -o build/assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
+	CGO_ENABLED=1 go build -o build/assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
 
 build-images: installer-image controller-image
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
In order to be FIPS compliant, we need to compile
all go code with CGO_ENABLED=1.

The original cherry pick of the PR for master failed https://github.com/openshift/assisted-installer/pull/683#issuecomment-1633186997