### PR TITLE
release ocm 2.9 MGMT 15507 Set restricted list of approvers for the new branch

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,30 +2,9 @@
 
 aliases:
   approvers:
-    - avishayt
-    - eranco74
-    - filanov
-    - eliorerz
-    - gamli75
-    - ori-amizur
     - romfreiman
-    - tsorya
-    - nmagnezi
-    - carbonin
-    - danielerez
+    - oourfali
+    - filanov
+    - gamli75
+    - eliorerz
     - osherdp
-    - flaper87
-    - mkowalski
-    - omertuc
-    - paul-maidment
-    - rccrdpccl
-    - jhernand
-    - adriengentil
-    - javipolo
-    - CrystalChun
-  emeritus_approvers:
-    - empovit
-    - celebdor
-    - yevgeny-shnaidman
-    - lranjbar
-    - ybettan


### PR DESCRIPTION
- NO-ISSUE: Remove slaviered from project OWNERS (#669)
- MGMT-13586: Wait for ETCD Bootstrap to complete (#670)
- MGMT-15235: Compile with CGO_ENABLED=1 for FIPS (#683)
- MGMT-15344: Assisted-controller should not timeout on waiting cvo by itself (#688)
- MGMT-15343: dependabot group updates (#692)
- Updating ose-agent-installer-orchestrator images to be consistent with ART (#652)
- OCPBUGS-17252: Bump golang.org/x/net/html (#695)
- Revert "MGMT-15235: Compile with CGO_ENABLED=1 for FIPS (#683)" (#693)
- MGMT-15235: Compile with CGO_ENABLED=1 for amd64 (#699)
- OCPBUGS-4240: allow controller to complete for agent-based installs (#700)
- OCPBUGS-16482: bump golangci-lint to 1.53.1 (#702)
- NO-ISSUE: dependabot exclude k8s (#706)
- MGMT-15507: Set restricted list of approvers for protected release-ocm-2.9 branch
