### PR TITLE
OCPBUGS-42553: Rhcos fails to reboot for skip mco reboot on s390x

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -1345,7 +1345,7 @@ func (c *controller) uploadSummaryLogs(podName string, namespace string, sinceSe
 
 	if !ok {
 		msg := "Some Logs were not collected in summary"
-		c.log.Errorf(msg)
+		c.log.Error(msg)
 		return errors.New(msg)
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -923,7 +923,7 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 		growpartcmd = makecmd("growpart", device, "4")
 	}
 	ret, err := o.ExecPrivilegeCommand(nil, "uname", "-m")
-	if err == nil && ret != nil && ret == "s390x" {
+	if err == nil && ret == "s390x" {
 		o.log.Infof("Running on s390x archtiecture - skip overwrite image.")
 		return nil
 	}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -922,6 +922,11 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 	} else {
 		growpartcmd = makecmd("growpart", device, "4")
 	}
+	ret, err := o.ExecPrivilegeCommand(nil, "uname", "-m")
+	if err == nil && ret != nil && ret == "s390x" {
+		o.log.Infof("Running on s390x archtiecture - skip overwrite image.")
+		return nil
+	}
 	cmds := []*cmd{
 		makecmd("mount", partitionForDevice(device, "4"), "/mnt"),
 		makecmd("mount", partitionForDevice(device, "3"), "/mnt/boot"),
@@ -949,7 +954,6 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 				"rhcos"), extraArgs...)...,
 		),
 		makecmd("fsfreeze", "--freeze", "/mnt/boot"),
-		makecmd("if ", "command -v zipl -v > /dev/null; then zipl -V -t /mnt/boot -b /mnt/boot/loader/entries; ", "fi"),
 		makecmd("umount", "/mnt/boot"),
 		makecmd("fsfreeze", "--freeze", "/mnt"),
 		makecmd("umount", "/mnt"),

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -949,6 +949,7 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 				"rhcos"), extraArgs...)...,
 		),
 		makecmd("fsfreeze", "--freeze", "/mnt/boot"),
+		makecmd("if ", "command -v zipl -v > /dev/null; then zipl -V -t /mnt/boot -b /mnt/boot/loader/entries; ", "fi"),
 		makecmd("umount", "/mnt/boot"),
 		makecmd("fsfreeze", "--freeze", "/mnt"),
 		makecmd("umount", "/mnt"),

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -434,6 +434,7 @@ var _ = Describe("overwrite OS image", func() {
 			"abc",
 		}
 		mockPrivileged("cat", "/proc/cmdline")
+		mockPrivileged("uname", "-m")
 		mockPrivileged("mount", part4, "/mnt")
 		mockPrivileged("mount", part3, "/mnt/boot")
 		mockPrivileged("growpart", "--free-percent=92", device, "4")


### PR DESCRIPTION
There seems to be an issue with ostree command could not run successful zipl command on s390x architecture. For the time being the reason is unknown (it could be that the /boot directory is not mounted with rw option).
Until the root cause is not found the overwrite of the image for s390x will be skipped by checking the uname before overwrite happen.
This patch adds a uname check to the OverwriteOsImage function. Beside that the ops_test will be adapted accordingly.
The fix was tested against integration envrionment:
[root@a3e06001 ~]# oc get no
NAME                                 STATUS   ROLES                         AGE     VERSION                                                                                                                                                          
master-t313-0.boea3e06.lnxero1.boe   Ready    control-plane,master,worker   2d20h   v1.31.2                                                                                                                                                          
[root@a3e06001 ~]# oc get co                                                                                                                                                                                                                         
NAME                                       VERSION       AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE  
authentication                             4.18.0-ec.3   True        False         False      2d2h    
baremetal                                  4.18.0-ec.3   True        False         False      3d1h    
cloud-controller-manager                   4.18.0-ec.3   True        False         False      3d1h    
cloud-credential                           4.18.0-ec.3   True        False         False      3d2h    
cluster-autoscaler                         4.18.0-ec.3   True        False         False      3d1h    
config-operator                            4.18.0-ec.3   True        False         False      3d1h    
console                                    4.18.0-ec.3   True        False         False      3d1h    
...

