### PR TITLE
MGMT-16843: Use hostnamectl to replace illegal hostname

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -609,8 +609,8 @@ func (o *ops) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string
 }
 
 func (o *ops) CreateRandomHostname(hostname string) error {
-	command := fmt.Sprintf("echo %s > /etc/hostname", hostname)
-	o.log.Infof("create random hostname with command %s", command)
+	command := fmt.Sprintf("hostnamectl set-hostname %s", hostname)
+	o.log.Infof("applying random hostname with command %s", command)
 	_, err := o.ExecPrivilegeCommand(o.logWriter, "bash", "-c", command)
 	return err
 }


### PR DESCRIPTION
Hosts may not restart before beginning installation
so if we generate a random hostname, it won't take
effect unless we use hostnamectl to actually replace
the hostname live.