### PR TITLE
MGMT-16258:  Partitions naming convetion is different for various disk types

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1100,6 +1100,19 @@ func (o *ops) ignitionPlatformId() string {
 	return id
 }
 
+func getPartition(device, partitionNumber string) string {
+	var format string
+	switch {
+	case strings.HasPrefix(device, "/dev/nvme"):
+		format = "%sp%s"
+	case strings.HasPrefix(device, "/dev/mmcblk"):
+		format = "%sP%s"
+	default:
+		format = "%s%s"
+	}
+	return fmt.Sprintf(format, device, partitionNumber)
+}
+
 func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error {
 	type cmd struct {
 		command string
@@ -1110,8 +1123,8 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 		return &cmd{command: commad, args: args}
 	}
 	cmds := []*cmd{
-		makecmd("mount", device+"4", "/mnt"),
-		makecmd("mount", device+"3", "/mnt/boot"),
+		makecmd("mount", getPartition(device, "4"), "/mnt"),
+		makecmd("mount", getPartition(device, "3"), "/mnt/boot"),
 		makecmd("growpart", device, "4"),
 		makecmd("xfs_growfs", "/mnt"),
 

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -554,17 +554,16 @@ var _ = Describe("overwrite OS image", func() {
 				"--pid",
 				"--"), args...)...).Times(1)
 	}
-	It("overwrite OS image", func() {
+	runTest := func(device, part3, part4 string) {
 		osImage := "quay.io/release-image:latest"
-		device := "/dev/sda"
 		extraArgs := []string{
 			"--karg",
 			"abc",
 		}
 		mockPrivileged("cat", "/proc/cmdline")
-		mockPrivileged("mount", "/dev/sda4", "/mnt")
-		mockPrivileged("mount", "/dev/sda3", "/mnt/boot")
-		mockPrivileged("growpart", "/dev/sda", "4")
+		mockPrivileged("mount", part4, "/mnt")
+		mockPrivileged("mount", part3, "/mnt/boot")
+		mockPrivileged("growpart", device, "4")
 		mockPrivileged("xfs_growfs", "/mnt")
 		mockPrivileged("setenforce", "0")
 		mockPrivileged("ostree",
@@ -591,6 +590,15 @@ var _ = Describe("overwrite OS image", func() {
 		mockPrivileged("umount", "/mnt")
 		err := o.OverwriteOsImage(osImage, device, extraArgs)
 		Expect(err).ToNot(HaveOccurred())
+	}
+	It("overwrite OS image - sda", func() {
+		runTest("/dev/sda", "/dev/sda3", "/dev/sda4")
+	})
+	It("overwrite OS image - nvme", func() {
+		runTest("/dev/nvme0n1", "/dev/nvme0n1p3", "/dev/nvme0n1p4")
+	})
+	It("overwrite OS image - mmcblk", func() {
+		runTest("/dev/mmcblk1", "/dev/mmcblk1P3", "/dev/mmcblk1P4")
 	})
 })
 


### PR DESCRIPTION
For SCSI or SATA disks the partition number is appended to the device. For nvme disks, "p" and then the partition number is appended to the device.
When overwriting OS image, the correct naming has to be used.  Otherwise the partition may not exist and skipping MCO reboot will be aborted.

/cc @tsorya 
/cc @filanov 