### PR TITLE
MGMT-17541: Replace broken golangci reference

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.17
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.37.1
 RUN yum install -y docker && \
     yum clean all
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \


### PR DESCRIPTION
The reference to the quay image has been replaced with RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.37.1 Which installs v1.37.1 of `golangci-lint` into the skipper build container. If we leave this unchanged, the skipper build container fails with an error about a missing image.