### PR TITLE
MGMT-19621: Fix Race condition between the OLM operators monitor to the cluster installation monitor

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -220,9 +220,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	mockGetServiceOperators := func(operators []models.MonitoredOperator) {
 		for index := range operators {
 			if operators[index].Status != models.OperatorStatusAvailable {
-				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), operators[index].Name, gomock.Any()).Return(&operators[index], nil).Times(1)
+				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), operators[index].Name, gomock.Any(), gomock.Any()).Return(&operators[index], nil).Times(1)
 			} else {
-				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), operators[index].Name, gomock.Any()).Return(&operators[index], nil).AnyTimes()
+				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), operators[index].Name, gomock.Any(), gomock.Any()).Return(&operators[index], nil).AnyTimes()
 			}
 		}
 	}
@@ -294,11 +294,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	}
 
 	mockGetOLMOperators := func(operators []models.MonitoredOperator) {
-		mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).Times(1)
+		mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).Times(1)
 	}
 
 	mockApplyPostInstallManifests := func(operators []models.MonitoredOperator) {
-		mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).Times(1)
+		mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).Times(1)
 		mockbmclient.EXPECT().DownloadFile(gomock.Any(), customManifestsFile, gomock.Any()).DoAndReturn(
 			func(ctx context.Context, filename, dest string) error {
 				if err := os.WriteFile(dest, []byte("[]"), 0600); err != nil {
@@ -991,10 +991,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				mockAllCapabilitiesEnabled()
 				setClusterAsFinalizing()
 
-				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), consoleOperatorName, gomock.Any()).
+				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), consoleOperatorName, gomock.Any(), gomock.Any()).
 					Return(&models.MonitoredOperator{Status: "", StatusInfo: ""}, nil).AnyTimes()
 				mockk8sclient.EXPECT().GetClusterOperator(consoleOperatorName).Return(nil, fmt.Errorf("dummy")).AnyTimes()
-				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any()).
+				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).
 					Return(&models.MonitoredOperator{Status: "", StatusInfo: ""}, nil).AnyTimes()
 				mockk8sclient.EXPECT().GetClusterVersion().Return(nil, fmt.Errorf("dummy")).AnyTimes()
 
@@ -1145,11 +1145,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					setControllerWaitForOLMOperators(assistedController.ClusterID)
 					operators := []models.MonitoredOperator{{SubscriptionName: "local-storage-operator", Namespace: "openshift-local-storage", OperatorType: models.OperatorTypeOlm, Name: "lso", Status: models.OperatorStatusProgressing, TimeoutSeconds: 0}}
 					mockApplyPostInstallManifests(operators)
-					mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).AnyTimes()
+					mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).AnyTimes()
 				})
 
 				By("endless empty status", func() {
-					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
+					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any(), gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
 					mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSVFromSubscription("openshift-local-storage", "local-storage-operator").Return("lso-1.1", nil).AnyTimes()
@@ -1183,11 +1183,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					setControllerWaitForOLMOperators(assistedController.ClusterID)
 					operators := []models.MonitoredOperator{{SubscriptionName: "local-storage-operator", Namespace: "openshift-local-storage", OperatorType: models.OperatorTypeOlm, Name: "lso", Status: models.OperatorStatusProgressing, TimeoutSeconds: 0}}
 					mockApplyPostInstallManifests(operators)
-					mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).AnyTimes()
+					mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(operators, nil).AnyTimes()
 				})
 
 				By("endless empty status", func() {
-					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
+					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), "lso", gomock.Any(), gomock.Any()).Return(&models.MonitoredOperator{Name: "lso", Status: ""}, nil).AnyTimes()
 					mockk8sclient.EXPECT().ListJobs(gomock.Any()).Return(&batchV1.JobList{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetAllInstallPlansOfSubscription(gomock.Any()).Return([]olmv1alpha1.InstallPlan{}, nil).AnyTimes()
 					mockk8sclient.EXPECT().GetCSVFromSubscription("openshift-local-storage", "local-storage-operator").Return("lso-1.1", nil).AnyTimes()
@@ -1789,7 +1789,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		AfterEach(func() { cancel() })
 
 		It("List is empty", func() {
-			mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any()).Return([]models.MonitoredOperator{}, nil).Times(1)
+			mockbmclient.EXPECT().GetClusterMonitoredOLMOperators(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]models.MonitoredOperator{}, nil).Times(1)
 			mockSuccessUpdateFinalizingStages(models.FinalizingStageWaitingForOlmOperatorsCsvInitialization)
 
 			Expect(assistedController.waitForOLMOperators(context.TODO())).To(BeNil())
@@ -2039,9 +2039,9 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					StatusInfo: t.newCVOCondition.Message,
 				}
 
-				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any()).Return(t.currentServiceCVOStatus, nil).Times(1)
+				mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).Return(t.currentServiceCVOStatus, nil).Times(1)
 				if newServiceCVOStatus.Status != models.OperatorStatusAvailable {
-					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any()).Return(newServiceCVOStatus, nil).Times(1)
+					mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).Return(newServiceCVOStatus, nil).Times(1)
 				}
 				if t.shouldSendUpdate {
 
@@ -2075,7 +2075,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			}
 
 			mockk8sclient.EXPECT().GetClusterVersion().Return(clusterVersionReport, nil).AnyTimes()
