### PR TITLE
MGMT-20567: Enable HTTP endpoint for MCO ignition

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -43,6 +44,7 @@ const (
 	encapsulatedMachineConfigFile   = "/etc/ignition-machine-config-encapsulated.json"
 	defaultIgnitionPlatformId       = "ignition.platform.id=metal"
 	ignitionContent                 = "application/vnd.coreos.ignition+json; version=3.4.0"
+	schemeHTTPS                     = "https"
 )
 
 //go:generate mockgen -source=ops.go -package=ops -destination=mock_ops.go
@@ -917,32 +919,50 @@ func (o *ops) getEmbeddedIgnition(source string) ([]byte, error) {
 }
 
 func (o *ops) getIgnitionFromBoostrap(source, ca string) ([]byte, error) {
-	if ca == "" {
-		return nil, errors.New("CA cert is empty")
+	parsedURL, err := url.Parse(source)
+	if err != nil || parsedURL == nil {
+		return nil, errors.Wrapf(err, "failed to parse ignition source URL - %s", source)
 	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM([]byte(ca))
-	tr := &http.Transport{TLSClientConfig: &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    caCertPool,
-	}}
-	client := http.Client{Transport: tr}
+
+	client := &http.Client{}
+	if parsedURL.Scheme == schemeHTTPS && ca == "" {
+		return nil, fmt.Errorf("ignition endpoint %s was specified with HTTPS, but CA certificate is empty", source)
+	}
+
+	if parsedURL.Scheme == schemeHTTPS {
+		caCertPool := x509.NewCertPool()
+		if ok := caCertPool.AppendCertsFromPEM([]byte(ca)); !ok {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		o.log.Info("using HTTPS with given CA certificate to get ignition from bootstrap")
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caCertPool,
+			},
+		}
+		client.Transport = tr
+	}
+
 	o.log.Infof("Getting ignition from %s", source)
 	req, err := http.NewRequest("GET", source, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	req.Header.Add("Accept", ignitionContent)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get ignition from %s", source)
 	}
+
 	defer resp.Body.Close()
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to copy ignition from %s", source)
 	}
