### PR TITLE
OCPBUGS-32105: Fix race to mark node Joined

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -776,15 +776,17 @@ func (i *installer) updateReadyMasters(nodes *v1.NodeList, readyMasters *[]strin
 			ctx := utils.GenerateRequestContext()
 			log := utils.RequestIDLogger(ctx, i.log)
 			log.Infof("Found a new ready master node %s with id %s", node.Name, node.Status.NodeInfo.SystemUUID)
-			*readyMasters = append(*readyMasters, node.Name)
 
 			host, ok := common.HostMatchByNameOrIPAddress(node, inventoryHostsMap, knownIpAddresses)
+			if ok && (host.Host.Status == nil || *host.Host.Status != models.HostStatusInstalled) {
+				if err := i.inventoryClient.UpdateHostInstallProgress(ctx, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
+					log.Errorf("Failed to update node installation status, %s", err)
+					continue
+				}
+			}
+			*readyMasters = append(*readyMasters, node.Name)
 			if !ok {
 				return fmt.Errorf("node %s is not in inventory hosts", node.Name)
-			}
-			ctx = utils.GenerateRequestContext()
-			if err := i.inventoryClient.UpdateHostInstallProgress(ctx, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
-				utils.RequestIDLogger(ctx, i.log).Errorf("Failed to update node installation status, %s", err)
 			}
 		}
 	}

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -120,11 +120,15 @@ func CreateInventoryClientWithDelay(clusterId string, inventoryURL string, pullS
 		rehttp.RetryAny(
 			rehttp.RetryAll(
 				rehttp.RetryMaxRetries(minRetries),
-				rehttp.RetryStatusInterval(400, 404),
+				rehttp.RetryStatuses(404, 423, 425),
 			),
 			rehttp.RetryAll(
 				rehttp.RetryMaxRetries(maxRetries),
-				rehttp.RetryStatusInterval(405, 600),
+				rehttp.RetryStatuses(408, 429),
+			),
+			rehttp.RetryAll(
+				rehttp.RetryMaxRetries(maxRetries),
+				rehttp.RetryStatusInterval(500, 600),
 			),
 			rehttp.RetryAll(
 				rehttp.RetryMaxRetries(maxRetries),


### PR DESCRIPTION
In the race between assisted-installer on the bootstrap node and assisted-installer-controller on the cluster control plane to mark nodes as Joined, a win for the assisted-installer-controller would cause the bootstrapping process to lock up for 30+ minutes.

Prevent this by not retrying HTTP requests that receive a 409 response at the HTTP transport level. Instead, retry at the logic level and avoid making requests that cannot succeed.