### PR TITLE
NO-ISSUE: Update Dockerfile to use `go.uber.org/mock`

### DIFF
--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -5,7 +5,7 @@ ENV GOFLAGS=""
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0 && \ 
   go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
   go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
-  go install github.com/golang/mock/mockgen@v1.6.0 && \
+  go install go.uber.org/mock/mockgen@v0.4.0 && \
   go install gotest.tools/gotestsum@v1.6.3 && \
   go install github.com/axw/gocov/gocov@latest && \
   go install github.com/AlekSi/gocov-xml@latest

--- a/src/assisted_installer_controller/mock_controller.go
+++ b/src/assisted_installer_controller/mock_controller.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=assisted_installer_controller.go -package=assisted_installer_controller -destination=mock_controller.go
 //
+
 // Package assisted_installer_controller is a generated GoMock package.
 package assisted_installer_controller
 

--- a/src/assisted_installer_controller/mock_reboots_notifier.go
+++ b/src/assisted_installer_controller/mock_reboots_notifier.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=reboots_notifier.go -package=assisted_installer_controller -destination=mock_reboots_notifier.go
 //
+
 // Package assisted_installer_controller is a generated GoMock package.
 package assisted_installer_controller
 

--- a/src/ignition/mock_ignition.go
+++ b/src/ignition/mock_ignition.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=ignition.go -package=ignition -destination=mock_ignition.go
 //
+
 // Package ignition is a generated GoMock package.
 package ignition
 

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=inventory_client.go -package=inventory_client -destination=mock_inventory_client.go
 //
+
 // Package inventory_client is a generated GoMock package.
 package inventory_client
 

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=k8s_client.go -package=k8s_client -destination=mock_k8s_client.go
 //
+
 // Package k8s_client is a generated GoMock package.
 package k8s_client
 

--- a/src/ops/execute/mock_execute.go
+++ b/src/ops/execute/mock_execute.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=execute.go -package=execute -destination=mock_execute.go
 //
+
 // Package execute is a generated GoMock package.
 package execute
 

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=ops.go -package=ops -destination=mock_ops.go
 //
+
 // Package ops is a generated GoMock package.
 package ops
 


### PR DESCRIPTION
The change to use `go.uber.org/mock` instead of the deprecated `github.com/golang/mock` was was mostly done in the past. But the _Dockerfile_ wasn't updated to use the new `mockgen` command.  As a result if one installs the `mockgen` with the command from the dockerfile and then runs `make generate` the resulting code doesn't build:

```
$ grep mockgen Dockerfile.assisted-installer-build
  go install github.com/golang/mock/mockgen@v1.6.0 && \

$ go install github.com/golang/mock/mockgen@v1.6.0

$ make generate
go generate ..
make format
make[1]: Entering directory '/files/projects/assisted-installer/repository'
make[1]: Leaving directory '/files/projects/assisted-installer/repository'

$ make build
CGO_ENABLED=0  go build -o build/installer src/main/main.go
src/main/drymock/dry_mode_k8s_mock.go:308:36: cannot use mockController (variable of type *"go.uber.org/mock/gomock".Controller) as *"github.com/golang/mock/gomock".Controller value in argument to k8s_client.NewMockK8SClient
make: *** [Makefile:68: installer] Error 1
```

To avoid this issue this patch updates the _Dockerfile_ to use the `go.uber.org/mock` package.

There are also some minor white space changes introduced by running `go generate`.