### PR TITLE
OCPBUGS-36779: Reload host inventory on conflict

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -722,6 +722,8 @@ func (i *installer) waitForMasterNodes(ctx context.Context, minMasterNodes int, 
 		}
 		if err = i.updateReadyMasters(nodes, &readyMasters, inventoryHostsMap); err != nil {
 			i.log.WithError(err).Warnf("Failed to update ready with masters")
+			// Re-fetch inventory on next invocation
+			inventoryHostsMap = nil
 			return false
 		}
 		i.log.Infof("Found %d ready master nodes", len(readyMasters))
@@ -782,7 +784,7 @@ func (i *installer) updateReadyMasters(nodes *v1.NodeList, readyMasters *[]strin
 			if ok && (host.Host.Status == nil || *host.Host.Status != models.HostStatusInstalled) {
 				if err := i.inventoryClient.UpdateHostInstallProgress(ctx, host.Host.InfraEnvID.String(), host.Host.ID.String(), models.HostStageJoined, ""); err != nil {
 					log.Errorf("Failed to update node installation status, %s", err)
-					continue
+					return err
 				}
 			}
 			*readyMasters = append(*readyMasters, node.Name)


### PR DESCRIPTION
In a race between the assisted-installer and
assisted-installer-controller to mark a control plane node as ready, the former will get a 409 Conflict response from assisted-service if the latter wins. Since f548d3284a438c8e2020253d2250620b095c70a1 we retry that check promptly. However, prior to this change we never read fresh inventory data (which would show the host has already reached the "installed" state and thus prevent us from attempting another (unnecessary) write that is doomed to fail due to a conflict.

Reload the host inventory in the event of a failure to update the host status, so that we can take into account that the change may already have been performed by the assisted-installer-controller.