### PR TITLE
OCPBUGS-31570: Bump to latest preinstall utils for disk cleanup fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/operator-framework/api v0.23.0
 	github.com/operator-framework/operator-lifecycle-manager v0.22.0
 	github.com/pkg/errors v0.9.1
-	github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b
+	github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240722132034-cf015589a8b3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/thoas/go-funk v0.9.3
 	github.com/tidwall/gjson v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -893,8 +893,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b h1:QYPDs7dSQrPOudmlr/TWlZ1bO6ZFAqhQuQPBfKvCrkk=
-github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b/go.mod h1:kLsipUXPVdPRjK4pVmCKXBjxFYXtN9KjHsBm2QLBEfI=
+github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240722132034-cf015589a8b3 h1:jwt30gRbj1oAL8cLPdaZfH5hIBnHylKYtuSuV7XjlTM=
+github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240722132034-cf015589a8b3/go.mod h1:kLsipUXPVdPRjK4pVmCKXBjxFYXtN9KjHsBm2QLBEfI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -597,7 +597,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b
+# github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240722132034-cf015589a8b3
 ## explicit; go 1.20
 github.com/rh-ecosystem-edge/preinstall-utils/pkg
 # github.com/shirou/gopsutil/v3 v3.23.12


### PR DESCRIPTION
The purpose of this PR is to pick up a change to disk cleanup made in https://github.com/rh-ecosystem-edge/preinstall-utils/commit/cf015589a8b3b0ec90c439661c41c91a8fa5b0f9

This change is to ensure that in the case of thin provisioning we clean up all necessary disks in the correct order.

This has been tested in assisted-test infra with a 5 node cluster and an artificially created thin provisioning, the cluster installs correctly where it would not have done so before this change.