### PR TITLE
MGMT-19101: Add support to existing root install for installer kargs args

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -371,7 +371,7 @@ func (i *installer) writeImageToDisk(ignitionPath string) error {
 		if i.Config.CoreosImage == "" {
 			return i.ops.WriteImageToDisk(liveLogger, ignitionPath, i.Device, i.Config.InstallerArgs)
 		} else {
-			return i.ops.WriteImageToExistingRoot(liveLogger, ignitionPath)
+			return i.ops.WriteImageToExistingRoot(liveLogger, ignitionPath, i.Config.InstallerArgs)
 		}
 	})
 	if err != nil {

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -899,7 +899,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					cleanupDevice.EXPECT().CleanupInstallDevice(device).Times(0)
 					mkdirSuccess(InstallDir)
 					downloadHostIgnitionSuccess(infraEnvId, hostId, "master-host-id.ign")
-					mockops.EXPECT().WriteImageToExistingRoot(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign")).Return(nil).Times(1)
+					mockops.EXPECT().WriteImageToExistingRoot(gomock.Any(), filepath.Join(InstallDir, "master-host-id.ign"), gomock.Any()).Return(nil).Times(1)
 					mockops.EXPECT().SetBootOrder(device).Times(0)
 					uploadLogsSuccess(false)
 					reportLogProgressSuccess()

--- a/src/ops/mock_ops.go
+++ b/src/ops/mock_ops.go
@@ -97,20 +97,6 @@ func (mr *MockOpsMockRecorder) DryRebootHappened(markerPath any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRebootHappened", reflect.TypeOf((*MockOps)(nil).DryRebootHappened), markerPath)
 }
 
-// FileExists mocks base method.
-func (m *MockOps) FileExists(path string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FileExists", path)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// FileExists indicates an expected call of FileExists.
-func (mr *MockOpsMockRecorder) FileExists(path any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileExists", reflect.TypeOf((*MockOps)(nil).FileExists), path)
-}
-
 // EvaluateDiskSymlink mocks base method.
 func (m *MockOps) EvaluateDiskSymlink(arg0 string) string {
 	m.ctrl.T.Helper()
@@ -157,6 +143,20 @@ func (m *MockOps) ExtractFromIgnition(ignitionPath, fileToExtract string) error 
 func (mr *MockOpsMockRecorder) ExtractFromIgnition(ignitionPath, fileToExtract any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFromIgnition", reflect.TypeOf((*MockOps)(nil).ExtractFromIgnition), ignitionPath, fileToExtract)
+}
+
+// FileExists mocks base method.
+func (m *MockOps) FileExists(path string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileExists", path)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// FileExists indicates an expected call of FileExists.
+func (mr *MockOpsMockRecorder) FileExists(path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileExists", reflect.TypeOf((*MockOps)(nil).FileExists), path)
 }
 
 // FormatDisk mocks base method.
@@ -401,15 +401,15 @@ func (mr *MockOpsMockRecorder) WriteImageToDisk(liveLogger, ignitionPath, device
 }
 
 // WriteImageToExistingRoot mocks base method.
-func (m *MockOps) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string) error {
+func (m *MockOps) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string, installerArgs []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteImageToExistingRoot", liveLogger, ignitionPath)
+	ret := m.ctrl.Call(m, "WriteImageToExistingRoot", liveLogger, ignitionPath, installerArgs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteImageToExistingRoot indicates an expected call of WriteImageToExistingRoot.
-func (mr *MockOpsMockRecorder) WriteImageToExistingRoot(liveLogger, ignitionPath any) *gomock.Call {
+func (mr *MockOpsMockRecorder) WriteImageToExistingRoot(liveLogger, ignitionPath, installerArgs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToExistingRoot", reflect.TypeOf((*MockOps)(nil).WriteImageToExistingRoot), liveLogger, ignitionPath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageToExistingRoot", reflect.TypeOf((*MockOps)(nil).WriteImageToExistingRoot), liveLogger, ignitionPath, installerArgs)
 }

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -50,7 +50,7 @@ const (
 type Ops interface {
 	Mkdir(dirName string) error
 	WriteImageToDisk(liveLogger io.Writer, ignitionPath string, device string, extraArgs []string) error
-	WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string) error
+	WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string, installerArgs []string) error
 	Reboot(delay string) error
 	SetBootOrder(device string) error
 	ExtractFromIgnition(ignitionPath string, fileToExtract string) error
@@ -144,7 +144,28 @@ func (o *ops) importOSTreeCommit(liveLogger io.Writer) (string, error) {
 	return matches[1], nil
 }
 
-func (o *ops) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string) error {
+func ostreeArgs(commit string, installerArgs []string) []string {
+	ostreeArgs := []string{"admin", "deploy",
+		"--stateroot", "install",
+		"--karg", "$ignition_firstboot",
+		"--karg", defaultIgnitionPlatformId,
+	}
+
+	lastArgIndex := len(installerArgs) - 1
+	for i, arg := range installerArgs {
+		if arg == "--append-karg" && i < lastArgIndex {
+			ostreeArgs = append(ostreeArgs, "--karg-append", installerArgs[i+1])
+			continue
+		}
+		if arg == "--delete-karg" && i < lastArgIndex {
+			ostreeArgs = append(ostreeArgs, "--karg-delete", installerArgs[i+1])
+			continue
+		}
+	}
+	return append(ostreeArgs, commit)
+}
+
+func (o *ops) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string, installerArgs []string) error {
 	out, err := o.ExecPrivilegeCommand(liveLogger, "mount", "/sysroot", "-o", "remount,rw")
 	if err != nil {
 		return errors.Wrapf(err, "failed to remount sysroot: %s", out)
@@ -165,11 +186,7 @@ func (o *ops) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string
 	}
 	o.log.Infof("imported commit %s", commit)
 
-	out, err = o.ExecPrivilegeCommand(liveLogger, "ostree", "admin", "deploy",
-		"--stateroot", "install",
-		"--karg", "$ignition_firstboot",
-		"--karg", defaultIgnitionPlatformId,
-		commit)
+	out, err = o.ExecPrivilegeCommand(liveLogger, "ostree", ostreeArgs(commit, installerArgs)...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to deploy commit to stateroot: %s", out)
 	}

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -606,3 +606,70 @@ var _ = Describe("importOSTreeCommit", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("ostreeArgs", func() {
+	It("returns the basic args when no additional installer args are provided", func() {
+		args := ostreeArgs("commit", nil)
+		expectedArgs := []string{
+			"admin", "deploy",
+			"--stateroot", "install",
+			"--karg", "$ignition_firstboot",
+			"--karg", defaultIgnitionPlatformId,
+			"commit",
+		}
+		Expect(args).To(Equal(expectedArgs))
+	})
+
+	It("ignores non append-karg or delete-karg args", func() {
+		args := ostreeArgs("commit", []string{"--copy-network", "--network-dir", "/some/dir/"})
+		expectedArgs := []string{
+			"admin", "deploy",
+			"--stateroot", "install",
+			"--karg", "$ignition_firstboot",
+			"--karg", defaultIgnitionPlatformId,
+			"commit",
+		}
+		Expect(args).To(Equal(expectedArgs))
+	})
+
+	It("adds append args", func() {
+		args := ostreeArgs("commit", []string{"--append-karg", "nameserver=8.8.8.8"})
+		expectedArgs := []string{
+			"admin", "deploy",
+			"--stateroot", "install",
+			"--karg", "$ignition_firstboot",
+			"--karg", defaultIgnitionPlatformId,
+			"--karg-append", "nameserver=8.8.8.8",
+			"commit",
+		}
+		Expect(args).To(Equal(expectedArgs))
+	})
+
+	It("adds remove args", func() {
+		args := ostreeArgs("commit", []string{"--delete-karg", "console"})
+		expectedArgs := []string{
+			"admin", "deploy",
+			"--stateroot", "install",
+			"--karg", "$ignition_firstboot",
+			"--karg", defaultIgnitionPlatformId,
+			"--karg-delete", "console",
+			"commit",
+		}
+		Expect(args).To(Equal(expectedArgs))
+	})
+
+	It("works with multiple instances of append and remove", func() {
+		args := ostreeArgs("commit", []string{"--append-karg", "nameserver=8.8.8.8", "--delete-karg", "console", "--append-karg", "ip=192.0.2.100"})
+		expectedArgs := []string{
+			"admin", "deploy",
+			"--stateroot", "install",
+			"--karg", "$ignition_firstboot",
+			"--karg", defaultIgnitionPlatformId,
+			"--karg-append", "nameserver=8.8.8.8",
+			"--karg-delete", "console",
+			"--karg-append", "ip=192.0.2.100",
+			"commit",
+		}
+		Expect(args).To(Equal(expectedArgs))
+	})
+})


### PR DESCRIPTION
The installer args are now passed to the existing root install function and if any are --append-karg or --remove-karg the corresponding arg is added to the ostree command args.

https://issues.redhat.com/browse/MGMT-19101