### PR TITLE
OCPBUGS-16482: bump golangci-lint to 1.53.1

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=quay.io/app-sre/golangci-lint:v1.53.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN yum install -y docker && \
     yum clean all
 


### PR DESCRIPTION
Cannot update golangci-lint in the same PR as one exhibiting issues because the CI still uses the previous version.

Updating k8s.io/apimachinery module to a newer version causes the old linter to throw nil pointer error.

Example https://github.com/openshift/assisted-installer/pull/701