### PR TITLE
NO-ISSUE: Make konflux builds for downstream images to be multi-arch

### DIFF
--- a/.tekton/assisted-installer-controller-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-controller-downstream-main-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted-installer-controller-downstream
   - name: path-context

--- a/.tekton/assisted-installer-controller-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-controller-downstream-main-push.yaml
@@ -26,6 +26,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted-installer-controller-downstream
   - name: path-context

--- a/.tekton/assisted-installer-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-downstream-main-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted-installer-downstream
   - name: path-context

--- a/.tekton/assisted-installer-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-downstream-main-push.yaml
@@ -26,6 +26,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted-installer-downstream
   - name: path-context


### PR DESCRIPTION
Currently downstream images are only built for x64, but we need to build for arm, s390x and ppc64le as well.
These downstream images are going to be used by SaaS.