### PR TITLE
MGMT-19100: Install to the current boot device when CoreosImage is set

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	SkipInstallationDiskCleanup bool
 	EnableSkipMcoReboot         bool
 	NotifyNumReboots            bool
+	CoreosImage                 string
 }
 
 func printHelpAndExit(err error) {
@@ -79,6 +80,7 @@ func (c *Config) ProcessArgs(args []string) {
 	flagSet.BoolVar(&c.SkipInstallationDiskCleanup, "skip-installation-disk-cleanup", false, "Skip installation disk cleanup gives disk management to coreos-installer in case needed")
 	flagSet.BoolVar(&c.EnableSkipMcoReboot, "enable-skip-mco-reboot", false, "indicate assisted installer to generate settings to match MCO requirements for skipping reboot after firstboot")
 	flagSet.BoolVar(&c.NotifyNumReboots, "notify-num-reboots", false, "indicate number of reboots should be notified as event")
+	flagSet.StringVar(&c.CoreosImage, "coreos-image", "", "CoreOS image to install to the existing root")
 
 	var installerArgs string
 	flagSet.StringVar(&installerArgs, "installer-args", "", "JSON array of additional coreos-installer arguments")

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -66,6 +66,12 @@ var _ = Describe("ProcessArgs", func() {
 		Expect(config.InfraEnvID).To(Equal("9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8"))
 	})
 
+	It("should set coreos image when provided", func() {
+		config := &Config{}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--infra-env-id", "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--coreos-image", "example.com/coreos/os:latest"}
+		config.ProcessArgs(arguments)
+		Expect(config.CoreosImage).To(Equal("example.com/coreos/os:latest"))
+	})
 })
 
 var _ = Describe("SetInstallerArgs", func() {

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -114,7 +114,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign"), device, extra).Return(nil).Times(1)
 			}
 
-			setBootOrderSuccess := func(extra interface{}) {
+			setBootOrderSuccess := func() {
 				mockops.EXPECT().SetBootOrder(device).Return(nil).Times(1)
 			}
 
@@ -389,7 +389,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -425,7 +425,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -449,7 +449,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							//HostRoleMaster flow:
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							getEncapsulatedMcSuccess(nil)
 							overwriteImageSuccess()
 							ret := installerObj.InstallNode()
@@ -480,7 +480,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -513,7 +513,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							//HostRoleMaster flow:
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							reportLogProgressSuccess()
 							ironicAgentDoesntExist()
@@ -554,7 +554,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
 							reportLogProgressSuccess()
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							ironicAgentDoesntExist()
 							rebootSuccess()
@@ -584,7 +584,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ret := installerObj.InstallNode()
@@ -615,7 +615,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(true)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
@@ -637,7 +637,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					downloadFileSuccess(bootstrapIgn)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					extractSecretFromIgnitionSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
@@ -661,7 +661,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					//HostRoleMaster flow:
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(gomock.Any())
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ret := installerObj.InstallNode()
@@ -748,7 +748,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							//HostRoleMaster flow:
 							downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 							writeToDiskSuccess(gomock.Any())
-							setBootOrderSuccess(gomock.Any())
+							setBootOrderSuccess()
 							uploadLogsSuccess(true)
 							reportLogProgressSuccess()
 							ironicAgentDoesntExist()
@@ -847,18 +847,23 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				})
 			})
 			Context("Master role", func() {
-				installerArgs := []string{"-n", "--append-karg", "nameserver=8.8.8.8"}
-				conf := config.Config{Role: string(models.HostRoleMaster),
-					ClusterID:           "cluster-id",
-					InfraEnvID:          "infra-env-id",
-					HostID:              "host-id",
-					Device:              "/dev/vda",
-					URL:                 "https://assisted-service.com:80",
-					OpenshiftVersion:    openShiftVersion,
-					InstallerArgs:       installerArgs,
-					EnableSkipMcoReboot: withEnableSkipMcoReboot,
-				}
+				var (
+					conf          config.Config
+					installerArgs []string
+				)
+
 				BeforeEach(func() {
+					installerArgs = []string{"-n", "--append-karg", "nameserver=8.8.8.8"}
+					conf = config.Config{Role: string(models.HostRoleMaster),
+						ClusterID:           "cluster-id",
+						InfraEnvID:          "infra-env-id",
+						HostID:              "host-id",
+						Device:              "/dev/vda",
+						URL:                 "https://assisted-service.com:80",
+						OpenshiftVersion:    openShiftVersion,
+						InstallerArgs:       installerArgs,
+						EnableSkipMcoReboot: withEnableSkipMcoReboot,
+					}
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)
 					evaluateDiskSymlinkSuccess()
 
@@ -873,13 +878,35 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
 					rebootSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
+					ret := installerObj.InstallNode()
+					Expect(ret).Should(BeNil())
+				})
+
+				It("installs to the existing root and does not skip reboot, clean install device, or set boot order when coreosImage is set", func() {
+					installerObj.Config.CoreosImage = "example.com/coreos/os:latest"
+					updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
+						{string(models.HostStageInstalling), conf.Role},
+						{string(models.HostStageWritingImageToDisk)},
+						{string(models.HostStageRebooting)},
+					})
+					cleanupDevice.EXPECT().CleanupInstallDevice(device).Times(0)
+					mkdirSuccess(InstallDir)
+					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
+					mockops.EXPECT().WriteImageToExistingRoot(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign")).Return(nil).Times(1)
+					mockops.EXPECT().SetBootOrder(device).Times(0)
+					uploadLogsSuccess(false)
+					reportLogProgressSuccess()
+					ironicAgentDoesntExist()
+					rebootSuccess()
+					mockops.EXPECT().GetEncapsulatedMC(gomock.Any()).Times(0)
+					mockops.EXPECT().OverwriteOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 					ret := installerObj.InstallNode()
 					Expect(ret).Should(BeNil())
 				})
