### PR TITLE
MGMT-16843: Ensure valid hostname during install

### DIFF
--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-installer/src/common"
 	"github.com/openshift/assisted-installer/src/ignition"
+	"github.com/openshift/assisted-service/pkg/validations"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -288,7 +289,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				checkLocalHostname := func(hostname string, err error) {
 					mockops.EXPECT().GetHostname().Return(hostname, err).Times(1)
-					if hostname == "localhost" {
+					validateErr := validations.ValidateHostname(hostname)
+					if hostname == "localhost" || validateErr != nil {
 						mockops.EXPECT().CreateRandomHostname(gomock.Any()).Return(nil).Times(1)
 					}
 				}
@@ -369,7 +371,40 @@ var _ = Describe("installer HostRoleMaster role", func() {
 								{string(models.HostStageRebooting)},
 							})
 							bootstrapSetup()
-							checkLocalHostname("not localhost", nil)
+							checkLocalHostname("notlocalhost", nil)
+							restartNetworkManager(nil)
+							prepareControllerSuccess()
+							startServicesSuccess()
+							WaitMasterNodesSucccess()
+							waitForBootkubeSuccess()
+							bootkubeStatusSuccess()
+							waitForETCDBootstrapSuccess()
+							bootstrapETCDStatusSuccess()
+							resolvConfSuccess()
+							waitForControllerSuccessfully(conf.ClusterID)
+							//HostRoleMaster flow:
+							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
+							writeToDiskSuccess(gomock.Any())
+							reportLogProgressSuccess()
+							setBootOrderSuccess(gomock.Any())
+							uploadLogsSuccess(true)
+							ironicAgentDoesntExist()
+							rebootSuccess()
+							getEncapsulatedMcSuccess(nil)
+							overwriteImageSuccess()
+							ret := installerObj.InstallNode()
+							Expect(ret).Should(BeNil())
+						})
+						It("bootstrap role happy flow with invalid hostname", func() {
+							updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
+								{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
+								{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
+								{string(models.HostStageInstalling), string(models.HostRoleMaster)},
+								{string(models.HostStageWritingImageToDisk)},
+								{string(models.HostStageRebooting)},
+							})
+							bootstrapSetup()
+							checkLocalHostname("InvalidHostname", nil)
 							restartNetworkManager(nil)
 							prepareControllerSuccess()
 							startServicesSuccess()
@@ -463,7 +498,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					})
 					extractIgnitionToFS("extract failure", fmt.Errorf("extract failed"))
 					bootstrapSetup()
-					checkLocalHostname("not localhost", nil)
+					checkLocalHostname("notlocalhost", nil)
 					restartNetworkManager(nil)
 					prepareControllerSuccess()
 					startServicesSuccess()
@@ -517,7 +552,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 						{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 					})
 					bootstrapSetup()
-					checkLocalHostname("not localhost", nil)
+					checkLocalHostname("notlocalhost", nil)
 					err := fmt.Errorf("Failed to restart NetworkManager")
 					restartNetworkManager(err)
 					//HostRoleMaster flow:
@@ -576,7 +611,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							extractIgnitionToFS("extract failure", fmt.Errorf("extract failed"))
 
 							bootstrapSetup()
-							checkLocalHostname("not localhost", nil)
+							checkLocalHostname("notlocalhost", nil)
 							restartNetworkManager(nil)
 							prepareControllerSuccess()
 							startServicesSuccess()
@@ -1013,7 +1048,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				checkLocalHostname := func(hostname string, err error) {
 					mockops.EXPECT().GetHostname().Return(hostname, err).Times(1)
-					if hostname == "localhost" {
+					validateErr := validations.ValidateHostname(hostname)
+					if hostname == "localhost" || validateErr != nil {
 						mockops.EXPECT().CreateRandomHostname(gomock.Any()).Return(nil).Times(1)
 					}
 				}
@@ -1084,7 +1120,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					// single node bootstrap flow
 					singleNodeBootstrapSetup()
 					err := fmt.Errorf("Failed to restart NetworkManager")
-					checkLocalHostname("not localhost", err)
+					checkLocalHostname("notlocalhost", err)
 					ret := installerObj.InstallNode()
 					Expect(ret).Should(Equal(err))
 				})


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-16843
Some processes during install time depend on the hostname and an invalid hostname (e.g. 'localhost', having capital letters, etc.) that could cause the install to fail.

Extra validation is added when checking the hostname to ensure it is valid. A random hostname will be assigned if the current hostname is invalid.

See above issue for an example of the scenario with an invalid hostname fails to install.

/cc @omertuc @gamli75 