-			mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any()).Return(currentServiceCVOStatus, nil).AnyTimes()
+			mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).Return(currentServiceCVOStatus, nil).AnyTimes()
 			mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), gomock.Any(), cvoOperatorName, "", gomock.Any(), gomock.Any()).Return(fmt.Errorf("dummy")).AnyTimes()
 
 			err := func() error {
@@ -2101,7 +2101,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			}
 
 			mockk8sclient.EXPECT().GetClusterVersion().Return(clusterVersionReport, nil).AnyTimes()
-			mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any()).Return(currentServiceCVOStatus, nil).AnyTimes()
+			mockbmclient.EXPECT().GetClusterMonitoredOperator(gomock.Any(), gomock.Any(), cvoOperatorName, gomock.Any(), gomock.Any()).Return(currentServiceCVOStatus, nil).AnyTimes()
 			mockbmclient.EXPECT().UpdateClusterOperator(gomock.Any(), gomock.Any(), cvoOperatorName, "", gomock.Any(), gomock.Any()).Return(fmt.Errorf("dummy")).AnyTimes()
 
 			err := func() error {

--- a/src/inventory_client/mock_inventory_client.go
+++ b/src/inventory_client/mock_inventory_client.go
@@ -126,33 +126,33 @@ func (mr *MockInventoryClientMockRecorder) GetCluster(ctx, withHosts any) *gomoc
 }
 
 // GetClusterMonitoredOLMOperators mocks base method.
