### PR TITLE
MGMT-18684: Ensure that bootstrap CSR is authenticated against cluster hosts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/coreos/ignition/v2 v2.18.0
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
-	github.com/go-openapi/swag v0.23.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -82,6 +81,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect

--- a/src/assisted_installer_controller/reboots_notifier.go
+++ b/src/assisted_installer_controller/reboots_notifier.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-installer/src/common"
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-installer/src/utils"
@@ -97,8 +97,8 @@ func (r *rebootsNotifier) run(ctx context.Context, nodeName string, hostId, infr
 		ClusterID:  clusterId,
 		Name:       eventName,
 		Category:   models.EventCategoryUser,
-		Severity:   swag.String(models.EventSeverityInfo),
-		Message:    swag.String(fmt.Sprintf(eventMessageTemplate, nodeName, numberOfReboots)),
+		Severity:   convert.String(models.EventSeverityInfo),
+		Message:    convert.String(fmt.Sprintf(eventMessageTemplate, nodeName, numberOfReboots)),
 	}
 
 	if err = r.ic.TriggerEvent(ctx, ev); err != nil {

--- a/src/assisted_installer_controller/reboots_notifier_test.go
+++ b/src/assisted_installer_controller/reboots_notifier_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/openshift/assisted-service/models"
@@ -71,9 +71,9 @@ var _ = Describe("Reboots notifier", func() {
 				ClusterID:  &clusterId,
 				HostID:     &hostId,
 				InfraEnvID: &infraenvId,
-				Message:    swag.String(fmt.Sprintf(eventMessageTemplate, nodeName, 1)),
+				Message:    convert.String(fmt.Sprintf(eventMessageTemplate, nodeName, 1)),
 				Name:       eventName,
-				Severity:   swag.String(models.EventSeverityInfo),
+				Severity:   convert.String(models.EventSeverityInfo),
 			}).Return(nil)
 			notifier.Start(context.TODO(), nodeName, &hostId, &infraenvId, &clusterId)
 			notifier.Finalize()

--- a/src/convert/convert_types.go
+++ b/src/convert/convert_types.go
@@ -1,0 +1,730 @@
+package convert
+
+import "time"
+
+// This file was taken from the aws go sdk
+
+// String returns a pointer to of the string value passed in.
+func String(v string) *string {
+	return &v
+}
+
+// StringValue returns the value of the string pointer passed in or
+// "" if the pointer is nil.
+func StringValue(v *string) string {
+	if v != nil {
+		return *v
+	}
+	return ""
+}
+
+// StringSlice converts a slice of string values into a slice of
+// string pointers
+func StringSlice(src []string) []*string {
+	dst := make([]*string, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// StringValueSlice converts a slice of string pointers into a slice of
+// string values
+func StringValueSlice(src []*string) []string {
+	dst := make([]string, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// StringMap converts a string map of string values into a string
+// map of string pointers
+func StringMap(src map[string]string) map[string]*string {
+	dst := make(map[string]*string)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// StringValueMap converts a string map of string pointers into a string
+// map of string values
+func StringValueMap(src map[string]*string) map[string]string {
+	dst := make(map[string]string)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Bool returns a pointer to of the bool value passed in.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// BoolValue returns the value of the bool pointer passed in or
+// false if the pointer is nil.
+func BoolValue(v *bool) bool {
+	if v != nil {
+		return *v
+	}
+	return false
+}
+
+// BoolSlice converts a slice of bool values into a slice of
+// bool pointers
+func BoolSlice(src []bool) []*bool {
+	dst := make([]*bool, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// BoolValueSlice converts a slice of bool pointers into a slice of
+// bool values
+func BoolValueSlice(src []*bool) []bool {
+	dst := make([]bool, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// BoolMap converts a string map of bool values into a string
+// map of bool pointers
+func BoolMap(src map[string]bool) map[string]*bool {
+	dst := make(map[string]*bool)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// BoolValueMap converts a string map of bool pointers into a string
+// map of bool values
+func BoolValueMap(src map[string]*bool) map[string]bool {
+	dst := make(map[string]bool)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int returns a pointer to of the int value passed in.
+func Int(v int) *int {
+	return &v
+}
+
+// IntValue returns the value of the int pointer passed in or
+// 0 if the pointer is nil.
+func IntValue(v *int) int {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// IntSlice converts a slice of int values into a slice of
+// int pointers
+func IntSlice(src []int) []*int {
+	dst := make([]*int, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// IntValueSlice converts a slice of int pointers into a slice of
+// int values
+func IntValueSlice(src []*int) []int {
+	dst := make([]int, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// IntMap converts a string map of int values into a string
+// map of int pointers
+func IntMap(src map[string]int) map[string]*int {
+	dst := make(map[string]*int)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// IntValueMap converts a string map of int pointers into a string
+// map of int values
+func IntValueMap(src map[string]*int) map[string]int {
+	dst := make(map[string]int)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int32 returns a pointer to of the int32 value passed in.
+func Int32(v int32) *int32 {
+	return &v
+}
+
+// Int32Value returns the value of the int32 pointer passed in or
+// 0 if the pointer is nil.
+func Int32Value(v *int32) int32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int32Slice converts a slice of int32 values into a slice of
+// int32 pointers
+func Int32Slice(src []int32) []*int32 {
+	dst := make([]*int32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int32ValueSlice converts a slice of int32 pointers into a slice of
+// int32 values
+func Int32ValueSlice(src []*int32) []int32 {
+	dst := make([]int32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int32Map converts a string map of int32 values into a string
+// map of int32 pointers
+func Int32Map(src map[string]int32) map[string]*int32 {
+	dst := make(map[string]*int32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int32ValueMap converts a string map of int32 pointers into a string
+// map of int32 values
+func Int32ValueMap(src map[string]*int32) map[string]int32 {
+	dst := make(map[string]int32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int64 returns a pointer to of the int64 value passed in.
+func Int64(v int64) *int64 {
+	return &v
+}
+
+// Int64Value returns the value of the int64 pointer passed in or
+// 0 if the pointer is nil.
+func Int64Value(v *int64) int64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int64Slice converts a slice of int64 values into a slice of
+// int64 pointers
+func Int64Slice(src []int64) []*int64 {
+	dst := make([]*int64, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int64ValueSlice converts a slice of int64 pointers into a slice of
+// int64 values
+func Int64ValueSlice(src []*int64) []int64 {
+	dst := make([]int64, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int64Map converts a string map of int64 values into a string
+// map of int64 pointers
+func Int64Map(src map[string]int64) map[string]*int64 {
+	dst := make(map[string]*int64)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int64ValueMap converts a string map of int64 pointers into a string
+// map of int64 values
+func Int64ValueMap(src map[string]*int64) map[string]int64 {
+	dst := make(map[string]int64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint16 returns a pointer to of the uint16 value passed in.
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+// Uint16Value returns the value of the uint16 pointer passed in or
+// 0 if the pointer is nil.
+func Uint16Value(v *uint16) uint16 {
+	if v != nil {
+		return *v
+	}
+
+	return 0
+}
+
+// Uint16Slice converts a slice of uint16 values into a slice of
+// uint16 pointers
+func Uint16Slice(src []uint16) []*uint16 {
+	dst := make([]*uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+
+	return dst
+}
+
+// Uint16ValueSlice converts a slice of uint16 pointers into a slice of
+// uint16 values
+func Uint16ValueSlice(src []*uint16) []uint16 {
+	dst := make([]uint16, len(src))
+
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+
+	return dst
+}
+
+// Uint16Map converts a string map of uint16 values into a string
+// map of uint16 pointers
+func Uint16Map(src map[string]uint16) map[string]*uint16 {
+	dst := make(map[string]*uint16)
+
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+
+	return dst
+}
+
+// Uint16ValueMap converts a string map of uint16 pointers into a string
+// map of uint16 values
+func Uint16ValueMap(src map[string]*uint16) map[string]uint16 {
+	dst := make(map[string]uint16)
+
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+
+	return dst
+}
+
+// Uint returns a pointer to of the uint value passed in.
+func Uint(v uint) *uint {
+	return &v
+}
+
+// UintValue returns the value of the uint pointer passed in or
+// 0 if the pointer is nil.
+func UintValue(v *uint) uint {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UintSlice converts a slice of uint values into a slice of
+// uint pointers
+func UintSlice(src []uint) []*uint {
+	dst := make([]*uint, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// UintValueSlice converts a slice of uint pointers into a slice of
+// uint values
+func UintValueSlice(src []*uint) []uint {
+	dst := make([]uint, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// UintMap converts a string map of uint values into a string
+// map of uint pointers
+func UintMap(src map[string]uint) map[string]*uint {
+	dst := make(map[string]*uint)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// UintValueMap converts a string map of uint pointers into a string
+// map of uint values
+func UintValueMap(src map[string]*uint) map[string]uint {
+	dst := make(map[string]uint)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint32 returns a pointer to of the uint32 value passed in.
+func Uint32(v uint32) *uint32 {
+	return &v
+}
+
+// Uint32Value returns the value of the uint32 pointer passed in or
+// 0 if the pointer is nil.
+func Uint32Value(v *uint32) uint32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint32Slice converts a slice of uint32 values into a slice of
+// uint32 pointers
+func Uint32Slice(src []uint32) []*uint32 {
+	dst := make([]*uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint32ValueSlice converts a slice of uint32 pointers into a slice of
+// uint32 values
+func Uint32ValueSlice(src []*uint32) []uint32 {
+	dst := make([]uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint32Map converts a string map of uint32 values into a string
+// map of uint32 pointers
+func Uint32Map(src map[string]uint32) map[string]*uint32 {
+	dst := make(map[string]*uint32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint32ValueMap converts a string map of uint32 pointers into a string
+// map of uint32 values
+func Uint32ValueMap(src map[string]*uint32) map[string]uint32 {
+	dst := make(map[string]uint32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint64 returns a pointer to of the uint64 value passed in.
+func Uint64(v uint64) *uint64 {
+	return &v
+}
+
+// Uint64Value returns the value of the uint64 pointer passed in or
+// 0 if the pointer is nil.
+func Uint64Value(v *uint64) uint64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint64Slice converts a slice of uint64 values into a slice of
+// uint64 pointers
+func Uint64Slice(src []uint64) []*uint64 {
+	dst := make([]*uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint64ValueSlice converts a slice of uint64 pointers into a slice of
+// uint64 values
+func Uint64ValueSlice(src []*uint64) []uint64 {
+	dst := make([]uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint64Map converts a string map of uint64 values into a string
+// map of uint64 pointers
+func Uint64Map(src map[string]uint64) map[string]*uint64 {
+	dst := make(map[string]*uint64)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint64ValueMap converts a string map of uint64 pointers into a string
+// map of uint64 values
+func Uint64ValueMap(src map[string]*uint64) map[string]uint64 {
+	dst := make(map[string]uint64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Float32 returns a pointer to of the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+
+	return 0
+}
+
+// Float32Slice converts a slice of float32 values into a slice of
+// float32 pointers
+func Float32Slice(src []float32) []*float32 {
+	dst := make([]*float32, len(src))
+
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+
+	return dst
+}
+
+// Float32ValueSlice converts a slice of float32 pointers into a slice of
+// float32 values
+func Float32ValueSlice(src []*float32) []float32 {
+	dst := make([]float32, len(src))
+
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+
+	return dst
+}
+
+// Float32Map converts a string map of float32 values into a string
+// map of float32 pointers
+func Float32Map(src map[string]float32) map[string]*float32 {
+	dst := make(map[string]*float32)
+
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+
+	return dst
+}
+
+// Float32ValueMap converts a string map of float32 pointers into a string
+// map of float32 values
+func Float32ValueMap(src map[string]*float32) map[string]float32 {
+	dst := make(map[string]float32)
+
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+
+	return dst
+}
+
+// Float64 returns a pointer to of the float64 value passed in.
+func Float64(v float64) *float64 {
+	return &v
+}
+
+// Float64Value returns the value of the float64 pointer passed in or
+// 0 if the pointer is nil.
+func Float64Value(v *float64) float64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float64Slice converts a slice of float64 values into a slice of
+// float64 pointers
+func Float64Slice(src []float64) []*float64 {
+	dst := make([]*float64, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Float64ValueSlice converts a slice of float64 pointers into a slice of
+// float64 values
+func Float64ValueSlice(src []*float64) []float64 {
+	dst := make([]float64, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Float64Map converts a string map of float64 values into a string
+// map of float64 pointers
+func Float64Map(src map[string]float64) map[string]*float64 {
+	dst := make(map[string]*float64)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Float64ValueMap converts a string map of float64 pointers into a string
+// map of float64 values
+func Float64ValueMap(src map[string]*float64) map[string]float64 {
+	dst := make(map[string]float64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Time returns a pointer to of the time.Time value passed in.
+func Time(v time.Time) *time.Time {
+	return &v
+}
+
+// TimeValue returns the value of the time.Time pointer passed in or
+// time.Time{} if the pointer is nil.
+func TimeValue(v *time.Time) time.Time {
+	if v != nil {
+		return *v
+	}
+	return time.Time{}
+}
+
+// TimeSlice converts a slice of time.Time values into a slice of
+// time.Time pointers
+func TimeSlice(src []time.Time) []*time.Time {
+	dst := make([]*time.Time, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// TimeValueSlice converts a slice of time.Time pointers into a slice of
+// time.Time values
+func TimeValueSlice(src []*time.Time) []time.Time {
+	dst := make([]time.Time, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// TimeMap converts a string map of time.Time values into a string
+// map of time.Time pointers
+func TimeMap(src map[string]time.Time) map[string]*time.Time {
+	dst := make(map[string]*time.Time)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// TimeValueMap converts a string map of time.Time pointers into a string
+// map of time.Time values
+func TimeValueMap(src map[string]*time.Time) map[string]time.Time {
+	dst := make(map[string]time.Time)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}

--- a/src/ignition/mock_ignition.go
+++ b/src/ignition/mock_ignition.go
@@ -38,6 +38,20 @@ func (m *MockIgnition) EXPECT() *MockIgnitionMockRecorder {
 	return m.recorder
 }
 
+// InjectKubeletTempPrivateKey mocks base method.
+func (m *MockIgnition) InjectKubeletTempPrivateKey(pathToSourceIgnition string, privateKeyBytes []byte, certPathToInject string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InjectKubeletTempPrivateKey", pathToSourceIgnition, privateKeyBytes, certPathToInject)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InjectKubeletTempPrivateKey indicates an expected call of InjectKubeletTempPrivateKey.
+func (mr *MockIgnitionMockRecorder) InjectKubeletTempPrivateKey(pathToSourceIgnition, privateKeyBytes, certPathToInject interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectKubeletTempPrivateKey", reflect.TypeOf((*MockIgnition)(nil).InjectKubeletTempPrivateKey), pathToSourceIgnition, privateKeyBytes, certPathToInject)
+}
+
 // MergeIgnitionConfig mocks base method.
 func (m *MockIgnition) MergeIgnitionConfig(base, overrides *types.Config) (*types.Config, error) {
 	m.ctrl.T.Helper()

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -114,7 +114,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign"), device, extra).Return(nil).Times(1)
 			}
 
-			setBootOrderSuccess := func(extra interface{}) {
+			setBootOrderSuccess := func() {
 				mockops.EXPECT().SetBootOrder(device).Return(nil).Times(1)
 			}
 
@@ -310,6 +310,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				for _, version := range []string{"4.7", "4.7.1", "4.7-pre-release", "4.8"} {
 					Context(version, func() {
 						BeforeEach(func() {
+							mockk8sclient.EXPECT().CreateNamespace(nodePublicKeysNamespace).Times(1)
+							mockk8sclient.EXPECT().CreateConfigMap(gomock.Any(), nodePublicKeysNamespace, gomock.Any())
 							conf.OpenshiftVersion = version
 						})
 						AfterEach(func() {
@@ -339,7 +341,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -372,7 +374,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -404,7 +406,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							//HostRoleMaster flow:
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							reportLogProgressSuccess()
 							ironicAgentDoesntExist()
@@ -435,13 +437,15 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ret := installerObj.InstallNode()
 					Expect(ret).To(HaveOccurred())
 				})
 				It("bootstrap role extract ignition retry", func() {
+					mockk8sclient.EXPECT().CreateNamespace(nodePublicKeysNamespace).Times(1)
+					mockk8sclient.EXPECT().CreateConfigMap(gomock.Any(), nodePublicKeysNamespace, gomock.Any())
 					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 						{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 						{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
@@ -465,7 +469,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(true)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
@@ -487,7 +491,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					downloadFileSuccess(bootstrapIgn)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					extractSecretFromIgnitionSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
@@ -511,7 +515,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ret := installerObj.InstallNode()
@@ -554,6 +558,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 						})
 
 						It(fmt.Sprintf("for platform type %v is expected to remove uninitialized taint = %v", platformType, expectedRemoveUninitializedTaint), func() {
+							mockk8sclient.EXPECT().CreateNamespace(nodePublicKeysNamespace).Times(1)
+							mockk8sclient.EXPECT().CreateConfigMap(gomock.Any(), nodePublicKeysNamespace, gomock.Any())
 							updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 								{string(models.HostStageWaitingForControlPlane), waitingForBootstrapToPrepare},
 								{string(models.HostStageWaitingForControlPlane), waitingForMastersStatusInfo},
@@ -599,7 +605,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							//HostRoleMaster flow:
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							reportLogProgressSuccess()
 							ironicAgentDoesntExist()
@@ -724,7 +730,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
@@ -747,7 +753,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
@@ -814,7 +820,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					getEncapsulatedMcSuccess(nil)
@@ -869,7 +875,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ironicAgentDoesntExist()
@@ -894,6 +900,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					evaluateDiskSymlinkSuccess()
 				})
 				It("worker role happy flow", func() {
+					mockk8sclient.EXPECT().CreateNamespace(nodePublicKeysNamespace).Times(1)
+					mockk8sclient.EXPECT().CreateConfigMap(gomock.Any(), nodePublicKeysNamespace, gomock.Any())
 					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 						{string(models.HostStageInstalling), conf.Role},
 						{string(models.HostStageWritingImageToDisk)},
@@ -921,7 +929,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "worker-host-id.ign")
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "worker-host-id.ign"), device, nil).Return(nil).Times(1)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					// failure must do nothing
 					reportLogProgressSuccess()
 					mockops.EXPECT().UploadInstallationLogs(false).Return("", errors.Errorf("Dummy")).Times(1)
@@ -1023,7 +1031,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					singleNodeMergeIgnitionSuccess()
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), singleNodeMasterIgnitionPath, device, nil).Return(nil).Times(1)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(true)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()

--- a/src/inventory_client/inventory_client.go
+++ b/src/inventory_client/inventory_client.go
@@ -20,8 +20,8 @@ import (
 	ttlCache "github.com/ReneKroon/ttlcache/v2"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/hashicorp/go-version"
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/utils"
 	"github.com/openshift/assisted-service/client"
 	"github.com/openshift/assisted-service/client/events"
@@ -254,7 +254,7 @@ func (c *inventoryClient) UploadIngressCa(ctx context.Context, ingressCA string,
 }
 
 func (c *inventoryClient) GetCluster(ctx context.Context, withHosts bool) (*models.Cluster, error) {
-	cluster, err := c.ai.Installer.V2GetCluster(ctx, &installer.V2GetClusterParams{ClusterID: c.clusterId, ExcludeHosts: swag.Bool(!withHosts)})
+	cluster, err := c.ai.Installer.V2GetCluster(ctx, &installer.V2GetClusterParams{ClusterID: c.clusterId, ExcludeHosts: convert.Bool(!withHosts)})
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (c *inventoryClient) GetCluster(ctx context.Context, withHosts bool) (*mode
 }
 
 func (c *inventoryClient) ListsHostsForRole(ctx context.Context, role string) (models.HostList, error) {
-	ret, err := c.ai.Installer.ListClusterHosts(ctx, &installer.ListClusterHostsParams{ClusterID: c.clusterId, Role: swag.String(role)})
+	ret, err := c.ai.Installer.ListClusterHosts(ctx, &installer.ListClusterHostsParams{ClusterID: c.clusterId, Role: convert.String(role)})
 	if err != nil {
 		return nil, err
 	}

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -61,6 +61,20 @@ func (mr *MockK8SClientMockRecorder) ApproveCsr(csr any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApproveCsr", reflect.TypeOf((*MockK8SClient)(nil).ApproveCsr), csr)
 }
 
+// CreateConfigMap mocks base method.
+func (m *MockK8SClient) CreateConfigMap(name, namespace string, data map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConfigMap", name, namespace, data)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateConfigMap indicates an expected call of CreateConfigMap.
+func (mr *MockK8SClientMockRecorder) CreateConfigMap(name, namespace, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConfigMap", reflect.TypeOf((*MockK8SClient)(nil).CreateConfigMap), name, namespace, data)
+}
+
 // CreateEvent mocks base method.
 func (m *MockK8SClient) CreateEvent(namespace, name, message, component string) (*v12.Event, error) {
 	m.ctrl.T.Helper()
@@ -74,6 +88,20 @@ func (m *MockK8SClient) CreateEvent(namespace, name, message, component string) 
 func (mr *MockK8SClientMockRecorder) CreateEvent(namespace, name, message, component any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEvent", reflect.TypeOf((*MockK8SClient)(nil).CreateEvent), namespace, name, message, component)
+}
+
+// CreateNamespace mocks base method.
+func (m *MockK8SClient) CreateNamespace(name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNamespace", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateNamespace indicates an expected call of CreateNamespace.
+func (mr *MockK8SClientMockRecorder) CreateNamespace(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockK8SClient)(nil).CreateNamespace), name)
 }
 
 // DeleteInstallPlan mocks base method.

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/k8s_client"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/go-openapi/swag"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
@@ -64,21 +64,21 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	It("Waiting for cluster installed - first cluster error then installed", func() {
 		// fail to connect to assisted and then succeed
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, fmt.Errorf("dummy")).Times(1)
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
 	})
 
 	It("Waiting for cluster cancelled", func() {
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusCancelled)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusCancelled)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
 	})
 
 	It("Waiting for cluster error - should set error status", func() {
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusError)},
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusError)},
 			nil).Times(1)
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(true))
@@ -91,7 +91,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)}, nil).Times(1)
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
 		Expect(exitCode).Should(Equal(0))
@@ -105,7 +105,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterNotFound()).Times(maximumErrorsBeforeExit)
 
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
@@ -119,7 +119,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterNotFound()).Times(1)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
@@ -133,7 +133,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))
@@ -147,7 +147,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(nil, installer.NewV2GetClusterUnauthorized()).Times(maximumErrorsBeforeExit - 2)
 		// added to make waitForInstallation exit
-		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: swag.String(models.ClusterStatusInstalled)}, nil).Times(1)
+		mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Return(&models.Cluster{Status: convert.String(models.ClusterStatusInstalled)}, nil).Times(1)
 
 		waitForInstallation(mockbmclient, l, mockController)
 		Expect(status.HasError()).Should(Equal(false))

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	config_latest "github.com/coreos/ignition/v2/config/v3_2"
-	"github.com/go-openapi/swag"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/thoas/go-funk"
 	"github.com/vincent-petithory/dataurl"
@@ -33,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/assisted-installer/src/config"
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/ops/execute"
 	"github.com/openshift/assisted-installer/src/utils"
 )
@@ -593,7 +593,7 @@ func (o *ops) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string
 	}
 
 	if len(files) == 0 {
-		lerr := fmt.Errorf("Failed to find must-gather output")
+		lerr := fmt.Errorf("failed to find must-gather output")
 		o.log.Errorf(lerr.Error())
 		return "", lerr
 	}
@@ -707,7 +707,7 @@ func (o *ops) getPointedIgnitionAndCA(ignitionPath string) (string, string, erro
 	for i := range conf.Ignition.Config.Merge {
 		r := &conf.Ignition.Config.Merge[i]
 		if r.Source != nil {
-			source = swag.StringValue(r.Source)
+			source = convert.StringValue(r.Source)
 			if source != "" {
 				break
 			}
@@ -720,7 +720,7 @@ func (o *ops) getPointedIgnitionAndCA(ignitionPath string) (string, string, erro
 	for i := range conf.Ignition.Security.TLS.CertificateAuthorities {
 		r := &conf.Ignition.Security.TLS.CertificateAuthorities[i]
 		if r.Source != nil {
-			d, err := dataurl.DecodeString(swag.StringValue(r.Source))
+			d, err := dataurl.DecodeString(convert.StringValue(r.Source))
 			if err != nil {
 				return "", "", err
 			}

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"reflect"
 
+	"github.com/openshift/assisted-installer/src/convert"
 	"github.com/openshift/assisted-installer/src/ops/execute"
 
 	"github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/go-openapi/swag"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -192,11 +192,11 @@ WkBKOclmOV2xlTVuPw==
 		ret.Ignition.Version = "3.2.0"
 		ret.Ignition.Config.Merge = append(ret.Ignition.Config.Merge,
 			types.Resource{
-				Source: swag.String(source),
+				Source: convert.String(source),
 			})
 		ret.Ignition.Security.TLS.CertificateAuthorities = append(ret.Ignition.Security.TLS.CertificateAuthorities,
 			types.Resource{
-				Source: swag.String(dataurl.EncodeBytes(localhostCert)),
+				Source: convert.String(dataurl.EncodeBytes(localhostCert)),
 			})
 		return ret
 	}


### PR DESCRIPTION
Once the minimal control plane has been performed and consists of two nodes, we start the assisted-installer-controller pod and then reboot the bootstrap when this is ready. The bootstrap will attempt to join the control plane when it boots up. As part of this process, CSR's are submitted. Presently, we just assume that these are meant to be signed and blindly approve them.

This is problematic from a security perspective and could lead to an attack where, with careful timing, someone might be able to add a rogue node to the cluster. To prevent this, we should check that the hostname being presented in the CSR actually matches one of our known hosts.

To do this, requires two steps:

1: Prior to start of the assisted-installer-controller pod, we will save a list of known hosts in a config map called `known-hosts`, this will contain a single entry `content` which will be a newline separated list of hostnames
2: During the CSR validation, this will be read and used to verify that the CSR originates from a known host