### PR TITLE
MGMT-19371: Add downstream dockerfiles for mce

### DIFF
--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,0 +1,51 @@
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV COMPONENT_NAME=assisted-installer-controller
+ENV COMPONENT_VERSION=1.0.0
+ENV COMPONENT_TAG_EXTENSION=" "
+ENV GOFLAGS="-p=4"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV BUILD_TAGS="strictfipsruntime"
+
+ENV USER_UID=1001 \
+    USER_NAME=assisted-installer
+
+COPY --chown=${USER_UID} . /app
+WORKDIR /app
+
+RUN go install github.com/google/go-licenses@v1.6.0
+RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -o assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
+
+
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+ARG release=main
+ARG version=latest
+
+RUN PKGS=$(if [ "$(uname -m)" == "s390x" ]; then echo -n 'tar gzip rsync' ; else echo -n 'tar gzip openshift-clients rsync'; fi) && \
+    subscription-manager refresh && dnf -y install $PKGS && dnf clean all
+
+COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder /app/assisted-installer-controller /assisted-installer-controller
+
+ENTRYPOINT ["/assisted-installer-controller"]
+
+LABEL com.redhat.component="multicluster-engine-assisted-installer-controller-container" \
+      name="multicluster-engine/assisted-installer-controller-rhel9" \
+      version="${version}" \
+      upstream-ref="${version}" \
+      upstream-url="https://github.com/openshift/assisted-installer" \
+      summary="OpenShift Assisted Installer Controller" \
+      io.k8s.display-name="OpenShift Assisted Installer Controller" \
+      maintainer="Liat Gamliel <lgamliel@redhat.com>" \
+      description="OpenShift Assisted Installer Controller" \
+      io.k8s.description="OpenShift Assisted Installer Controller" \
+      distribution-scope="public" \
+      release="${release}" \
+      vendor="Red Hat, Inc." \
+      upstream_commit="${version}" \
+      org.label-schema.vcs-ref="${version}" \
+      org.label-schema.vcs-url="https://github.com/openshift/assisted-installer"

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,0 +1,51 @@
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV COMPONENT_NAME=installer
+ENV COMPONENT_VERSION=1.0.0
+ENV COMPONENT_TAG_EXTENSION=" "
+ENV GOFLAGS="-p=4"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV BUILD_TAGS="strictfipsruntime"
+
+ENV USER_UID=1001 \
+    USER_NAME=assisted-installer
+
+COPY --chown=${USER_UID} . /app
+WORKDIR /app
+
+RUN go install github.com/google/go-licenses@v1.6.0
+RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -o installer src/main/main.go
+
+
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+ARG release=main
+ARG version=latest
+
+RUN subscription-manager refresh && dnf install -y util-linux && dnf clean all
+
+COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder /app/installer /installer
+COPY --from=builder /app/deploy/assisted-installer-controller /assisted-installer-controller/deploy
+
+ENTRYPOINT ["/installer"]
+
+LABEL com.redhat.component="multicluster-engine-assisted-installer-container" \
+      name="multicluster-engine/assisted-installer-rhel9" \
+      version="${version}" \
+      upstream-ref="${version}" \
+      upstream-url="https://github.com/openshift/assisted-installer" \
+      summary="OpenShift Assisted Installer" \
+      io.k8s.display-name="OpenShift Assisted Installer" \
+      maintainer="Liat Gamliel <lgamliel@redhat.com>" \
+      description="OpenShift Assisted Installer" \
+      io.k8s.description="OpenShift Assisted Installer" \
+      distribution-scope="public" \
+      release="${release}" \
+      vendor="Red Hat, Inc." \
+      upstream_commit="${version}" \
+      org.label-schema.vcs-ref="${version}" \
+      org.label-schema.vcs-url="https://github.com/openshift/assisted-installer"


### PR DESCRIPTION
As part of migrating to konflux, we need to update our downstream dockerfiles for mce and put them in our upstream repos.

Part-of [MGMT-19371](https://issues.redhat.com//browse/MGMT-19371)