### PR TITLE
MGMT-15984: Assisted installer doesn't freeze and unmount file systems used for overwriting os image

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -143,12 +143,6 @@ func (i *installer) InstallNode() error {
 		return err
 	}
 
-	if err = i.ops.SetBootOrder(i.Device); err != nil {
-		i.log.WithError(err).Warnf("Failed to set boot order")
-		// Ignore the error for now so it doesn't fail the installation in case it fails
-		//return err
-	}
-
 	if i.Config.Role == string(models.HostRoleWorker) {
 		// Wait for 2 masters to be ready before rebooting
 		if err = i.workerWaitFor2ReadyMasters(ctx); err != nil {
@@ -158,6 +152,12 @@ func (i *installer) InstallNode() error {
 
 	if i.EnableSkipMcoReboot {
 		i.skipMcoReboot(ignitionPath)
+	}
+
+	if err = i.ops.SetBootOrder(i.Device); err != nil {
+		i.log.WithError(err).Warnf("Failed to set boot order")
+		// Ignore the error for now so it doesn't fail the installation in case it fails
+		//return err
 	}
 
 	if isBootstrap {

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1109,6 +1109,10 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 				"--stateroot",
 				"rhcos"), extraArgs...)...,
 		),
+		makecmd("fsfreeze", "--freeze", "/mnt/boot"),
+		makecmd("umount", "/mnt/boot"),
+		makecmd("fsfreeze", "--freeze", "/mnt"),
+		makecmd("umount", "/mnt"),
 	}
 	for i := range cmds {
 		c := cmds[i]

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -583,6 +583,10 @@ var _ = Describe("overwrite OS image", func() {
 			"rhcos",
 			"--karg",
 			"abc")
+		mockPrivileged("fsfreeze", "--freeze", "/mnt/boot")
+		mockPrivileged("umount", "/mnt/boot")
+		mockPrivileged("fsfreeze", "--freeze", "/mnt")
+		mockPrivileged("umount", "/mnt")
 		err := o.OverwriteOsImage(osImage, device, extraArgs)
 		Expect(err).ToNot(HaveOccurred())
 	})


### PR DESCRIPTION
This causes the file system to become corrupt in some cases.

In addition - move the 'change boot order' operation after 'skip mco reboot'

/cc @filanov 
/cc @tsorya 