### PR TITLE
[release-ocm-2.9] MGMT-18313: Replace golang base image as it is based on Centos Linux 7

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,8 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS builder
+
+# Workaround for creating build folder
+USER root
+
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer
@@ -10,12 +14,13 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN TARGETPLATFORM=$TARGETPLATFORM make installer
+RUN git config --global --add safe.directory '*'; \
+    TARGETPLATFORM=$TARGETPLATFORM make installer
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+# for the 'nsenter' executable
+RUN dnf install -y util-linux-core && dnf clean all
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,12 +1,10 @@
-FROM quay.io/openshift/origin-cli-artifacts:latest as cli-artifacts
-ARG TARGETPLATFORM
-RUN mkdir -p /usr/share/openshift/assisted
-RUN case $TARGETPLATFORM in "") dir=linux_amd64;; *) dir=`echo $TARGETPLATFORM | sed 's@/@_@'` ;; esac ;  ln /usr/share/openshift/${dir}/oc /usr/share/openshift/assisted
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS builder
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer
+
+USER root
 
 # Bring in the go dependencies before anything else so we can take
 # advantage of caching these layers in future builds.
@@ -15,15 +13,18 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN TARGETPLATFORM=$TARGETPLATFORM make controller
+RUN git config --global --add safe.directory '*'; \
+    TARGETPLATFORM=$TARGETPLATFORM make controller
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+ARG TARGETPLATFORM
 
-RUN yum -y install make gcc unzip wget curl rsync && yum clean all
-COPY --from=cli-artifacts /usr/share/openshift/assisted/oc /usr/bin/oc
+# openshift clients
+RUN case $TARGETPLATFORM in "") platform=amd64;; *) platform=`echo $TARGETPLATFORM | sed 's#linux/##'` ;; esac ; \
+    curl -k -L -s "https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/latest/amd64/openshift-client-linux-${platform}-rhel9.tar.gz" | tar xvz -C /usr/bin; \
+    chmod +x /usr/bin/oc /usr/bin/kubectl
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller
 
 ENTRYPOINT ["/usr/bin/assisted-installer-controller"]


### PR DESCRIPTION
This PR moves centos base image from stream8 to stream 9 as well as stream8 is EOL