### PR TITLE
[release-ocm-2.8] NO-ISSUE: Use archived dnf repositories for centos8 as the current ones are no longer valid

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -14,6 +14,9 @@ RUN TARGETPLATFORM=$TARGETPLATFORM make installer
 
 FROM quay.io/centos/centos:stream8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy
 

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -19,6 +19,9 @@ RUN TARGETPLATFORM=$TARGETPLATFORM make controller
 
 FROM quay.io/centos/centos:stream8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum -y install make gcc unzip wget curl rsync && yum clean all
 COPY --from=cli-artifacts /usr/share/openshift/assisted/oc /usr/bin/oc
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller


### PR DESCRIPTION
[CentOS Linux 8 had reached the End Of Life (EOL)](https://www.centos.org/centos-linux-eol/) on December 31st, 2021. It means that CentOS 8 will no longer receive development resources from the official CentOS project. After Dec 31st, 2021, if you need to update your CentOS, you need to change the mirrors to [vault.centos.org](https://vault.centos.org/) where they will be archived permanently. Alternatively, you may want to [upgrade to CentOS Stream](https://techglimpse.com/convert-centos8-linux-centosstream/).

from - https://techglimpse.com/failed-metadata-repo-appstream-centos-8/