### PR TITLE
MGMT-20949: Add etcd-operator pod relocation for clusters with 2 CP nodes to controller

### DIFF
--- a/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
+++ b/deploy/assisted-installer-controller/assisted-installer-controller-role.yaml
@@ -179,6 +179,7 @@ rules:
     resources:
       - pods
     verbs:
+      - delete
       - deletecollection
   - apiGroups:
       - "security.openshift.io"

--- a/src/assisted_installer_controller/mock_controller.go
+++ b/src/assisted_installer_controller/mock_controller.go
@@ -80,6 +80,18 @@ func (mr *MockControllerMockRecorder) PostInstallConfigs(ctx, wg any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostInstallConfigs", reflect.TypeOf((*MockController)(nil).PostInstallConfigs), ctx, wg)
 }
 
+// RelocateEtcdOperatorPod mocks base method.
+func (m *MockController) RelocateEtcdOperatorPod(ctx context.Context, wg *sync.WaitGroup) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RelocateEtcdOperatorPod", ctx, wg)
+}
+
+// RelocateEtcdOperatorPod indicates an expected call of RelocateEtcdOperatorPod.
+func (mr *MockControllerMockRecorder) RelocateEtcdOperatorPod(ctx, wg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelocateEtcdOperatorPod", reflect.TypeOf((*MockController)(nil).RelocateEtcdOperatorPod), ctx, wg)
+}
+
 // SetReadyState mocks base method.
 func (m *MockController) SetReadyState(waitTimeout time.Duration) *models.Cluster {
 	m.ctrl.T.Helper()

--- a/src/k8s_client/k8s_client.go
+++ b/src/k8s_client/k8s_client.go
@@ -80,6 +80,7 @@ type K8SClient interface {
 	GetClusterOperator(name string) (*configv1.ClusterOperator, error)
 	CreateEvent(namespace, name, message, component string) (*v1.Event, error)
 	DeleteService(namespace, name string) error
+	DeletePod(name, namespace string) error
 	DeletePods(namespace string) error
 	PatchNamespace(namespace string, data []byte) error
 	GetNode(name string) (*v1.Node, error)
@@ -203,6 +204,10 @@ func (c *k8sClient) ListJobs(namespace string) (*batchV1.JobList, error) {
 
 func (c *k8sClient) DeleteJob(job types.NamespacedName) error {
 	return c.client.BatchV1().Jobs(job.Namespace).Delete(context.TODO(), job.Name, metav1.DeleteOptions{})
+}
+
+func (c *k8sClient) DeletePod(name, namespace string) error {
+	return c.client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
 func (c *k8sClient) DeletePods(namespace string) error {

--- a/src/k8s_client/mock_k8s_client.go
+++ b/src/k8s_client/mock_k8s_client.go
@@ -105,6 +105,20 @@ func (mr *MockK8SClientMockRecorder) DeleteJob(job any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockK8SClient)(nil).DeleteJob), job)
 }
 
+// DeletePod mocks base method.
+func (m *MockK8SClient) DeletePod(name, namespace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePod", name, namespace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePod indicates an expected call of DeletePod.
+func (mr *MockK8SClientMockRecorder) DeletePod(name, namespace any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockK8SClient)(nil).DeletePod), name, namespace)
+}
+
 // DeletePods mocks base method.
 func (m *MockK8SClient) DeletePods(namespace string) error {
 	m.ctrl.T.Helper()

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -216,6 +216,9 @@ func main() {
 	go assistedController.UpdateNodeLabels(mainContext, &wg)
 	wg.Add(1)
 
+	go assistedController.RelocateEtcdOperatorPod(mainContext, &wg)
+	wg.Add(1)
+
 	// monitoring installation by cluster status
 	switch invoker {
 	case common.InvokerAgent:


### PR DESCRIPTION
Adding to the controller, relocation of the etcd operator pod from the first master node if the cluster has 2 masters.
This will happen after both masters are ready and is done for 2 reasons:
1. To avoid a race condition in the etcd operator that could result in the second master (the bootstrap) not being properly added to the etcd cluster - its etcd pod will be stuck at crash loopback.
2. To free up resources on the first master since with minimum resources we can run into a problem where 1 pod is stuck pending - because the pod is from a daemonset and should run on the first master, but its resource requests are too high for the pod to be scheduled on the first master.

Closes MGMT-20949