### PR TITLE
MGMT-19421: phase 1 of replacing the refference HighAvailabilityMode with ControlPlaneCount

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
@@ -11,5 +11,5 @@ data:
   skip-cert-verification: '{{.SkipCertVerification}}'
   ca-cert-path: '{{.CACertPath}}'
   check-cluster-version: '{{.CheckCVO}}'
-  control-plane-count: {{.HaMode}}
+  control-plane-count: '{{.ControlPlaneCount}}'
   must-gather-image: '{{.MustGatherImage}}'

--- a/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-cm.yaml.template
@@ -11,5 +11,5 @@ data:
   skip-cert-verification: '{{.SkipCertVerification}}'
   ca-cert-path: '{{.CACertPath}}'
   check-cluster-version: '{{.CheckCVO}}'
-  high-availability-mode: {{.HaMode}}
+  control-plane-count: {{.HaMode}}
   must-gather-image: '{{.MustGatherImage}}'

--- a/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-pod.yaml.template
@@ -52,11 +52,11 @@ spec:
               value: "{{.OpenshiftVersion}}"
             - name: NOTIFY_NUM_REBOOTS
               value: "{{.NotifyNumReboots}}"
-            - name: HIGH_AVAILABILITY_MODE
+            - name: CONTROL_PLANE_COUNT
               valueFrom:
                 configMapKeyRef:
                   name: assisted-installer-controller-config
