### PR TITLE
MGMT-20534: Move getting Node replicas into waitForNodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/net v0.33.0
-	golang.org/x/sync v0.11.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.9
 	k8s.io/apimachinery v0.29.9
@@ -162,6 +161,7 @@ require (
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -300,7 +300,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					}
 				}
 				WaitMasterNodesSucccessWithCluster := func(cluster *models.Cluster) {
-					mockk8sclient.EXPECT().GetControlPlaneReplicas().Return(3, nil).Times(1)
+					mockk8sclient.EXPECT().GetControlPlaneReplicas().Return(3, nil).AnyTimes()
 					mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(inventoryNamesHost, nil).AnyTimes()
 					mockk8sclient.EXPECT().ListNodesByRole("master").Return(GetKubeNodes(map[string]string{}), nil).Times(1)
 					kubeNamesIds = map[string]string{"node0": "7916fa89-ea7a-443e-a862-b3e930309f65"}
@@ -316,10 +316,10 @@ var _ = Describe("installer HostRoleMaster role", func() {
 					WaitMasterNodesSucccessWithCluster(&models.Cluster{})
 				}
 				WaitArbiterNodesSucccessWithoutArbiter := func() {
-					mockk8sclient.EXPECT().GetArbiterReplicas().Return(0, nil).Times(1)
+					mockk8sclient.EXPECT().GetArbiterReplicas().Return(0, nil).AnyTimes()
 				}
 				WaitArbiterNodesSucccessWithArbiter := func() {
-					mockk8sclient.EXPECT().GetArbiterReplicas().Return(1, nil).Times(1)
+					mockk8sclient.EXPECT().GetArbiterReplicas().Return(1, nil).AnyTimes()
 					mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(inventoryNamesHost, nil).AnyTimes()
 					mockk8sclient.EXPECT().ListNodesByRole("arbiter").Return(GetKubeNodes(map[string]string{}), nil).Times(1)
 					kubeNamesIds = map[string]string{"node0": "7916fa89-ea7a-443e-a862-b3e930309f65"}
@@ -878,7 +878,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 							checkOcBinary(true)
 							startServicesSuccess()
 
-							mockk8sclient.EXPECT().GetControlPlaneReplicas().Return(3, nil).Times(1)
+							mockk8sclient.EXPECT().GetControlPlaneReplicas().Return(3, nil).AnyTimes()
 							mockbmclient.EXPECT().GetEnabledHostsNamesHosts(gomock.Any(), gomock.Any()).Return(inventoryNamesHost, nil).AnyTimes()
 							mockk8sclient.EXPECT().ListNodesByRole("master").Return(GetKubeNodes(map[string]string{}), nil).Times(1)
 							kubeNamesIds = map[string]string{"node0": "7916fa89-ea7a-443e-a862-b3e930309f65"}
@@ -898,7 +898,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 								"node1": "eb82821f-bf21-4614-9a3b-ecb07929f238"}
 							mockk8sclient.EXPECT().ListNodesByRole("master").Return(GetKubeNodes(kubeNamesIds), nil).Times(1)
 							mockbmclient.EXPECT().UpdateHostInstallProgress(gomock.Any(), inventoryNamesHost["node1"].Host.InfraEnvID.String(), inventoryNamesHost["node1"].Host.ID.String(), models.HostStageJoined, "").Times(1)
-							mockk8sclient.EXPECT().GetArbiterReplicas().Return(0, nil).Times(1)
+							mockk8sclient.EXPECT().GetArbiterReplicas().Return(0, nil).AnyTimes()
 							waitForBootkubeSuccess()
 							bootkubeStatusSuccess()
 							waitForETCDBootstrapSuccess()


### PR DESCRIPTION
Originally, GetControlPlaneReplicas and GetArbiterReplicas were called once outside a retry. These functions can fail since they call the spoke cluster's kube api server, which most likely is not ready by the time the installer is checking for these Nodes. This leads to the cluster prematurely failing because of the error returned from these functions.

This moves the functions into the retry block that waitForNodes already uses so that the whole install doesn't fail when the spoke's kube apiserver is not ready yet.

---

Failures encountered in slack thread: https://redhat-internal.slack.com/archives/C014N2VLTQE/p1745997401995939
Original code added here https://github.com/openshift/assisted-installer/commit/c43bcb972dc310561de5649370e71172311ae090#diff-1046cc2d18cf5f82336bbad36a2d28540606e1c6aaa0b5073c545301ef60ffd4R670