### PR TITLE
OCPBUGS-45116: Add retry to mount efi device

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -260,7 +260,10 @@ func (o *ops) findEfiDirectory(device string) (string, error) {
 		out string
 		err error
 	)
-	if _, err = o.ExecPrivilegeCommand(nil, "mount", partitionForDevice(device, "2"), "/mnt"); err != nil {
+	if err = utils.Retry(3, 5*time.Second, o.log, func() (err error) {
+		_, err = o.ExecPrivilegeCommand(nil, "mount", partitionForDevice(device, "2"), "/mnt")
+		return
+	}); err != nil {
 		return "", errors.Wrap(err, "failed to mount efi device")
 	}
 	defer func() {


### PR DESCRIPTION
There is a race condition between the mount and setting the boot order, this pr adds a retry to the mount operation.