### PR TITLE
[master] MGMT-20756: assisted installer naive string concatenation for partition finding

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1060,7 +1060,7 @@ func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string,
 		return "", errors.Errorf("failed to find device %s in lsblk output", device)
 	}
 
-	if len(diskNode.Children) == 0 {
+	if diskNode.Children == nil || len(diskNode.Children) == 0 {
 		return "", errors.Errorf("device %s has no partitions", device)
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1033,6 +1033,52 @@ func stripDev(device string) string {
 	return strings.Replace(device, "/dev/", "", 1)
 }
 
+// getPartitionPathFromLsblk uses lsblk to find the actual partition device path
+// for a given device and partition number. This handles all device types including
+// device mapper devices correctly.
+func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string, error) {
+	type node struct {
+		Name     string  `json:"name"`
+		Size     int64   `json:"size"`
+		Children []*node `json:"children"`
+	}
+	var disks struct {
+		Blockdevices []*node `json:"blockdevices"`
+	}
+
+	ret, err := o.ExecPrivilegeCommand(nil, "lsblk", "-b", "-J")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to run lsblk command")
+	}
+	if err = json.Unmarshal([]byte(ret), &disks); err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal lsblk output")
+	}
+
+	deviceName := stripDev(device)
+	diskNode, ok := funk.Find(disks.Blockdevices, func(n *node) bool { return deviceName == n.Name }).(*node)
+	if !ok {
+		return "", errors.Errorf("failed to find device %s in lsblk output", device)
+	}
+
+	if len(diskNode.Children) == 0 {
+		return "", errors.Errorf("device %s has no partitions", device)
+	}
+
+	// Convert partition number to integer for indexing
+	partNum, err := strconv.Atoi(partitionNumber)
+	if err != nil {
+		return "", errors.Errorf("invalid partition number %s", partitionNumber)
+	}
+
+	// Partition numbers are 1-based, but array indices are 0-based
+	if partNum < 1 || partNum > len(diskNode.Children) {
+		return "", errors.Errorf("partition %s not found on device %s", partitionNumber, device)
+	}
+
+	partitionName := diskNode.Children[partNum-1].Name
+	return "/dev/" + partitionName, nil
+}
+
 func partitionNameForDeviceName(deviceName, partitionNumber string) string {
 	var format string
 	switch {
@@ -1075,11 +1121,11 @@ func (o *ops) calculateFreePercent(device string) (int64, error) {
 	if !ok {
 		return 0, errors.Errorf("failed to find device is %s in lsblk output", device)
 	}
-	partitionName := partitionNameForDeviceName(diskNode.Name, "4")
-	partitionNode, ok = funk.Find(diskNode.Children, func(n *node) bool { return partitionName == n.Name }).(*node)
-	if !ok {
-		return 0, errors.Errorf("failed to find partition node %s in lsblk output", device)
+	// Find partition 4 (1-based indexing, so array index 3)
+	if len(diskNode.Children) < 4 {
+		return 0, errors.Errorf("device %s does not have 4 partitions", device)
 	}
+	partitionNode = diskNode.Children[3] // partition 4 is at index 3
 	var usedSize int64
 	funk.ForEach(diskNode.Children, func(n *node) { usedSize += n.Size })
 
@@ -1116,9 +1162,19 @@ func (o *ops) OverwriteOsImage(osImage, device string, extraArgs []string) error
 		o.log.Infof("Running on s390x archtiecture - skip overwrite image.")
 		return nil
 	}
+
+	partition4, err := o.getPartitionPathFromLsblk(device, "4")
+	if err != nil {
+		return errors.Wrapf(err, "failed to find partition 4 for device %s", device)
+	}
+	partition3, err := o.getPartitionPathFromLsblk(device, "3")
+	if err != nil {
+		return errors.Wrapf(err, "failed to find partition 3 for device %s", device)
+	}
+
 	cmds := []*cmd{
-		makecmd("mount", partitionForDevice(device, "4"), "/mnt"),
-		makecmd("mount", partitionForDevice(device, "3"), "/mnt/boot"),
+		makecmd("mount", partition4, "/mnt"),
+		makecmd("mount", partition3, "/mnt/boot"),
 		growpartcmd,
 		makecmd("xfs_growfs", "/mnt"),
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1060,7 +1060,7 @@ func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string,
 		return "", errors.Errorf("failed to find device %s in lsblk output", device)
 	}
 
-	if diskNode.Children == nil || len(diskNode.Children) == 0 {
+	if len(diskNode.Children) == 0 {
 		return "", errors.Errorf("device %s has no partitions", device)
 	}
 


### PR DESCRIPTION
## Problem
Assisted installer used naive string concatenation for partition finding, causing failures with device mapper devices (dm-*). For example, trying to mount `/dev/dm-02` instead of the correct `/dev/dm-2`.

## Solution  
Replace string concatenation with robust `lsblk --json` based partition discovery that works with all device types:
- Device mapper: `/dev/dm-0` → `/dev/dm-2`, `/dev/dm-3`, `/dev/dm-4`
- Standard SATA: `/dev/sda` → `/dev/sda2`, `/dev/sda3`, `/dev/sda4`  
- NVMe: `/dev/nvme0n1` → `/dev/nvme0n1p2`, `/dev/nvme0n1p3`, `/dev/nvme0n1p4`
- MMC: `/dev/mmcblk1` → `/dev/mmcblk1P2`, `/dev/mmcblk1P3`, `/dev/mmcblk1P4`

## Changes
- Add `getPartitionPathFromLsblk()` function using `lsblk --json` output parsing
- Update `OverwriteOsImage()` to use new partition discovery method
- Fix `calculateFreePercent()` to use proper array indexing  
- Add comprehensive unit tests (16 tests) covering all device types and edge cases
- Add integration test for device mapper devices

## Testing
- ✅ All existing tests pass (maintains backward compatibility)
- ✅ New device mapper test passes 
- ✅ Comprehensive unit test coverage for new functionality
- ✅ Verified exact ticket scenario: `/dev/dm-0` partition 2 correctly returns `/dev/dm-2`

Fixes: [MGMT-20756](https://issues.redhat.com//browse/MGMT-20756)