### PR TITLE
MGMT-19148: Wait for OLM operator setup jobs

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -746,7 +746,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				},
 			}
 
-			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).Times(1)
+			mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("", fmt.Errorf("dummy")).Times(1)
 			Expect(assistedController.waitForCSVBeCreated(operators)).Should(Equal(false))
@@ -758,7 +758,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					Name: operatorName, Status: models.OperatorStatusProgressing, OperatorType: models.OperatorTypeOlm,
 				},
 			}
-			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+			mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).AnyTimes()
 			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("", nil).Times(1)
 			mockk8sclient.EXPECT().GetCSV(operators[0].Namespace, gomock.Any()).Return(nil, fmt.Errorf("dummy")).Times(1)
@@ -777,7 +777,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			succeededJob := batchV1.Job{ObjectMeta: metav1.ObjectMeta{Name: "succeed", Namespace: olmNamespace}, Status: batchV1.JobStatus{Failed: 0}}
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("", nil).Times(1)
 			mockk8sclient.EXPECT().GetCSV(operators[0].Namespace, gomock.Any()).Return(nil, apierrors.NewNotFound(apischema.GroupResource{}, failedJob.Name)).Times(1)
-			mockk8sclient.EXPECT().ListJobs(olmNamespace).Return(&batchV1.JobList{Items: []batchV1.Job{failedJob, succeededJob, failedJob1}}, nil).Times(1)
+			mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{Items: []batchV1.Job{failedJob, succeededJob, failedJob1}}, nil).Times(1)
 			mockk8sclient.EXPECT().DeleteJob(types.NamespacedName{Name: failedJob.Name, Namespace: failedJob.Namespace}).Return(nil).Times(1)
 			mockk8sclient.EXPECT().DeleteJob(types.NamespacedName{Name: failedJob1.Name, Namespace: failedJob1.Namespace}).Return(nil).Times(1)
 
@@ -798,7 +798,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					Name: operatorName, Status: models.OperatorStatusProgressing, OperatorType: models.OperatorTypeOlm,
 				},
 			}
-			mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).Times(1)
+			mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).Times(1)
 			mockk8sclient.EXPECT().GetCSVFromSubscription(operators[0].Namespace, operators[0].SubscriptionName).Return("randomCSV", nil).Times(1)
 			mockk8sclient.EXPECT().GetCSV(operators[0].Namespace, gomock.Any()).Return(nil, nil).Times(1)
@@ -1129,7 +1129,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				)
 
 				wg.Add(1)
-				mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+				mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).AnyTimes()
 				mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 				assistedController.PostInstallConfigs(context.TODO(), &wg)
 				wg.Wait()
