### PR TITLE
MGMT-16993: [STG] avoid reboot not working correctly when there is a partition on installation disk

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -43,6 +43,7 @@ const (
 	dryRunCoreosInstallerExecutable = "dry-installer"
 	encapsulatedMachineConfigFile   = "/etc/ignition-machine-config-encapsulated.json"
 	defaultIgnitionPlatformId       = "ignition.platform.id=metal"
+	ignitionContent                 = "application/vnd.coreos.ignition+json; version=3.4.0"
 )
 
 //go:generate mockgen -source=ops.go -package=ops -destination=mock_ops.go
@@ -1024,7 +1025,12 @@ func (o *ops) getIgnitionFromBoostrap(source, ca string) ([]byte, error) {
 	}}
 	client := http.Client{Transport: tr}
 	o.log.Infof("Getting ignition from %s", source)
-	resp, err := client.Get(source)
+	req, err := http.NewRequest("GET", source, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", ignitionContent)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get ignition from %s", source)
 	}


### PR DESCRIPTION
When adding a partition on installation disk, the partition is part of ignition that contains machine config.  The ignition has a version and may contain some fields that are present only in later versions of coreos-ignition.
Since the basic ignition served by machine-config-server has version 2.2, when there is parition in a ignition 3.*, the MCS refuses to serve
  the content with internal server error.  In order to overcome this, a
header "Accept: application/vnd.coreos.ignition+json; version=3.4.0" is added which instructs MCS to convert the returned ignition to 3.4.0

/cc @tsorya 
/cc @javipolo 