### PR TITLE
MGMT-17353: Debug pod left in ImagePullBackOff after install in disconnected environment

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -50,6 +50,8 @@ spec:
                   optional: true
             - name: OPENSHIFT_VERSION
               value: "{{.OpenshiftVersion}}"
+            - name: NOTIFY_NUM_REBOOTS
+              value: "{{.NotifyNumReboots}}"
             - name: HIGH_AVAILABILITY_MODE
               valueFrom:
                 configMapKeyRef:

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -96,6 +96,7 @@ type ControllerConfig struct {
 	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
 	DryFakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH" required:"false" default:""`
 	DryRunClusterHostsPath  string `envconfig:"DRY_CLUSTER_HOSTS_PATH"`
+	NotifyNumReboots        bool   `evconfig:"NOTIFY_NUM_REBOOTS" default:"false"`
 	// DryRunClusterHostsPath gets read parsed into ParsedClusterHosts by DryParseClusterHosts
 	ParsedClusterHosts config.DryClusterHosts
 }

--- a/src/assisted_installer_controller/reboots_notifier.go
+++ b/src/assisted_installer_controller/reboots_notifier.go
@@ -39,14 +39,16 @@ type rebootsNotifier struct {
 	kubeconfigPath string
 	ops            ops.Ops
 	ic             inventory_client.InventoryClient
+	enabled        bool
 	mu             sync.Mutex
 }
 
-func NewRebootsNotifier(ops ops.Ops, ic inventory_client.InventoryClient, log logrus.FieldLogger) RebootsNotifier {
+func NewRebootsNotifier(ops ops.Ops, ic inventory_client.InventoryClient, enabled bool, log logrus.FieldLogger) RebootsNotifier {
 	return &rebootsNotifier{
-		log: log,
-		ops: ops,
-		ic:  ic,
+		log:     log,
+		ops:     ops,
+		ic:      ic,
+		enabled: enabled,
 	}
 }
 
@@ -105,6 +107,9 @@ func (r *rebootsNotifier) run(ctx context.Context, nodeName string, hostId, infr
 }
 
 func (r *rebootsNotifier) Start(ctx context.Context, nodeName string, hostId, infraenvId, clusterId *strfmt.UUID) {
+	if !r.enabled {
+		return
+	}
 	execCtx, cancel := context.WithTimeout(ctx, getNumRebootsTimeout)
 	r.cancelers = append(r.cancelers, cancel)
 	r.wg.Add(1)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	DisksToFormat               ArrayFlags
 	SkipInstallationDiskCleanup bool
 	EnableSkipMcoReboot         bool
+	NotifyNumReboots            bool
 }
 
 func printHelpAndExit(err error) {
@@ -77,6 +78,7 @@ func (c *Config) ProcessArgs(args []string) {
 	flagSet.Var(&c.DisksToFormat, "format-disk", "Disk to format. Can be specified multiple times")
 	flagSet.BoolVar(&c.SkipInstallationDiskCleanup, "skip-installation-disk-cleanup", false, "Skip installation disk cleanup gives disk management to coreos-installer in case needed")
 	flagSet.BoolVar(&c.EnableSkipMcoReboot, "enable-skip-mco-reboot", false, "indicate assisted installer to generate settings to match MCO requirements for skipping reboot after firstboot")
+	flagSet.BoolVar(&c.NotifyNumReboots, "notify-num-reboots", false, "indicate number of reboots should be notified as event")
 
 	var installerArgs string
 	flagSet.StringVar(&installerArgs, "installer-args", "", "JSON array of additional coreos-installer arguments")

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -117,7 +117,7 @@ func main() {
 		log.Fatalf("Failed to create inventory client %v", err)
 	}
 
-	rn := assistedinstallercontroller.NewRebootsNotifier(o, client, logger)
+	rn := assistedinstallercontroller.NewRebootsNotifier(o, client, Options.ControllerConfig.NotifyNumReboots, logger)
 	defer rn.Finalize()
 	assistedController := assistedinstallercontroller.NewController(logger,
 		Options.ControllerConfig,

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -382,6 +382,7 @@ func (o *ops) renderControllerPod() error {
 		"ControllerImage":  o.installerConfig.ControllerImage,
 		"CACertPath":       o.installerConfig.CACertPath,
 		"OpenshiftVersion": o.installerConfig.OpenshiftVersion,
+		"NotifyNumReboots": o.installerConfig.NotifyNumReboots,
 	}
 
 	if o.installerConfig.ServiceIPs != "" {


### PR DESCRIPTION


In order to provide the number of reboots for installed node, "oc debug" is used and then the command "last reboot".  "oc debug" uses external image called "support-tools".  This image is not part of standard installation and it is not available in disconnected environments. Therefore, this notification is removed from the controller.

/cc @tsorya 