### PR TITLE
MGMT-11622: operator status should be logged

### DIFF
--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -34,8 +34,8 @@ type OperatorHandler interface {
 //  3. Returns true if the status changed to 'available', or false otherwise.
 func (c *controller) checkAndUpdateOperatorAvailability(handler OperatorHandler, useCache bool) bool {
 	operatorName := handler.GetName()
-	c.log.Infof("Checking <%s> operator availability status", operatorName)
 	operatorStatusInService, isAvailable := c.isOperatorAvailableInService(operatorName, c.OpenshiftVersion, useCache)
+	c.log.Infof("Checking availability of operator <%s>: %v", operatorName, isAvailable)
 	if isAvailable {
 		return true
 	}


### PR DESCRIPTION
In this PR, we improve the logging by adding the operator's availability status alongside its name. This way, the logs will not only show that we are checking the operator's status, but also what the actual result is. This makes the logs more informative and helps us better understand the outcome of the availability check without having to look at additional data.