+
 	return buf.Bytes(), nil
 }
 

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -188,21 +188,28 @@ grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
 5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
 WkBKOclmOV2xlTVuPw==
 -----END CERTIFICATE-----`)
-	buildPointerIgnition := func(source string) types.Config {
+	buildPointerIgnition := func(source string, withCert bool) types.Config {
 		ret := types.Config{}
 		ret.Ignition.Version = "3.2.0"
 		ret.Ignition.Config.Merge = append(ret.Ignition.Config.Merge,
 			types.Resource{
 				Source: swag.String(source),
 			})
+
+		if !withCert {
+			return ret
+		}
+
 		ret.Ignition.Security.TLS.CertificateAuthorities = append(ret.Ignition.Security.TLS.CertificateAuthorities,
 			types.Resource{
 				Source: swag.String(dataurl.EncodeBytes(localhostCert)),
 			})
+
 		return ret
 	}
-	buildPointerIgnitionFile := func(source string) string {
-		cfg := buildPointerIgnition(source)
+
+	buildPointerIgnitionFile := func(source string, withCert bool) string {
+		cfg := buildPointerIgnition(source, withCert)
 		b, err := json.Marshal(&cfg)
 		Expect(err).ToNot(HaveOccurred())
 		f, err := os.CreateTemp("", "ign")
@@ -214,7 +221,7 @@ WkBKOclmOV2xlTVuPw==
 	}
 	Context("get pointed ignition", func() {
 		checkSource := func(source string) {
-			ignitionPath := buildPointerIgnitionFile(source)
+			ignitionPath := buildPointerIgnitionFile(source, true)
 			defer func() {
 				_ = os.RemoveAll(ignitionPath)
 			}()
@@ -231,6 +238,7 @@ WkBKOclmOV2xlTVuPw==
 			checkSource(dataurl.EncodeBytes([]byte("source")))
 		})
 	})
+
 	Context("get MCS ignition", func() {
 		var (
 			osImageURL      string
@@ -265,8 +273,8 @@ WkBKOclmOV2xlTVuPw==
 			Expect(err).ToNot(HaveOccurred())
 			return string(b)
 		}
-		checkMcsIgnition := func(source string, shouldSucceed bool) {
-			ignitionPath := buildPointerIgnitionFile(source)
+		checkMcsIgnition := func(source string, withCert bool, shouldSucceed bool) {
+			ignitionPath := buildPointerIgnitionFile(source, withCert)
 			defer func() {
 				_ = os.RemoveAll(ignitionPath)
 			}()
@@ -297,7 +305,7 @@ WkBKOclmOV2xlTVuPw==
 			}
 		})
 		It("from bootstrap - non existant URL", func() {
-			checkMcsIgnition("https://127.0.0.1:44", false)
+			checkMcsIgnition("https://127.0.0.1:44", true, false)
 		})
 		It("from bootstrap - success", func() {
 			s := ghttp.NewTLSServer()
@@ -306,7 +314,7 @@ WkBKOclmOV2xlTVuPw==
 					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
 					Expect(err).ToNot(HaveOccurred())
 				})
-			checkMcsIgnition(s.URL(), true)
+			checkMcsIgnition(s.URL(), true, true)
 			s.Close()
 		})
 		It("from bootstrap - empty response", func() {
@@ -316,11 +324,51 @@ WkBKOclmOV2xlTVuPw==
 					_, err := io.WriteString(w, "")
 					Expect(err).ToNot(HaveOccurred())
 				})
-			checkMcsIgnition(s.URL(), false)
+			checkMcsIgnition(s.URL(), true, false)
+			s.Close()
+		})
+		It("from bootstrap - with http no cert should succeed", func() {
+			s := ghttp.NewServer()
+			s.RouteToHandler("GET", "/",
+				func(w http.ResponseWriter, req *http.Request) {
+					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			checkMcsIgnition(s.URL(), false, true)
+			s.Close()
+		})
+		It("from bootstrap - with http with cert should succeed", func() {
+			s := ghttp.NewServer()
+			s.RouteToHandler("GET", "/",
+				func(w http.ResponseWriter, req *http.Request) {
+					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			checkMcsIgnition(s.URL(), true, true)
+			s.Close()
+		})
+		It("from bootstrap - with https with cert should succeed", func() {
+			s := ghttp.NewTLSServer()
+			s.RouteToHandler("GET", "/",
+				func(w http.ResponseWriter, req *http.Request) {
+					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			checkMcsIgnition(s.URL(), true, true)
+			s.Close()
+		})
+		It("from bootstrap - with https no cert should fail", func() {
+			s := ghttp.NewTLSServer()
+			s.RouteToHandler("GET", "/",
+				func(w http.ResponseWriter, req *http.Request) {
+					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			checkMcsIgnition(s.URL(), false, false)
 			s.Close()
 		})
 		It("embedded - success", func() {
-			checkMcsIgnition(dataurl.EncodeBytes(compress([]byte(buildMcsIgnition(osImageURL, kernelArguments)))), true)
+			checkMcsIgnition(dataurl.EncodeBytes(compress([]byte(buildMcsIgnition(osImageURL, kernelArguments)))), true, true)
 		})
 	})
 })


### PR DESCRIPTION
Currently assisted-service generates `HTTP` endpoints for MCO pointer ignitions in day2, compared to `HTTPS` for day1. Assisted Installer expects an `HTTPS` endpoint and CA certificate, therefore day2 hosts fail skipping `MCO` reboot, and  delays the installation by 20 minutes.

logs:
```
May 05 12:42:11 localhost.localdomain installer[2721]: time="2025-05-05T12:42:11Z" level=info msg="Updating node installation stage: Waiting for control plane - " request_id=48bfbb1b-eaed-41bf-a2be-db5a6561aca9
May 05 12:42:11 localhost.localdomain installer[2721]: time="2025-05-05T12:42:11Z" level=warning msg="failed to get encapsulated Machine Config" error="CA cert is empty"
May 05 12:42:16 localhost.localdomain installer[2721]: time="2025-05-05T12:42:16Z" level=warning msg="failed to get encapsulated Machine Config" error="CA cert is empty"
May 05 12:42:21 localhost.localdomain installer[2721]: time="2025-05-05T12:42:21Z" level=warning msg="failed to get encapsulated Machine Config" error="CA cert is empty"
May 05 12:42:26 localhost.localdomain installer[2721]: time="2025-05-05T12:42:26Z" level=warning msg="failed to get
.
.
.
```

This PR enables `HTTP` endpoints without certificate as well. Logs after the fix:
```
May 05 18:23:21 localhost.localdomain installer[3141]: time="2025-05-05T18:23:21Z" level=info msg="Waiting for 2 ready masters"
May 05 18:23:21 localhost.localdomain installer[3141]: time="2025-05-05T18:23:21Z" level=info msg="Updating node installation stage: Waiting for control plane - " request_id=0671e049-ee18-4bae-b23f-da8dadf328c8
May 05 18:23:21 localhost.localdomain installer[3141]: time="2025-05-05T18:23:21Z" level=info msg="Getting ignition from http://192.168.127.100:22624/config/worker"
May 05 18:23:21 localhost.localdomain installer[3141]: time="2025-05-05T18:23:21Z" level=info msg="Running mount with args [/dev/vda4 /mnt]"
May 05 18:23:21 localhost.localdomain installer[3141]: time="2025-05-05T18:23:21Z" level=info msg="Running mount with args [/dev/vda3 /mnt/boot]"
```

**Note** - Skipping MCO reboot was disabled for day2 hosts because of this bug, this PR will be followed by enabling it again