### PR TITLE
MGMT-15833: Coerce OLM to reconcile subscriptions by re-annotating them

### DIFF
--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -69,6 +69,7 @@ type K8SClient interface {
 	GetBMH(name string) (*metal3v1alpha1.BareMetalHost, error)
 	UpdateBMHStatus(bmh *metal3v1alpha1.BareMetalHost) error
 	UpdateBMH(bmh *metal3v1alpha1.BareMetalHost) error
+	UpdateSubscription(sub *operatorsv1alpha1.Subscription) error
 	SetProxyEnvVars() error
 	GetClusterVersion() (*configv1.ClusterVersion, error)
 	GetServiceNetworks() ([]string, error)
@@ -525,6 +526,10 @@ func (c *k8sClient) UpdateBMHStatus(bmh *metal3v1alpha1.BareMetalHost) error {
 
 func (c *k8sClient) UpdateBMH(bmh *metal3v1alpha1.BareMetalHost) error {
 	return c.runtimeClient.Update(context.TODO(), bmh)
+}
+
+func (c *k8sClient) UpdateSubscription(sub *operatorsv1alpha1.Subscription) error {
+	return c.runtimeClient.Update(context.Background(), sub)
 }
 
 func (c *k8sClient) GetClusterVersion() (*configv1.ClusterVersion, error) {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -629,3 +629,17 @@ func (mr *MockK8SClientMockRecorder) UpdateBMHStatus(bmh interface{}) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBMHStatus", reflect.TypeOf((*MockK8SClient)(nil).UpdateBMHStatus), bmh)
 }
+
+// UpdateSubscription mocks base method.
+func (m *MockK8SClient) UpdateSubscription(sub *v1alpha10.Subscription) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubscription", sub)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSubscription indicates an expected call of UpdateSubscription.
+func (mr *MockK8SClientMockRecorder) UpdateSubscription(sub interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscription", reflect.TypeOf((*MockK8SClient)(nil).UpdateSubscription), sub)
+}


### PR DESCRIPTION
OLM often gives up on reconciling subscriptions. Today we have code in
the assisted-controller to coerce OLM on the assisted installed cluster
into reconciling subscriptions. We do it by deleting Jobs and deleting
InstallPlans.

Starting 4.14rc1, this doesn't seem to be enough. We noticed that we
also have to edit subscriptions to force OLM to reconcile them.

This commit adds code that would periodically add and remove a dummy
annotation from subscriptions to force OLM to reconcile them.