### PR TITLE
MGMT-19381: Change downstream base images to rhel9.4 instead of ubi9

### DIFF
--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -18,7 +18,7 @@ RUN go install github.com/google/go-licenses@v1.6.0
 RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -21,7 +21,7 @@ RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -o assisted-installer-controller src/main/assisted-installer-controller/assisted_installer_main.go
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 

--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -18,7 +18,7 @@ RUN go install github.com/google/go-licenses@v1.6.0
 RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -21,7 +21,7 @@ RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -o installer src/main/main.go
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 


### PR DESCRIPTION
Currently our base images use ubi9 and MintMaker wants to upgrade it to 9.5, because MintMaker looks at the repo and tries to upgrade to the newest tag.
This changes the base image to use a repo that is just for rhel9.4.

Part-of [MGMT-19381](https://issues.redhat.com//browse/MGMT-19381)