### PR TITLE
MGMT-16266: Indication event showing how often host has been rebooted missing on some nodes

### DIFF
--- a/src/assisted_installer_controller/reboots_notifier_test.go
+++ b/src/assisted_installer_controller/reboots_notifier_test.go
@@ -77,10 +77,4 @@ var _ = Describe("Reboots notifier", func() {
 		notifier.Start(context.TODO(), nodeName, &hostId, &infraenvId, &clusterId)
 		notifier.Finalize()
 	})
-	It("fail to get number of reboots", func() {
-		mockclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockops.EXPECT().GetNumberOfReboots(gomock.Any(), nodeName, gomock.Any()).Return(1, errors.New("error"))
-		notifier.Start(context.TODO(), nodeName, &hostId, &infraenvId, &clusterId)
-		notifier.Finalize()
-	})
 })


### PR DESCRIPTION


There are many possible failures.  Many of these failures are temporary such as API is not reachable, or failure to create debug pod. Added retry for the retrieval of number of reboots

/cc @filanov 