### PR TITLE
MGMT-18518: Linter fixes & renovate config for linter and golang

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,53 +15,52 @@ run:
   # include test files or not, default is true
   tests: true
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - build
-    - client
-    - docs
-    - models
-    - restapi
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
 issues:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  exclude-dirs:
+    - build
+    - client
+    - docs
+    - models
+    - restapi
+  
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - G107
+  
+  # make issues output unique by line, default is true
+  uniq-by-line: true
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - gosec
-    - megacheck
     - unconvert
     - goimports
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
     settings:
       printf:
         funcs:

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0 && \ 
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.7 && \ 
   go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
   go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
   go install go.uber.org/mock/mockgen@v0.4.0 && \

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,85 @@
 {
-    "schedule": ["on Saturday"],
-    "groupName": "Konflux build pipeline",
-    "includePaths": [".tekton/*"],
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+
     "commitMessagePrefix": "NO-ISSUE: ",
-    "labels": ["lgtm", "approved", "konflux"]
+    "labels": ["lgtm", "approved"],
+
+    "prHourlyLimit": 0,
+    "prConcurrentLimit": 0,
+
+    "enabledManagers": [
+        "custom.regex",
+        "tekton"
+    ],
+
+    "tekton": {
+        "fileMatch": ["^.tekton/*"]
+    },
+
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.assisted-installer-build$"
+            ],
+            "matchStrings": [
+                "RUN curl .*https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- .* (?<currentValue>.*?) && .*"
+            ],
+            "depNameTemplate": "github.com/golangci/golangci-lint",
+            "datasourceTemplate": "go"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.assisted-installer$",
+                "^Dockerfile.assisted-installer-build$",
+                "^Dockerfile.assisted-installer-controller$",
+                "^Dockerfile.assisted-installer-controller-downstream$",
+                "^Dockerfile.assisted-installer-controller-mce$",
+                "^Dockerfile.assisted-installer-downstream$",
+                "^Dockerfile.assisted-installer-mce$"
+            ],
+            "matchStrings": [
+                "FROM registry.access.redhat.com/ubi9/go-toolset:(?<currentValue>.*?) AS .*\\n",
+                "FROM --platform=\\$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:(?<currentValue>.*?) AS builder\\n"
+            ],
+            "depNameTemplate": "registry.access.redhat.com/ubi9/go-toolset",
+            "datasourceTemplate": "docker"
+        }
+    ],
+
+    "packageRules": [
+        {
+            "groupName": "Go Builder",
+            "addLabels": ["golang"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "allowedVersions": "/^[0-9]+\\.[0-9]+$/"
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "enabled": false
+        },
+        {
+            "groupName": "Linter",
+            "addLabels": ["linter"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"],
+            "enabled": false
+        },
+        {
+            "groupName": "Konflux build pipeline",
+            "addLabels": ["konflux"],
+            "schedule": ["on Saturday"],
+            "matchManagers": ["tekton"]
+        }
+    ]
 }

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -354,7 +354,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			configuringSuccess()
 			listNodes()
 
-			for name, value := range inventoryNamesIds {
+			for name, v := range inventoryNamesIds {
+				value := v
 				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
@@ -493,7 +494,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			mockk8sclient.EXPECT().ListNodes().Return(nodes, nil).Times(1)
 			updateProgressSuccess(done, hosts)
 			configuringSuccess()
-			for name, value := range inventoryNamesIds {
+			for name, v := range inventoryNamesIds {
+				value := v
 				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
@@ -548,7 +550,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 				"node2": "57df89ee-3546-48a5-859a-0f1459485a66"}
 		})
 		It("WaitAndUpdateNodesStatus one by one", func() {
-			for name, value := range inventoryNamesIds {
+			for name, v := range inventoryNamesIds {
+				value := v
 				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			listNodesOneByOne := func() {
@@ -590,7 +593,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 	Context("UpdateStatusFails and then succeeds", func() {
 		It("UpdateStatus fails and then succeeds, list nodes failed ", func() {
-			for name, value := range inventoryNamesIds {
+			for name, v := range inventoryNamesIds {
+				value := v
 				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			updateProgressSuccessFailureTest := func(stages []models.HostStage, inventoryNamesIds map[string]inventory_client.HostData) {
@@ -641,7 +645,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			configuringSuccess()
 
 			mockk8sclient.EXPECT().ListCsrs().Return(nil, fmt.Errorf("no matter what")).AnyTimes()
-			for name, value := range inventoryNamesIds {
+			for name, v := range inventoryNamesIds {
+				value := v
 				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
 			}
 


### PR DESCRIPTION
* Upgrade linter
* Fix linter issues
* Renovate config for linter upgrade
* Renovate config for golang update

2 dockerfiles are not part of the renovate config:
* Dockerfile.assisted-installer-controller.ocp
* Dockerfile.assisted-installer.ocp