### PR TITLE
MGMT-19819: Add the commit reference from which the image is built to the image

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -16,6 +16,9 @@ COPY . .
 RUN git config --global --add safe.directory '*'; \
     TARGETPLATFORM=$TARGETPLATFORM make installer
 
+# Extract the commit reference from which the image is built
+RUN git rev-parse --short HEAD > /commit-reference.txt
+
 FROM quay.io/centos/centos:stream9
 
 # required for nsenter
@@ -23,6 +26,9 @@ RUN dnf install -y util-linux-core && dnf clean all
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/installer /usr/bin/installer
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/deploy/assisted-installer-controller /assisted-installer-controller/deploy
+
+# Copy the commit reference from the builder
+COPY --from=builder /commit-reference.txt /commit-reference.txt
 
 ENTRYPOINT ["/usr/bin/installer"]
 

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -16,6 +16,9 @@ COPY . .
 RUN git config --global --add safe.directory '*'; \
     TARGETPLATFORM=$TARGETPLATFORM make controller
 
+# Extract the commit reference from which the image is built
+RUN git rev-parse --short HEAD > /commit-reference.txt
+
 FROM quay.io/centos/centos:stream9
 ARG TARGETPLATFORM
 
@@ -25,5 +28,8 @@ RUN case $TARGETPLATFORM in "") platform=amd64;; *) platform=`echo $TARGETPLATFO
     chmod +x /usr/bin/oc /usr/bin/kubectl
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer/build/assisted-installer-controller /usr/bin/assisted-installer-controller
+
+# Copy the commit reference from the builder
+COPY --from=builder /commit-reference.txt /commit-reference.txt
 
 ENTRYPOINT ["/usr/bin/assisted-installer-controller"]


### PR DESCRIPTION
Currently, in most of assisted installer components CI images we don't have a way to tell from which commit reference the image was built. Since We use an image stream for each component, and we import these streams from one CI component configuration to another, we might end up with images to are not up-to-date. In this case, we would like to have the ability to check if this is actually the case.