### PR TITLE
NO-ISSUE: We should set disk symlink only for coreos installer command

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -100,7 +100,6 @@ func (i *installer) InstallNode() error {
 	i.log.Infof("Installing node with role: %s", i.Config.Role)
 
 	i.UpdateHostInstallProgress(models.HostStageStartingInstallation, i.Config.Role)
-	i.Config.Device = i.ops.EvaluateDiskSymlink(i.Config.Device)
 	i.cleanupInstallDevice()
 	if err := i.ops.Mkdir(InstallDir); err != nil {
 		i.log.Errorf("Failed to create install dir: %s", err)
@@ -319,7 +318,7 @@ func (i *installer) writeImageToDisk(ignitionPath string) error {
 	interval := time.Second
 	liveLogger := coreos_logger.NewCoreosInstallerLogWriter(i.log, i.inventoryClient, i.Config.InfraEnvID, i.Config.HostID)
 	err := utils.Retry(3, interval, i.log, func() error {
-		return i.ops.WriteImageToDisk(liveLogger, ignitionPath, i.Device, i.Config.InstallerArgs)
+		return i.ops.WriteImageToDisk(liveLogger, ignitionPath, i.ops.EvaluateDiskSymlink(i.Config.Device), i.Config.InstallerArgs)
 	})
 	if err != nil {
 		i.log.WithError(err).Error("Failed to write image to disk")

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -111,6 +111,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			}
 
 			writeToDiskSuccess := func(extra interface{}) {
+				evaluateDiskSymlinkSuccess()
 				mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign"), device, extra).Return(nil).Times(1)
 			}
 
@@ -219,7 +220,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				BeforeEach(func() {
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)
-					evaluateDiskSymlinkSuccess()
 				})
 				mcoImage := conf.MCOImage
 				extractIgnitionToFS := func(out string, err error) {
@@ -711,7 +711,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				BeforeEach(func() {
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)
-					evaluateDiskSymlinkSuccess()
 
 				})
 				It("master role happy flow", func() {
@@ -852,6 +851,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					err := fmt.Errorf("failed writing image to disk")
+					mockops.EXPECT().EvaluateDiskSymlink(device).Return(device).Times(3)
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign"), device, installerArgs).Return(err).Times(3)
 					ret := installerObj.InstallNode()
 					Expect(ret).To(HaveOccurred())
@@ -891,7 +891,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				BeforeEach(func() {
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)
-					evaluateDiskSymlinkSuccess()
 				})
 				It("worker role happy flow", func() {
 					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
@@ -920,6 +919,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					cleanInstallDevice()
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "worker-host-id.ign")
+					evaluateDiskSymlinkSuccess()
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "worker-host-id.ign"), device, nil).Return(nil).Times(1)
 					setBootOrderSuccess(gomock.Any())
 					// failure must do nothing
@@ -948,7 +948,6 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				}
 				BeforeEach(func() {
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)
-					evaluateDiskSymlinkSuccess()
 				})
 				mcoImage := conf.MCOImage
 				extractIgnitionToFS := func(out string, err error) {
@@ -1022,6 +1021,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					verifySingleNodeMasterIgnitionSuccess()
 					singleNodeMergeIgnitionSuccess()
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
+					evaluateDiskSymlinkSuccess()
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), singleNodeMasterIgnitionPath, device, nil).Return(nil).Times(1)
 					setBootOrderSuccess(gomock.Any())
 					uploadLogsSuccess(true)


### PR DESCRIPTION
As part of installation flow we set boot order in efibootmanager.
Till now we used disk name as device for the command and it creates many issues after booting as in many machines disk name changes and we start with wrong disk. This happened due to old bug in coreos installer that required disk name rather than disk id.
This change leaves workaround for a bug due to support of old ocp versions but uses disk name only for coreos-isntall command and all other commands will get disk id, this should allow us to set right disk in eftbootmanager and node should boot form the right disk