### PR TITLE
MGMT-15810: fix image missing nsenter executable

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -14,6 +14,9 @@ RUN TARGETPLATFORM=$TARGETPLATFORM make installer
 
 FROM quay.io/centos/centos:stream9
 
+# required for nsenter
+RUN dnf install -y util-linux-core && dnf clean all
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy
 


### PR DESCRIPTION
It seems like we were missing an explicit installation for the nsenter executable which does not exist by default in stream9 base image.

The resulting errors are:
```
level=info msg="failed executing nsenter [--target 1 --cgroup --mount
--ipc --pid -- vgs --noheadings -o vg_name,pv_name], env vars
[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HTTPS_PROXY= http_proxy= NO_PROXY= HTTP_PROXY= TERM=xterm
container=podman BUILD_LOGLEVEL=0
OPENSHIFT_BUILD_NAME=assisted-installer
OPENSHIFT_BUILD_NAMESPACE=ci-op-8g1imlzt https_proxy= no_proxy=
HOME=/root HOSTNAME=test-infra-cluster-3119ce36-master-2], error exec:
\"nsenter\": executable file not found in $PATH, waitStatus 0, Output
\"\""
```

(see
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/2274/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted/1706886740561629184)

/cc @ori-amizur 