### PR TITLE
MGMT-19950: Modify Konflux YAMLs to ocm-2.14

### DIFF
--- a/.tekton/assisted-installer-acm-ds-2-14-pull-request.yaml
+++ b/.tekton/assisted-installer-acm-ds-2-14-pull-request.yaml
@@ -4,16 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/assisted-installer?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-ocm-2.13"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-ocm-2.14"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
-    appstudio.openshift.io/component: assisted-installer-acm-ds-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2.14
+    appstudio.openshift.io/component: assisted-installer-acm-ds-2.14
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-acm-ds-2-13-on-push
+  name: assisted-installer-acm-ds-2.14-on-pull-request
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -22,7 +23,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-acm-ds-2-13:{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2.14/assisted-installer-acm-ds-2.14:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/assisted-installer-acm-ds-2-14-push.yaml
+++ b/.tekton/assisted-installer-acm-ds-2-14-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/assisted-installer?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-ocm-2.13"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-ocm-2.14"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
-    appstudio.openshift.io/component: assisted-installer-acm-ds-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2.14
+    appstudio.openshift.io/component: assisted-installer-acm-ds-2.14
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-acm-ds-2-13-on-pull-request
+  name: assisted-installer-acm-ds-2.14-on-push
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -23,9 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-acm-ds-2-13:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2.14/assisted-installer-acm-ds-2.14:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/assisted-installer-controller-acm-ds-2-14-pull-request.yaml
+++ b/.tekton/assisted-installer-controller-acm-ds-2-14-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-ocm-2.13"
+      == "release-ocm-2.14"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
-    appstudio.openshift.io/component: assisted-installer-controller-acm-ds-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2.14
+    appstudio.openshift.io/component: assisted-installer-controller-acm-ds-2.14
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-controller-acm-ds-2-13-on-pull-request
+  name: assisted-installer-controller-acm-ds-2.14-on-pull-request
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-controller-acm-ds-2-13:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2.14/assisted-installer-controller-acm-ds-2.14:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/assisted-installer-controller-acm-ds-2-14-push.yaml
+++ b/.tekton/assisted-installer-controller-acm-ds-2-14-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-ocm-2.13"
+      == "release-ocm-2.14"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
-    appstudio.openshift.io/component: assisted-installer-controller-acm-ds-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2.14
+    appstudio.openshift.io/component: assisted-installer-controller-acm-ds-2.14
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-controller-acm-ds-2-13-on-push
+  name: assisted-installer-controller-acm-ds-2.14-on-push
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-controller-acm-ds-2-13:{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2.14/assisted-installer-controller-acm-ds-2.14:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Now downstream images are built with Kofnflux, therefore we change the references in the master branch to ocm-2.14.