### PR TITLE
NO-ISSUE: fix dependable ignored packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       go-dependencies:
         patterns:
           - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+


### PR DESCRIPTION
Move excluded to ignore list.

- excluded are excluded from the group only.
- ignored are removed from the dependency tree ( i.e. golang ) 