### PR TITLE
MGMT-19973: Use rsync over cp to set up networking files for first boot

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -236,7 +236,7 @@ func (o *ops) configureFirstBootNetworking(liveLogger io.Writer, installerArgs [
 		return errors.Wrapf(err, "failed to create firstboot network directory: %s", out)
 	}
 
-	out, err = o.ExecPrivilegeCommand(liveLogger, "sh", "-c", "cp /etc/NetworkManager/system-connections/* /boot/coreos-firstboot-network")
+	out, err = o.ExecPrivilegeCommand(liveLogger, "rsync", "-av", "/etc/NetworkManager/system-connections/", "/boot/coreos-firstboot-network/")
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy network files to firstboot network directory: %s", out)
 	}

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -669,7 +669,7 @@ var _ = Describe("WriteImageToExistingRoot", func() {
 		expectExec("", nil, "ostree", "admin", "finalize-staged")
 
 		expectExec("", nil, "mkdir", "/boot/coreos-firstboot-network")
-		expectExec("", nil, "sh", "-c", "cp /etc/NetworkManager/system-connections/* /boot/coreos-firstboot-network")
+		expectExec("", nil, "rsync", "-av", "/etc/NetworkManager/system-connections/", "/boot/coreos-firstboot-network/")
 		expectIgnitionSetup()
 
 		installerArgs := []string{"-n"}
@@ -690,7 +690,7 @@ var _ = Describe("WriteImageToExistingRoot", func() {
 		expectExec("", nil, "ostree", "admin", "finalize-staged")
 
 		expectExec("", nil, "mkdir", "/boot/coreos-firstboot-network")
-		expectExec("", nil, "sh", "-c", "cp /etc/NetworkManager/system-connections/* /boot/coreos-firstboot-network")
+		expectExec("", nil, "rsync", "-av", "/etc/NetworkManager/system-connections/", "/boot/coreos-firstboot-network/")
 		expectIgnitionSetup()
 
 		installerArgs := []string{"--copy-network"}


### PR DESCRIPTION
`cp` complains for a glob path if no files exist in the source directory. This causes the whole install to fail when static networking is present, but no config matched for a particular host.

`rsync` doesn't complain in the same way and allows the command to be run unconditionally.

Specifically, before this fix, installs would fail with the following logs if we had the copy network flag, but no files in the source directory:
```
Feb 14 22:04:52 localhost.localdomain installer[3170]: time="2025-02-14T22:04:52Z" level=info msg="copying network files from /etc/NetworkManager/system-connections to /boot/coreos-firstboot-network"
Feb 14 22:04:52 localhost.localdomain assisted-installer[3168]: time="2025-02-14T22:04:52Z" level=info msg="copying network files from /etc/NetworkManager/system-connections to /boot/coreos-firstboot-network"
Feb 14 22:04:52 localhost.localdomain installer[3170]: time="2025-02-14T22:04:52Z" level=info msg="cp: cannot stat '/etc/NetworkManager/system-connections/*': No such file or directory\n"
Feb 14 22:04:52 localhost.localdomain assisted-installer[3168]: time="2025-02-14T22:04:52Z" level=info msg="cp: cannot stat '/etc/NetworkManager/system-connections/*': No such file or directory\n"
Feb 14 22:04:52 localhost.localdomain installer[3170]: time="2025-02-14T22:04:52Z" level=info msg="failed executing /usr/bin/nsenter [--target 1 --cgroup --mount --ipc --pid -- sh -c cp /etc/NetworkManager/system-connections/* /boot/coreos-firstboot-network], env vars [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin https_proxy= http_proxy= OPENSHIFT_BUILD_NAMESPACE=ci-op-vjk5c3ik no_proxy= HTTPS_PROXY= NO_PROXY= PULL_SECRET_TOKEN=<SECRET> container=podman HTTP_PROXY= BUILD_LOGLEVEL=0 OPENSHIFT_BUILD_NAME=assisted-installer-amd64 HOME=/root HOSTNAME=localhost.localdomain], error exit status 1, waitStatus 1, Output \"cp: cannot stat '/etc/NetworkManager/system-connections/*': No such file or directory\""
Feb 14 22:04:52 localhost.localdomain assisted-installer[3168]: time="2025-02-14T22:04:52Z" level=info msg="failed executing /usr/bin/nsenter [--target 1 --cgroup --mount --ipc --pid -- sh -c cp /etc/NetworkManager/system-connections/* /boot/coreos-firstboot-network], env vars [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin https_proxy= http_proxy= OPENSHIFT_BUILD_NAMESPACE=ci-op-vjk5c3ik no_proxy= HTTPS_PROXY= NO_PROXY= PULL_SECRET_TOKEN=<SECRET> container=podman HTTP_PROXY= BUILD_LOGLEVEL=0 OPENSHIFT_BUILD_NAME=assisted-installer-amd64 HOME=/root HOSTNAME=localhost.localdomain], error exit status 1, waitStatus 1, Output \"cp: cannot stat '/etc/NetworkManager/system-connections/*': No such file or directory\""
```

Resolves https://issues.redhat.com/browse/MGMT-19973