### PR TITLE
MGMT-15810: change base image to stream9

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -12,7 +12,7 @@ RUN go mod download
 COPY . .
 RUN TARGETPLATFORM=$TARGETPLATFORM make installer
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -17,9 +17,8 @@ RUN go mod download
 COPY . .
 RUN TARGETPLATFORM=$TARGETPLATFORM make controller
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN yum -y install make gcc unzip wget curl rsync && yum clean all
 COPY --from=cli-artifacts /usr/share/openshift/assisted/oc /usr/bin/oc
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller
 


### PR DESCRIPTION
Now that D/S building system fully supports RHEL-9 base images (and allows easy installation of nmstate and other libs that were previously unsupported) we can move U/S to stream9 and D/S to ubi9-minimal.

It doesn't seem possible to easily use ubi9-minimal U/S for the assisted-service, because installation of nmstate packages either requires entitlements running on a RHEL node, or alternatively an access to RedHat's internal network (which can be a major problem for U/S development). For a better consistency we're sticking with the same for the agent, installer, etc.