### PR TITLE
MGMT-15926: Operators installation fails due to timeout on failed jobs

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -705,6 +705,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				},
 			}
 
+			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).Times(1)
+			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("", fmt.Errorf("dummy")).Times(1)
 			Expect(assistedController.waitForCSVBeCreated(operators)).Should(Equal(false))
 		})
@@ -715,6 +717,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					Name: operatorName, Status: models.OperatorStatusProgressing, OperatorType: models.OperatorTypeOlm,
 				},
 			}
+			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("", nil).Times(1)
 			mockk8sclient.EXPECT().GetCSV(operators[0].Namespace, gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
 			Expect(assistedController.waitForCSVBeCreated(operators)).Should(Equal(false))
@@ -753,7 +757,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					Name: operatorName, Status: models.OperatorStatusProgressing, OperatorType: models.OperatorTypeOlm,
 				},
 			}
-
+			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).Times(1)
+			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("randomCSV", nil).Times(1)
 			mockk8sclient.EXPECT().GetCSV(operators[0].Namespace, gomock.Any()).Return(nil, nil).Times(1)
 			Expect(assistedController.waitForCSVBeCreated(operators)).Should(Equal(true))
@@ -1031,6 +1036,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockbmclient.EXPECT().CompleteInstallation(gomock.Any(), "cluster-id", true, "", nil).Return(nil).Times(1)
 
 				wg.Add(1)
+				mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+				mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 				assistedController.PostInstallConfigs(context.TODO(), &wg)
 				wg.Wait()
 				Expect(assistedController.Status.HasError()).Should(Equal(false))
@@ -1049,6 +1056,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				By("endless empty status", func() {
 					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
+					mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+					mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSVFromSubscription("openshift-local-storage", "local-storage-operator").Return("lso-1.1", nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSV("openshift-local-storage", "lso-1.1").Return(&olmv1alpha1.ClusterServiceVersion{Status: olmv1alpha1.ClusterServiceVersionStatus{Phase: olmv1alpha1.CSVPhaseInstalling}}, nil).AnyTimes()
 					mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), "cluster-id", "lso", "0.0.0", models.OperatorStatusProgressing, gomock.Any()).Return(nil).AnyTimes()


### PR DESCRIPTION
Installing operators fails due to failing job, The job are starting and timing out because workers aren't ready.
deleting the failed job to allow retry of operator installation. The solution is removing failed `OLM jobs` and `subscription install plans` during operator initialization check not only in the case of `notFound` error. Linking test installation same as in the origin failure -  http://rdu-infra-edge-06.infra-edge.lab.eng.rdu2.redhat.com:6008/clusters/5a46e946-60fe-43ab-8650-5a50c0429bf6