-func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string) ([]models.MonitoredOperator, error) {
+func (m *MockInventoryClient) GetClusterMonitoredOLMOperators(ctx context.Context, clusterId, openshiftVersion string, useCache bool) ([]models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion)
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOLMOperators", ctx, clusterId, openshiftVersion, useCache)
 	ret0, _ := ret[0].([]models.MonitoredOperator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMonitoredOLMOperators indicates an expected call of GetClusterMonitoredOLMOperators.
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion any) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOLMOperators(ctx, clusterId, openshiftVersion, useCache any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOLMOperators", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOLMOperators), ctx, clusterId, openshiftVersion, useCache)
 }
 
 // GetClusterMonitoredOperator mocks base method.
-func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string) (*models.MonitoredOperator, error) {
+func (m *MockInventoryClient) GetClusterMonitoredOperator(ctx context.Context, clusterId, operatorName, openshiftVersion string, useCache bool) (*models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion)
+	ret := m.ctrl.Call(m, "GetClusterMonitoredOperator", ctx, clusterId, operatorName, openshiftVersion, useCache)
 	ret0, _ := ret[0].(*models.MonitoredOperator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMonitoredOperator indicates an expected call of GetClusterMonitoredOperator.
-func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion any) *gomock.Call {
+func (mr *MockInventoryClientMockRecorder) GetClusterMonitoredOperator(ctx, clusterId, operatorName, openshiftVersion, useCache any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMonitoredOperator", reflect.TypeOf((*MockInventoryClient)(nil).GetClusterMonitoredOperator), ctx, clusterId, operatorName, openshiftVersion, useCache)
 }
 
 // GetEnabledHostsNamesHosts mocks base method.

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -312,6 +312,7 @@ func waitForInstallationAgentBasedInstaller(kubeClient k8s_client.K8SClient, log
 }
 
 func didInstallationFinish(clusterStatus string, log logrus.FieldLogger, status *assistedinstallercontroller.ControllerStatus) bool {
+	log.Info("Checking if the cluster installation finished...")
 	switch clusterStatus {
 	case models.ClusterStatusError:
 		log.Infof("Cluster installation failed.")


### PR DESCRIPTION
## Introduction

The purpose of this PR is to resolve a bug caused by a race condition between the main thread
of assisted installer controller and a goroutine responsible for monitoring the status of 
OLM operators.

When the main thread reaches the stage where cluster installation has been deemed complete it 
will cancel the contexts of any Go routines it spawned, including the OLM operator monitor. 

We use cache upon the status of monitored OLM operators and this is relevant to this bug.
Upon shutdown, this monitor thread performs final checks of the installed operators, this final
check depends on a cached result, which, coupled with a bug that causes the operator installation status to
be inconsistent with cache content, leads to a scenario where the installer will report a complete installation
while also reporting incomplete operator installation.

The solution is twofold, 

* Firstly to fix the bug that causes the inconsistent installation status
* Secondly, as a precaution, anywhere we are taking our 'last chance' to obtain the status of the operators, this call
should not depend upon the cache. This will ensure that we make an 'up to date' assessment of the situation.

## More Details

The controller flow runs in parallel Go routines executing different actions. Two key routines are:

- **Cluster Installation Monitor**: Every minute, it queries assisted-service to check if the cluster installation is finished by evaluating its status - https://github.com/openshift/assisted-installer/blob/e9ae12da779dd7d2610f515605ea3ff66e8c4f4b/src/main/assisted-installer-controller/assisted_installer_main.go#L224.
- **OLM Operators Monitor**: Every 30 seconds, it checks the current status of each monitored operator resource. When any operator status changes, it updates assisted-service - https://github.com/openshift/assisted-installer/blob/e9ae12da779dd7d2610f515605ea3ff66e8c4f4b/src/assisted_installer_controller/assisted_installer_controller.go#L987 and https://github.com/openshift/assisted-installer/blob/e27ef9e2a68813b0167169439005d16682bdc889/src/assisted_installer_controller/operator_handler.go#L51. It is important to note that the controller uses a cache for querying cluster's monitored operators, with 20 seconds TTL. 

The issue lies in the predicate logic - https://github.com/openshift/assisted-installer/blob/e9ae12da779dd7d2610f515605ea3ff66e8c4f4b/src/assisted_installer_controller/assisted_installer_controller.go#L1001. This causes a scenario where there is always a 30-second delay between the time all operators are ready (and the assisted-service is updated accordingly) and when the function acknowledges the update. This leads to the possibility of the following sequence:

1. The operators monitor updates assisted-service to indicate all operators are available, but it won't exit until the next cycle (30 seconds later). 
2. Before the cache data becomes stale (20 seconds), the cluster installation monitor runs, querying assisted-service, which has changed its status from finalizing to installed (this happens when all hosts and operators are installed, and the state machine progresses).
3. The cluster monitor detects the installation as complete and cancels the controller context across all threads -https://github.com/openshift/assisted-installer/blob/e9ae12da779dd7d2610f515605ea3ff66e8c4f4b/src/main/assisted-installer-controller/assisted_installer_main.go#L195
4. The operators monitor receiving the cancel context, and attempts to update all operators which are still in `progressing` status as `failed` in assisted-service - https://github.com/openshift/assisted-installer/blob/e27ef9e2a68813b0167169439005d16682bdc889/src/assisted_installer_controller/assisted_installer_controller.go#L542 and https://github.com/openshift/assisted-installer/blob/e27ef9e2a68813b0167169439005d16682bdc889/src/assisted_installer_controller/assisted_installer_controller.go#L971
5. The controller is getting the last updated operator back in the list of `progressing` operators as the cache contains data from the last query - https://github.com/openshift/assisted-installer/blob/e27ef9e2a68813b0167169439005d16682bdc889/src/inventory_client/inventory_client.go#L275
6. The controller updates assisted-service with the operator status as failed - https://github.com/openshift/assisted-installer/blob/e27ef9e2a68813b0167169439005d16682bdc889/src/assisted_installer_controller/assisted_installer_controller.go#L977
7. The result is a cluster marked as installed with failed operators.

This PR resolves the issue by several steps:
1. Avoid using cache in queries which are not part of waiting predicates, as they occur once and stale data might have irreversible impact.
2. moving the check for non-ready operators inside the predicate after the list reduction, thereby eliminating the 30-second delay. This change ensures that the moment the cluster is ready in assisted-service, the operators monitor acknowledges it immediately.
3. Adds a log to increase observability.