### PR TITLE
MGMT-16370: fix golangci-lint failing to be pulled

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.20
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.53.2 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.53.2
 RUN yum install -y docker && \
     yum clean all
 


### PR DESCRIPTION
app-sre made their repo mirroring golangci-lint private for legal reasons, and
now our jobs are failing to install it. Installing it now from the cli.

We could also have pulled golangci-lint from dockerhub, but rate
limitation there is quite aggressive.