@@ -1150,7 +1150,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				By("endless empty status", func() {
 					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
-					mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+					mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSVFromSubscription("openshift-local-storage", "local-storage-operator").Return("lso-1.1", nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSV("openshift-local-storage", "lso-1.1").Return(&olmv1alpha1.ClusterServiceVersion{Status: olmv1alpha1.ClusterServiceVersionStatus{Phase: olmv1alpha1.CSVPhaseInstalling}}, nil).AnyTimes()
@@ -1188,7 +1188,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 				By("endless empty status", func() {
 					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
-					mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
+					mockk8sclient.EXPECT().ListJobs(olmNamespace, metav1.ListOptions{}).Return(&batchV1.JobList{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSVFromSubscription("openshift-local-storage", "local-storage-operator").Return("lso-1.1", nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSV("openshift-local-storage", "lso-1.1").Return(&olmv1alpha1.ClusterServiceVersion{Status: olmv1alpha1.ClusterServiceVersionStatus{Phase: olmv1alpha1.CSVPhaseInstalling}}, nil).AnyTimes()

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-installer/src/inventory_client"

--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -8,6 +8,7 @@ import (
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/assisted-installer/src/k8s_client"
@@ -198,7 +199,7 @@ func (handler ClusterServiceVersionHandler) handleOLMEarlySetupBug() error {
 }
 
 func (handler ClusterServiceVersionHandler) deleteFailedOlmJobs() error {
-	jobs, err := handler.kc.ListJobs(olmNamespace)
+	jobs, err := handler.kc.ListJobs(olmNamespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/src/assisted_installer_controller/reboots_notifier_test.go
+++ b/src/assisted_installer_controller/reboots_notifier_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 var _ = Describe("Reboots notifier", func() {

--- a/src/common/common_test.go
+++ b/src/common/common_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/src/coreos_logger/coreos_installer_log_writer_test.go
+++ b/src/coreos_logger/coreos_installer_log_writer_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/openshift/assisted-installer/src/inventory_client"
 	"github.com/openshift/assisted-service/models"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/sirupsen/logrus/hooks/test"
 

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -30,7 +30,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 func TestValidator(t *testing.T) {

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -83,7 +83,7 @@ type K8SClient interface {
 	PatchNamespace(namespace string, data []byte) error
 	GetNode(name string) (*v1.Node, error)
 	PatchNodeLabels(nodeName string, nodeLabels string) error
-	ListJobs(namespace string) (*batchV1.JobList, error)
+	ListJobs(namespace string, options metav1.ListOptions) (*batchV1.JobList, error)
 	DeleteJob(job types.NamespacedName) error
 	IsClusterCapabilityEnabled(configv1.ClusterVersionCapability) (bool, error)
 	UntaintNode(name string) error
@@ -192,8 +192,8 @@ func (c *k8sClient) DeleteService(name, namespace string) error {
 	return c.client.CoreV1().Services(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
-func (c *k8sClient) ListJobs(namespace string) (*batchV1.JobList, error) {
-	jobs, err := c.client.BatchV1().Jobs(namespace).List(context.TODO(), metav1.ListOptions{})
+func (c *k8sClient) ListJobs(namespace string, options metav1.ListOptions) (*batchV1.JobList, error) {
+	jobs, err := c.client.BatchV1().Jobs(namespace).List(context.TODO(), options)
 	if err != nil {
 		return &batchV1.JobList{}, err
 	}

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -22,6 +22,7 @@ import (
 	v10 "k8s.io/api/batch/v1"
 	v11 "k8s.io/api/certificates/v1"
 	v12 "k8s.io/api/core/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 )
 
@@ -448,18 +449,18 @@ func (mr *MockK8SClientMockRecorder) ListEvents(namespace any) *gomock.Call {
 }
 
 // ListJobs mocks base method.
-func (m *MockK8SClient) ListJobs(namespace string) (*v10.JobList, error) {
+func (m *MockK8SClient) ListJobs(namespace string, options v13.ListOptions) (*v10.JobList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListJobs", namespace)
+	ret := m.ctrl.Call(m, "ListJobs", namespace, options)
 	ret0, _ := ret[0].(*v10.JobList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListJobs indicates an expected call of ListJobs.
-func (mr *MockK8SClientMockRecorder) ListJobs(namespace any) *gomock.Call {
+func (mr *MockK8SClientMockRecorder) ListJobs(namespace, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockK8SClient)(nil).ListJobs), namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockK8SClient)(nil).ListJobs), namespace, options)
 }
 
 // ListMachines mocks base method.

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/secretdump"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 // Added this way to be able to test it

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 func TestValidator(t *testing.T) {

--- a/src/main/drymock/dry_mode_k8s_mock.go
+++ b/src/main/drymock/dry_mode_k8s_mock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/assisted-installer/src/k8s_client"
 	"github.com/openshift/assisted-installer/src/ops"
 	"github.com/sirupsen/logrus"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"github.com/vincent-petithory/dataurl"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 var _ = Describe("installerArgs", func() {


### PR DESCRIPTION
When operators are automatically enabled from assisted installer the custom manifests may contain Kubernetes jobs to complete the setup. For example, a hypothetical storage operator can include in the custom manifests a job that waits for the storage class and marks it as the default. Currently the installer doesn't wait for jobs to finish, and it will declare the cluster to be ready even if those jobs haven't been completed. This patch changes the controller so that it assumes that jobs that have the `agent-install.openshift.io/setup-job` label are such setup jobs, and waits for them to finish. The value of the label must be the name of the corresponding operator.