### PR TITLE
WIP: MGMT-20700: Change the order of post install actions

### DIFF
--- a/src/assisted_installer_controller/operator_handler.go
+++ b/src/assisted_installer_controller/operator_handler.go
@@ -57,6 +57,7 @@ func (c *controller) checkAndUpdateOperatorAvailability(handler OperatorHandler,
 			operatorStatusInService.StatusInfo,
 			operatorMessage,
 		)
+
 		if !handler.OnChange(operatorStatus) {
 			c.log.WithError(err).Warnf("<%s> operator's OnChange() returned false. Will skip an update.", operatorName)
 			return false


### PR DESCRIPTION
wait for the CSV installation complete and only then apply the manifests. The reason is we have occasionally operators which their manifests apply fails due to the CRD not applied yet, therefore this PR waits for the CSV installation completion rather than just its existence before applying the manifests. More details and example can be found on the Jira isssue.