### PR TITLE
NO-ISSUE: Ignore JUnit output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ kubevirtci/
 .*.swp
 
 reports
+
+**/junit_unit_test.xml


### PR DESCRIPTION
Running the unit tests generates JUnit files named `junit_unit_test.xml` in multiple files. This patch changes the `.gitignore` file so that they aren't accidentally added to the repository.