@@ -896,7 +923,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()
@@ -963,7 +990,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					getEncapsulatedMcSuccess(nil)
@@ -1018,7 +1045,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()
 					writeToDiskSuccess(installerArgs)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					getEncapsulatedMcSuccess(nil)
 					overwriteImageSuccess()
 					ironicAgentDoesntExist()
@@ -1070,7 +1097,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "worker-host-id.ign")
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), filepath.Join(InstallDir, "worker-host-id.ign"), device, nil).Return(nil).Times(1)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					// failure must do nothing
 					reportLogProgressSuccess()
 					mockops.EXPECT().UploadInstallationLogs(false).Return("", errors.Errorf("Dummy")).Times(1)
@@ -1176,7 +1203,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					singleNodeMergeIgnitionSuccess()
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
 					mockops.EXPECT().WriteImageToDisk(gomock.Any(), singleNodeMasterIgnitionPath, device, nil).Return(nil).Times(1)
-					setBootOrderSuccess(gomock.Any())
+					setBootOrderSuccess()
 					uploadLogsSuccess(true)
 					reportLogProgressSuccess()
 					ironicAgentDoesntExist()

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -399,3 +399,17 @@ func (mr *MockOpsMockRecorder) WriteImageToDisk(liveLogger, ignitionPath, device
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToDisk", reflect.TypeOf((*MockOps)(nil).WriteImageToDisk), liveLogger, ignitionPath, device, extraArgs)
 }
+
+// WriteImageToExistingRoot mocks base method.
+func (m *MockOps) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteImageToExistingRoot", liveLogger, ignitionPath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteImageToExistingRoot indicates an expected call of WriteImageToExistingRoot.
+func (mr *MockOpsMockRecorder) WriteImageToExistingRoot(liveLogger, ignitionPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToExistingRoot", reflect.TypeOf((*MockOps)(nil).WriteImageToExistingRoot), liveLogger, ignitionPath)
+}

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -38,6 +38,7 @@ import (
 )
 
 const (
+	dockerConfigFile                = "/root/.docker/config.json"
 	coreosInstallerExecutable       = "coreos-installer"
 	dryRunCoreosInstallerExecutable = "dry-installer"
 	encapsulatedMachineConfigFile   = "/etc/ignition-machine-config-encapsulated.json"
@@ -130,7 +131,7 @@ var ostreeOutputRegex = regexp.MustCompile(`Imported: (\w+)`)
 
 func (o *ops) importOSTreeCommit(liveLogger io.Writer) (string, error) {
 	ostreeReleasePullSpec := fmt.Sprintf("ostree-unverified-registry:%s", o.installerConfig.CoreosImage)
-	out, err := o.ExecPrivilegeCommand(liveLogger, "ostree", "container", "unencapsulate", "--authfile", "/root/.docker/config.json", "--quiet", "--repo", "/ostree/repo", ostreeReleasePullSpec)
+	out, err := o.ExecPrivilegeCommand(liveLogger, "ostree", "container", "unencapsulate", "--authfile", dockerConfigFile, "--quiet", "--repo", "/ostree/repo", ostreeReleasePullSpec)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to unencapsulate rhcos payload image: %s", out)
 	}
@@ -1018,7 +1019,7 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 				"--sysroot",
 				"/mnt",
 				"--authfile",
-				"/root/.docker/config.json",
+				dockerConfigFile,
 				"--imgref",
 				"ostree-unverified-registry:"+osImage,
 				"--karg",


### PR DESCRIPTION
This indicates the container image that should be installed and booted for the installed host. It also indicates that we should install to the currently booted disk, in a new stateroot, rather than expecting a device path.

https://issues.redhat.com/browse/MGMT-19100

cc @tsorya @rccrdpccl @eranco74 