-                  key: high-availability-mode
+                  key: control-plane-count
                   optional: true
             - name: CHECK_CLUSTER_VERSION
               valueFrom:

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -91,6 +91,7 @@ type ControllerConfig struct {
 	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
 	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
 	HighAvailabilityMode    string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`
+	ControlPlainCount       int
 	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
 	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
 	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
@@ -1255,7 +1256,7 @@ func (c *controller) logHostResolvConf() {
 // It will patch router to add access logs
 // It will run http router health check to see if router is healthy on host network
 func (c *controller) logRouterStatus() {
-	if !c.status.HasError() || c.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone {
+	if !c.status.HasError() || c.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone || c.ControlPlainCount > 1 {
 		return
 	}
 	c.log.Infof("Start checking router status")

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -90,7 +90,6 @@ type ControllerConfig struct {
 	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:""`
 	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
 	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
-	HighAvailabilityMode    string `envconfig:"HIGH_AVAILABILITY_MODE" required:"false" default:"Full"`
 	ControlPlainCount       int
 	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
 	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
@@ -1256,7 +1255,7 @@ func (c *controller) logHostResolvConf() {
 // It will patch router to add access logs
 // It will run http router health check to see if router is healthy on host network
 func (c *controller) logRouterStatus() {
-	if !c.status.HasError() || c.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone || c.ControlPlainCount > 1 {
+	if !c.status.HasError() || c.ControlPlainCount != 1 {
 		return
 	}
 	c.log.Infof("Start checking router status")

--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -90,7 +90,7 @@ type ControllerConfig struct {
 	CACertPath              string `envconfig:"CA_CERT_PATH" required:"false" default:""`
 	Namespace               string `envconfig:"NAMESPACE" required:"false" default:"assisted-installer"`
 	OpenshiftVersion        string `envconfig:"OPENSHIFT_VERSION" required:"true"`
-	ControlPlainCount       int
+	ControlPlaneCount       int    `envconfig:"CONTROL_PLANE_COUNT" required:"false" default:"3"`
 	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
 	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
 	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
@@ -1255,7 +1255,7 @@ func (c *controller) logHostResolvConf() {
 // It will patch router to add access logs
 // It will run http router health check to see if router is healthy on host network
 func (c *controller) logRouterStatus() {
-	if !c.status.HasError() || c.ControlPlainCount != 1 {
+	if !c.status.HasError() || c.ControlPlaneCount != 1 {
 		return
 	}
 	c.log.Infof("Start checking router status")

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -1701,50 +1701,15 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("Validate router check will not run with no error", func() {
-			assistedController.HighAvailabilityMode = models.ClusterHighAvailabilityModeNone
-			successUpload()
-			logClusterOperatorsSuccess()
-			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(0).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
-			callUploadLogs(50 * time.Millisecond)
-		})
-
-		It("Validate router check will not run with no error 2", func() {
 			assistedController.ControlPlainCount = 1
 			successUpload()
 			logClusterOperatorsSuccess()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(0).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
 			callUploadLogs(50 * time.Millisecond)
-		})
-
-		FIt("Validate upload logs not blocked by router validation failure (with must-gather logs) 2", func() {
-			assistedController.ControlPlainCount = 1
-			assistedController.HighAvailabilityMode = ""
-			successUpload()
-			logClusterOperatorsSuccess()
-			logResolvConfSuccess()
-			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).MinTimes(1).Return(nil, fmt.Errorf("dummy"))
-			mockops.EXPECT().GetMustGatherLogs(gomock.Any(), gomock.Any(), assistedController.MustGatherImage).Return("../../test_files/tartest.tar.gz", nil).Times(1)
-			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			assistedController.status.Error()
-			callUploadLogs(300 * time.Millisecond)
-		})
-
-		It("Validate upload logs (with must-gather logs) with router status on sno 2", func() {
-			assistedController.ControlPlainCount = 1
-			assistedController.HighAvailabilityMode = ""
-			successUpload()
-			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(1).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
-			logClusterOperatorsSuccess()
-			logResolvConfSuccess()
-			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
-			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockops.EXPECT().GetMustGatherLogs(gomock.Any(), gomock.Any(), assistedController.MustGatherImage).Return("../../test_files/tartest.tar.gz", nil).Times(1)
-			assistedController.status.Error()
-			callUploadLogs(300 * time.Millisecond)
 		})
 
 		It("Validate upload logs not blocked by router validation failure (with must-gather logs)", func() {
-			assistedController.HighAvailabilityMode = models.ClusterHighAvailabilityModeNone
+			assistedController.ControlPlainCount = 1
 			successUpload()
 			logClusterOperatorsSuccess()
 			logResolvConfSuccess()
@@ -1756,7 +1721,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("Validate upload logs (with must-gather logs) with router status on sno", func() {
-			assistedController.HighAvailabilityMode = models.ClusterHighAvailabilityModeNone
+			assistedController.ControlPlainCount = 1
 			successUpload()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(1).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
 			logClusterOperatorsSuccess()

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -1701,7 +1701,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("Validate router check will not run with no error", func() {
-			assistedController.ControlPlainCount = 1
+			assistedController.ControlPlaneCount = 1
 			successUpload()
 			logClusterOperatorsSuccess()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(0).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
@@ -1709,7 +1709,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("Validate upload logs not blocked by router validation failure (with must-gather logs)", func() {
-			assistedController.ControlPlainCount = 1
+			assistedController.ControlPlaneCount = 1
 			successUpload()
 			logClusterOperatorsSuccess()
 			logResolvConfSuccess()
@@ -1721,7 +1721,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 
 		It("Validate upload logs (with must-gather logs) with router status on sno", func() {
-			assistedController.ControlPlainCount = 1
+			assistedController.ControlPlaneCount = 1
 			successUpload()
 			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(1).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
 			logClusterOperatorsSuccess()

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -1708,6 +1708,41 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			callUploadLogs(50 * time.Millisecond)
 		})
 
+		It("Validate router check will not run with no error 2", func() {
+			assistedController.ControlPlainCount = 1
+			successUpload()
+			logClusterOperatorsSuccess()
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(0).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
+			callUploadLogs(50 * time.Millisecond)
+		})
+
+		FIt("Validate upload logs not blocked by router validation failure (with must-gather logs) 2", func() {
+			assistedController.ControlPlainCount = 1
+			assistedController.HighAvailabilityMode = ""
+			successUpload()
+			logClusterOperatorsSuccess()
+			logResolvConfSuccess()
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).MinTimes(1).Return(nil, fmt.Errorf("dummy"))
+			mockops.EXPECT().GetMustGatherLogs(gomock.Any(), gomock.Any(), assistedController.MustGatherImage).Return("../../test_files/tartest.tar.gz", nil).Times(1)
+			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			assistedController.status.Error()
+			callUploadLogs(300 * time.Millisecond)
+		})
+
+		It("Validate upload logs (with must-gather logs) with router status on sno 2", func() {
+			assistedController.ControlPlainCount = 1
+			assistedController.HighAvailabilityMode = ""
+			successUpload()
+			mockbmclient.EXPECT().GetCluster(gomock.Any(), false).Times(1).Return(&models.Cluster{Name: "test", BaseDNSDomain: "test.com"}, nil)
+			logClusterOperatorsSuccess()
+			logResolvConfSuccess()
+			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("dummy")).Times(1)
+			mockbmclient.EXPECT().DownloadClusterCredentials(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockops.EXPECT().GetMustGatherLogs(gomock.Any(), gomock.Any(), assistedController.MustGatherImage).Return("../../test_files/tartest.tar.gz", nil).Times(1)
+			assistedController.status.Error()
+			callUploadLogs(300 * time.Millisecond)
+		})
+
 		It("Validate upload logs not blocked by router validation failure (with must-gather logs)", func() {
 			assistedController.HighAvailabilityMode = models.ClusterHighAvailabilityModeNone
 			successUpload()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ServiceIPs                  string
 	InstallerArgs               []string
 	HighAvailabilityMode        string
+	ControlPlaneCount           int
 	CheckClusterVersion         bool
 	MustGatherImage             string
 	DisksToFormat               ArrayFlags
@@ -74,6 +75,7 @@ func (c *Config) ProcessArgs(args []string) {
 	flagSet.StringVar(&c.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")
 	flagSet.StringVar(&c.ServiceIPs, "service-ips", "", "All IPs of assisted service node")
 	flagSet.StringVar(&c.HighAvailabilityMode, "high-availability-mode", "", "high-availability expectations, \"Full\" which represents the behavior in a \"normal\" cluster. Use 'None' for single-node deployment. Leave this value as \"\" for workers as we do not care about HA mode for workers.")
+	flagSet.IntVar(&c.ControlPlaneCount, "control-plane-count", 0, "The number of controller nodes in the cluster")
 	flagSet.BoolVar(&c.CheckClusterVersion, "check-cluster-version", false, "Do not monitor CVO")
 	flagSet.StringVar(&c.MustGatherImage, "must-gather-image", "", "Custom must-gather image")
 	flagSet.Var(&c.DisksToFormat, "format-disk", "Disk to format. Can be specified multiple times")
@@ -137,6 +139,7 @@ func (c *Config) SetDefaults() {
 	if c.Role == string(models.HostRoleWorker) {
 		//High availability mode is not relevant to workers, so make sure we clear this.
 		c.HighAvailabilityMode = ""
+		c.ControlPlaneCount = 0
 	}
 
 	if c.InfraEnvID == "" {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	NoProxy                     string
 	ServiceIPs                  string
 	InstallerArgs               []string
-	HighAvailabilityMode        string
 	ControlPlaneCount           int
 	CheckClusterVersion         bool
 	MustGatherImage             string
@@ -74,7 +73,6 @@ func (c *Config) ProcessArgs(args []string) {
 	flagSet.StringVar(&c.HTTPSProxy, "https-proxy", "", "A proxy URL to use for creating HTTPS connections outside the cluster")
 	flagSet.StringVar(&c.NoProxy, "no-proxy", "", "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying")
 	flagSet.StringVar(&c.ServiceIPs, "service-ips", "", "All IPs of assisted service node")
-	flagSet.StringVar(&c.HighAvailabilityMode, "high-availability-mode", "", "high-availability expectations, \"Full\" which represents the behavior in a \"normal\" cluster. Use 'None' for single-node deployment. Leave this value as \"\" for workers as we do not care about HA mode for workers.")
 	flagSet.IntVar(&c.ControlPlaneCount, "control-plane-count", 0, "The number of controller nodes in the cluster")
 	flagSet.BoolVar(&c.CheckClusterVersion, "check-cluster-version", false, "Do not monitor CVO")
 	flagSet.StringVar(&c.MustGatherImage, "must-gather-image", "", "Custom must-gather image")
@@ -138,7 +136,6 @@ func (c *Config) SetInstallerArgs(installerArgs string) error {
 func (c *Config) SetDefaults() {
 	if c.Role == string(models.HostRoleWorker) {
 		//High availability mode is not relevant to workers, so make sure we clear this.
-		c.HighAvailabilityMode = ""
 		c.ControlPlaneCount = 0
 	}
 

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -31,37 +31,37 @@ var _ = Describe("ProcessArgs", func() {
 		Expect(config.InstallerArgs[1]).To(Equal("arg2=bar"))
 	})
 
-	It("HighAvailabilityMode should be set to empty string if the host role is worker.", func() {
+	It("ControlPlaneCount should be set to 0 if the host role is worker.", func() {
 		config := &Config{}
-		arguments := []string{"--role", string(models.HostRoleWorker), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		arguments := []string{"--role", string(models.HostRoleWorker), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--control-plane-count", "3"}
 		config.ProcessArgs(arguments)
-		Expect(config.HighAvailabilityMode).To(BeEmpty())
+		Expect(config.ControlPlaneCount).To(BeZero())
 	})
 
-	It("HighAvailabilityMode should be unchanged if the host role is master.", func() {
+	It("ControlPlaneCount should be unchanged if the host role is master.", func() {
 		config := &Config{}
-		arguments := []string{"--role", string(models.HostRoleMaster), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		arguments := []string{"--role", string(models.HostRoleMaster), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--control-plane-count", "5"}
 		config.ProcessArgs(arguments)
-		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+		Expect(config.ControlPlaneCount).To(Equal(5))
 	})
 
-	It("HighAvailabilityMode should be unchanged if the host role is bootstrap.", func() {
+	It("ControlPlaneCount should be unchanged if the host role is bootstrap.", func() {
 		config := &Config{}
-		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--control-plane-count", "5"}
 		config.ProcessArgs(arguments)
-		Expect(config.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeFull))
+		Expect(config.ControlPlaneCount).To(Equal(5))
 	})
 
 	It("InfraEnvId should be set to ClusterId if the InfraEnvId is not defined", func() {
 		config := &Config{}
-		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--control-plane-count", "3"}
 		config.ProcessArgs(arguments)
 		Expect(config.InfraEnvID).To(Equal(config.ClusterID))
 	})
 
 	It("InfraEnvId should not be set to ClusterId if the InfraEnvId is defined", func() {
 		config := &Config{}
-		arguments := []string{"--role", string(models.HostRoleBootstrap), "--infra-env-id", "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--high-availability-mode", models.ClusterHighAvailabilityModeFull}
+		arguments := []string{"--role", string(models.HostRoleBootstrap), "--infra-env-id", "9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8", "--cluster-id", "0ae63135-5f7c-431e-9c72-0efaf2cb83b8", "--control-plane-count", "3"}
 		config.ProcessArgs(arguments)
 		Expect(config.InfraEnvID).To(Equal("9f2a26d7-10a6-4be0-b1c2-e895ad3b04b8"))
 	})

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -114,7 +114,7 @@ func (i *installer) InstallNode() error {
 	//cancel the context in case this method ends
 	defer cancel()
 	isBootstrap := false
-	if i.Config.Role == string(models.HostRoleBootstrap) && (i.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount > 1) {
+	if i.Config.Role == string(models.HostRoleBootstrap) && i.ControlPlaneCount != 1 {
 		isBootstrap = true
 		bootstrapErrGroup.Go(func() error {
 			return i.startBootstrap()
@@ -127,10 +127,10 @@ func (i *installer) InstallNode() error {
 	var ignitionPath string
 	var err error
 
-	// i.HighAvailabilityMode is set as an empty string for workers
+	// i.ControlPlaneCount is set as 0 for workers
 	// regardless of the availability mode of the cluster they are joining
 	// as it is of no consequence to them.
-	if i.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount == 1 {
+	if i.ControlPlaneCount == 1 {
 		i.log.Info("Installing single node openshift")
 		ignitionPath, err = i.createSingleNodeMasterIgnition()
 		if err != nil {
@@ -190,7 +190,7 @@ func (i *installer) InstallNode() error {
 	//upload host logs and report log status before reboot
 	i.log.Infof("Uploading logs and reporting status before rebooting the node %s for cluster %s", i.Config.HostID, i.Config.ClusterID)
 	i.inventoryClient.HostLogProgressReport(ctx, i.Config.InfraEnvID, i.Config.HostID, models.LogsStateRequested)
-	_, err = i.ops.UploadInstallationLogs(isBootstrap || i.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount == 1)
+	_, err = i.ops.UploadInstallationLogs(isBootstrap || i.ControlPlaneCount == 1)
 	if err != nil {
 		i.log.Errorf("upload installation logs %s", err)
 	}
@@ -258,7 +258,7 @@ func (i *installer) finalize() error {
 		// Deu to a race condition in etcd bootstrap strategy we need to bring back this delay.
 		// See: https://issues.redhat.com/browse/OCPBUGS-5988
 		whenToReboot := "+1"
-		if i.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount == 1 {
+		if i.ControlPlaneCount == 1 {
 			whenToReboot = "now"
 		}
 		if err = i.ops.Reboot(whenToReboot); err != nil {
@@ -419,7 +419,7 @@ func (i *installer) startBootstrap() error {
 		return err
 	}
 
-	if i.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount > 1 {
+	if i.ControlPlaneCount != 1 {
 		err = i.generateSshKeyPair()
 		if err != nil {
 			return err
@@ -450,7 +450,7 @@ func (i *installer) startBootstrap() error {
 	// restart NetworkManager to trigger NetworkManager/dispatcher.d/30-local-dns-prepender
 	// we don't do it on SNO because the "local-dns-prepender" is not even
 	// available on none-platform
-	if i.HighAvailabilityMode != models.ClusterHighAvailabilityModeNone || i.ControlPlaneCount > 1 {
+	if i.ControlPlaneCount != 1 {
 		err = i.ops.SystemctlAction("restart", "NetworkManager.service")
 		if err != nil {
 			i.log.Error(err)

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -1112,15 +1112,15 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			Context("None HA mode ", func() {
 
 				conf := config.Config{Role: string(models.HostRoleMaster),
-					ClusterID:            "cluster-id",
-					InfraEnvID:           "infra-env-id",
-					HostID:               "host-id",
-					Device:               "/dev/vda",
-					URL:                  "https://assisted-service.com:80",
-					OpenshiftVersion:     openShiftVersion,
-					MCOImage:             "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221",
-					HighAvailabilityMode: models.ClusterHighAvailabilityModeNone,
-					EnableSkipMcoReboot:  withEnableSkipMcoReboot,
+					ClusterID:           "cluster-id",
+					InfraEnvID:          "infra-env-id",
+					HostID:              "host-id",
+					Device:              "/dev/vda",
+					URL:                 "https://assisted-service.com:80",
+					OpenshiftVersion:    openShiftVersion,
+					MCOImage:            "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221",
+					ControlPlaneCount:   1,
+					EnableSkipMcoReboot: withEnableSkipMcoReboot,
 				}
 				BeforeEach(func() {
 					installerObj = NewAssistedInstaller(l, conf, mockops, mockbmclient, k8sBuilder, mockIgnition, cleanupDevice)

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -143,7 +143,7 @@ func main() {
 	var platformType models.PlatformType
 	removeUninitializedTaint := false
 	if invoker == common.InvokerAgent {
-		if Options.ControllerConfig.ControlPlainCount == 1 {
+		if Options.ControllerConfig.ControlPlaneCount == 1 {
 			// When the agent-based installer installs a SNO cluster, assisted-service
 			// will never be reachable because it will not be running after the boostrap
 			// node reboots to become the SNO cluster. SetReadyState will never be

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -143,7 +143,7 @@ func main() {
 	var platformType models.PlatformType
 	removeUninitializedTaint := false
 	if invoker == common.InvokerAgent {
-		if Options.ControllerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || Options.ControllerConfig.ControlPlainCount == 1 {
+		if Options.ControllerConfig.ControlPlainCount == 1 {
 			// When the agent-based installer installs a SNO cluster, assisted-service
 			// will never be reachable because it will not be running after the boostrap
 			// node reboots to become the SNO cluster. SetReadyState will never be

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -143,7 +143,7 @@ func main() {
 	var platformType models.PlatformType
 	removeUninitializedTaint := false
 	if invoker == common.InvokerAgent {
-		if Options.ControllerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+		if Options.ControllerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || Options.ControllerConfig.ControlPlainCount == 1 {
 			// When the agent-based installer installs a SNO cluster, assisted-service
 			// will never be reachable because it will not be running after the boostrap
 			// node reboots to become the SNO cluster. SetReadyState will never be

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -28,8 +28,6 @@ import (
 	"github.com/thoas/go-funk"
 	"github.com/vincent-petithory/dataurl"
 
-	"github.com/openshift/assisted-service/models"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -461,7 +459,7 @@ func (o *ops) renderControllerCm() error {
 		"ClusterId":            o.installerConfig.ClusterID,
 		"SkipCertVerification": strconv.FormatBool(o.installerConfig.SkipCertVerification),
 		"CACertPath":           o.installerConfig.CACertPath,
-		"HaMode":               o.installerConfig.HighAvailabilityMode,
+		"HaMode":               o.installerConfig.ControlPlaneCount,
 		"CheckCVO":             o.installerConfig.CheckClusterVersion,
 		"MustGatherImage":      o.installerConfig.MustGatherImage,
 	}
@@ -491,7 +489,7 @@ func (o *ops) renderControllerPod() error {
 		params["ServiceIPs"] = strings.Split(o.installerConfig.ServiceIPs, ",")
 	}
 
-	if o.installerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || o.installerConfig.ControlPlaneCount == 1 {
+	if o.installerConfig.ControlPlaneCount == 1 {
 		params["SNO"] = true
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -491,7 +491,7 @@ func (o *ops) renderControllerPod() error {
 		params["ServiceIPs"] = strings.Split(o.installerConfig.ServiceIPs, ",")
 	}
 
-	if o.installerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+	if o.installerConfig.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone || o.installerConfig.ControlPlaneCount == 1 {
 		params["SNO"] = true
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -459,7 +459,7 @@ func (o *ops) renderControllerCm() error {
 		"ClusterId":            o.installerConfig.ClusterID,
 		"SkipCertVerification": strconv.FormatBool(o.installerConfig.SkipCertVerification),
 		"CACertPath":           o.installerConfig.CACertPath,
-		"HaMode":               o.installerConfig.ControlPlaneCount,
+		"ControlPlaneCount":    strconv.Itoa(o.installerConfig.ControlPlaneCount),
 		"CheckCVO":             o.installerConfig.CheckClusterVersion,
 		"MustGatherImage":      o.installerConfig.MustGatherImage,
 	}


### PR DESCRIPTION
phase 1 of replacing the refference HighAvailabilityMode with ControlPlaneCount
in the first stage it still accepst --high-availability-mode as a command line argument, but it is being converted to ControlPlaneCount in the following maner:
- ControlPlaneCount is being set to 3 if --high-availability-mode is set to full
- ControlPlaneCount is being set ot 1 if --high-availability-mode is set to none
After the phase 1 of assisted-installer-agent is being merged --high-availability-mode will be fully removed from the valid parameters.