### PR TITLE
OCPBUGS-38466: Allow controller to continue when assisted-service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
 	sigs.k8s.io/controller-runtime v0.17.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -181,7 +182,6 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace (

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -115,7 +115,7 @@ type Controller interface {
 	UpdateNodeLabels(ctx context.Context, wg *sync.WaitGroup)
 	UpdateBMHs(ctx context.Context, wg *sync.WaitGroup)
 	UploadLogs(ctx context.Context, wg *sync.WaitGroup, invoker string)
-	SetReadyState() *models.Cluster
+	SetReadyState(waitTimeout time.Duration) *models.Cluster
 	GetStatus() *ControllerStatus
 }
 
@@ -1471,11 +1471,11 @@ func (c *controller) UploadLogs(ctx context.Context, wg *sync.WaitGroup, invoker
 	}
 }
 
-func (c *controller) SetReadyState() *models.Cluster {
+func (c controller) SetReadyState(waitTimeout time.Duration) *models.Cluster {
 	c.log.Infof("Start waiting to be ready")
 	var cluster *models.Cluster
 	var err error
-	_ = utils.WaitForPredicate(WaitTimeout, 1*time.Second, func() bool {
+	_ = utils.WaitForPredicate(waitTimeout, 1*time.Second, func() bool {
 		cluster, err = c.ic.GetCluster(context.TODO(), false)
 		if err != nil {
 			c.log.WithError(err).Warningf("Failed to connect to assisted service")

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -338,7 +338,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockk8sclient.EXPECT().CreateEvent(assistedController.Namespace, common.AssistedControllerIsReadyEvent, gomock.Any(), common.AssistedControllerPrefix).Return(nil, fmt.Errorf("dummy")).Times(1)
 			mockk8sclient.EXPECT().CreateEvent(assistedController.Namespace, common.AssistedControllerIsReadyEvent, gomock.Any(), common.AssistedControllerPrefix).Return(nil, nil).Times(1)
 
-			assistedController.SetReadyState()
+			assistedController.SetReadyState(WaitTimeout)
 			Expect(assistedController.status.HasError()).Should(Equal(false))
 		})
 

--- a/src/assisted_installer_controller/mock_controller.go
+++ b/src/assisted_installer_controller/mock_controller.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=assisted_installer_controller.go -package=assisted_installer_controller -destination=mock_controller.go
 //
+
 // Package assisted_installer_controller is a generated GoMock package.
 package assisted_installer_controller
 
@@ -12,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 	sync "sync"
+	time "time"
 
 	models "github.com/openshift/assisted-service/models"
 	gomock "go.uber.org/mock/gomock"
@@ -79,17 +81,17 @@ func (mr *MockControllerMockRecorder) PostInstallConfigs(ctx, wg any) *gomock.Ca
 }
 
 // SetReadyState mocks base method.
-func (m *MockController) SetReadyState() *models.Cluster {
+func (m *MockController) SetReadyState(waitTimeout time.Duration) *models.Cluster {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetReadyState")
+	ret := m.ctrl.Call(m, "SetReadyState", waitTimeout)
 	ret0, _ := ret[0].(*models.Cluster)
 	return ret0
 }
 
 // SetReadyState indicates an expected call of SetReadyState.
-func (mr *MockControllerMockRecorder) SetReadyState() *gomock.Call {
+func (mr *MockControllerMockRecorder) SetReadyState(waitTimeout any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadyState", reflect.TypeOf((*MockController)(nil).SetReadyState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadyState", reflect.TypeOf((*MockController)(nil).SetReadyState), waitTimeout)
 }
 
 // UpdateBMHs mocks base method.

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -501,7 +501,7 @@ func (i *installer) waitForControlPlane(ctx context.Context) error {
 	}
 	i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, waitingForMastersStatusInfo)
 
-	hasValidvSphereCredentials := common.HasValidvSphereCredentials(ctx, i.inventoryClient, i.log)
+	hasValidvSphereCredentials := common.HasValidvSphereCredentials(ctx, i.inventoryClient, kc, i.log)
 	if hasValidvSphereCredentials {
 		i.log.Infof("Has valid vSphere credentials: %v", hasValidvSphereCredentials)
 	}
@@ -706,8 +706,10 @@ func (i *installer) waitForMasterNodes(ctx context.Context, minMasterNodes int, 
 			// GetInvoker reads the openshift-install-manifests in the openshift-config namespace.
 			// This configmap exists after nodes start to appear in the cluster.
 			invoker := common.GetInvoker(kc, i.log)
-			removeUninitializedTaint := common.RemoveUninitializedTaint(platform, invoker,
-				hasValidvSphereCredentials, i.OpenshiftVersion)
+			removeUninitializedTaint := false
+			if platform != nil {
+				removeUninitializedTaint = common.RemoveUninitializedTaint(ctx, i.inventoryClient, kc, i.log, *platform.Type, i.OpenshiftVersion, invoker)
+			}
 			i.log.Infof("Remove uninitialized taint: %v", removeUninitializedTaint)
 			if removeUninitializedTaint {
 				for _, node := range nodes.Items {


### PR DESCRIPTION
is unavailable in agent-based installs.

assisted-service runs on the bootstrap node in agent-based installs. The bootstrap node reboots after the control plane is available.

If the assisted-installer-controller restarts after the bootstrap node reboots, or for some reason the controller is never able to contact assisted-service, the controller loops waiting or assisted-service to become available, times out, and exits.

With compact clusters, because the controller exited and is unable to approve CSRs, the third control plane node is unable to join the cluster causing the cluster installation to fail.

If the invoker is agent-installer, instead of exiting, this patch allows the controller to continue to run when assisted-service is offline.

Because assisted-service may be unavailable,
HasValidvSphereCredentials has been updated to also look at the install-config to determine if credentials were set. Because username and password are redacted, only the server name is used to determine if valid credentials were provided.