### PR TITLE
[release-ocm-2.13] MGMT-19953: Reduce the OWNERS list for release-ocm-2.13 as it is feature complete

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,28 +2,11 @@
 
 aliases:
   approvers:
-    - avishayt
-    - eranco74
-    - eliorerz
-    - gamli75
-    - ori-amizur
     - romfreiman
-    - tsorya
-    - carbonin
-    - danielerez
-    - omertuc
-    - paul-maidment
+    - oourfali
+    - gamli75
+    - eliorerz
     - rccrdpccl
-    - jhernand
     - adriengentil
-    - javipolo
-    - CrystalChun
     - danmanor
-    - giladravid16
-    - pastequo
-  emeritus_approvers:
-    - empovit
-    - celebdor
-    - yevgeny-shnaidman
-    - lranjbar
-    - ybettan
+    - eifrach


### PR DESCRIPTION
The list was copied from `release-ocm-2.12`