### PR TITLE
MGMT-15398: Use ubi golang base image to fix multi-arch builds

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15398
The base image previously used did not actually contain gcc compilers for different architectures (other than amd64). Compiling with the flag CGO_ENABLED=1 (for fips) caused issues for arm64 and ppc64le since the C libs and gcc compiler for these architectures didn't exist.

This new base image actually has the correct gcc and glibc for each architecture.