### PR TITLE
MGMT-13586: Wait for ETCD Bootstrap to complete (#670)

### DIFF
--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -271,6 +271,15 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockops.EXPECT().ExecPrivilegeCommand(gomock.Any(), "systemctl", "status", "bootkube.service").Return("1", nil).Times(1)
 		}
 
+		waitForETCDBootstrapSuccess := func() {
+			mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), infraEnvId, hostId, models.HostStageWaitingForBootkube, "waiting for ETCD bootstrap to be complete").Return(nil).Times(1)
+			mockops.EXPECT().ExecPrivilegeCommand(gomock.Any(), "systemctl", "is-active", "progress.service").Return("inactive", nil).Times(1)
+		}
+
+		bootstrapETCDStatusSuccess := func() {
+			mockops.EXPECT().ExecPrivilegeCommand(gomock.Any(), "systemctl", "status", "progress.service").Return("1", nil).Times(1)
+		}
+
 		extractSecretFromIgnitionSuccess := func() {
 			mockops.EXPECT().ExtractFromIgnition(filepath.Join(InstallDir, bootstrapIgn), dockerConfigFile).Return(nil).Times(1)
 		}
@@ -316,6 +325,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					WaitMasterNodesSucccess()
 					waitForBootkubeSuccess()
 					bootkubeStatusSuccess()
+					waitForETCDBootstrapSuccess()
+					bootstrapETCDStatusSuccess()
 					resolvConfSuccess()
 					waitForControllerSuccessfully(conf.ClusterID)
 					//HostRoleMaster flow:
@@ -345,6 +356,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					WaitMasterNodesSucccess()
 					waitForBootkubeSuccess()
 					bootkubeStatusSuccess()
+					waitForETCDBootstrapSuccess()
+					bootstrapETCDStatusSuccess()
 					resolvConfSuccess()
 					waitForControllerSuccessfully(conf.ClusterID)
 					//HostRoleMaster flow:
@@ -399,6 +412,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			WaitMasterNodesSucccess()
 			waitForBootkubeSuccess()
 			bootkubeStatusSuccess()
+			waitForETCDBootstrapSuccess()
+			bootstrapETCDStatusSuccess()
 			resolvConfSuccess()
 			waitForControllerSuccessfully(conf.ClusterID)
 			//HostRoleMaster flow:
@@ -483,6 +498,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			// mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), inventoryNamesHost["node0"].Host.InfraEnvID.String(), inventoryNamesHost["node0"].Host.ID.String(), models.HostStageJoined, "").Times(1)
 			waitForBootkubeSuccess()
 			bootkubeStatusSuccess()
+			waitForETCDBootstrapSuccess()
+			bootstrapETCDStatusSuccess()
 			resolvConfSuccess()
 			waitForControllerSuccessfully(conf.ClusterID)
 			//HostRoleMaster flow:


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13586
There have previously been issues where the bootstrap node will reboot before ETCD is ready. This change waits for the new status provided by the ETCD operator before rebooting the bootstrap node.

Cherry pick of https://github.com/openshift/assisted-installer/pull/670

/cc @tsorya 