### PR TITLE
MGMT-19748: Configure snyk ignore

### DIFF
--- a/.tekton/assisted-installer-controller-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-controller-downstream-main-pull-request.yaml
@@ -398,6 +398,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-controller-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-controller-downstream-main-push.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-controller-mce-downstream-2-13-pull-request.yaml
+++ b/.tekton/assisted-installer-controller-mce-downstream-2-13-pull-request.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-controller-mce-downstream-2-13-push.yaml
+++ b/.tekton/assisted-installer-controller-mce-downstream-2-13-push.yaml
@@ -392,6 +392,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-controller-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-controller-mce-downstream-main-pull-request.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-controller-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-controller-mce-downstream-main-push.yaml
@@ -392,6 +392,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-downstream-main-pull-request.yaml
@@ -398,6 +398,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-downstream-main-push.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-mce-downstream-2-13-pull-request.yaml
+++ b/.tekton/assisted-installer-mce-downstream-2-13-pull-request.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-mce-downstream-2-13-push.yaml
+++ b/.tekton/assisted-installer-mce-downstream-2-13-push.yaml
@@ -392,6 +392,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-mce-downstream-main-pull-request.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/assisted-installer-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-mce-downstream-main-push.yaml
@@ -392,6 +392,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ARGS
         value: "--project-name=assisted-installer --report --org=3e6fd93b-b325-49dd-8a33-432a0160ab66"
+      - name: IGNORE_FILE_PATHS
+        value: "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
In our konflux build pipelines, there is a task to check snyk to warn us on potential code vulnerabilities.
However there are some issues it find that we don't care about, so we need to add the problematic files as a list for snyk to ignore.

Part-of [MGMT-19748](https://issues.redhat.com//browse/MGMT-19748)