### PR TITLE
[master] MGMT-20756: assisted installer naive string concatenation for partition finding

### DIFF
--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -423,13 +423,11 @@ func (o *ops) findEfiDirectory(device string) (string, error) {
 		out string
 		err error
 	)
-
 	// Find the actual path for partition 2 using lsblk
 	partition2Path, err := o.getPartitionPathFromLsblk(device, "2")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to find partition 2 for EFI directory")
 	}
-
 	if err = utils.Retry(3, 5*time.Second, o.log, func() (err error) {
 		_, err = o.ExecPrivilegeCommand(nil, "mount", partition2Path, "/mnt")
 		return

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -423,8 +423,15 @@ func (o *ops) findEfiDirectory(device string) (string, error) {
 		out string
 		err error
 	)
+
+	// Find the actual path for partition 2 using lsblk
+	partition2Path, err := o.getPartitionPathFromLsblk(device, "2")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to find partition 2 for EFI directory")
+	}
+
 	if err = utils.Retry(3, 5*time.Second, o.log, func() (err error) {
-		_, err = o.ExecPrivilegeCommand(nil, "mount", partitionForDevice(device, "2"), "/mnt")
+		_, err = o.ExecPrivilegeCommand(nil, "mount", partition2Path, "/mnt")
 		return
 	}); err != nil {
 		return "", errors.Wrap(err, "failed to mount efi device")

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1066,7 +1066,7 @@ func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string,
 	}
 	diskNode := disks.Blockdevices[0] // lsblk with device filter returns only that device
 
-	if diskNode.Children == nil || len(diskNode.Children) == 0 {
+	if len(diskNode.Children) == 0 {
 		return "", errors.Errorf("device %s has no partitions", device)
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1066,7 +1066,7 @@ func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string,
 	}
 	diskNode := disks.Blockdevices[0] // lsblk with device filter returns only that device
 
-	if len(diskNode.Children) == 0 {
+	if diskNode.Children == nil || len(diskNode.Children) == 0 {
 		return "", errors.Errorf("device %s has no partitions", device)
 	}
 

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -1083,23 +1083,6 @@ func (o *ops) getPartitionPathFromLsblk(device, partitionNumber string) (string,
 	return "/dev/" + partitionName, nil
 }
 
-func partitionNameForDeviceName(deviceName, partitionNumber string) string {
-	var format string
-	switch {
-	case strings.HasPrefix(deviceName, "nvme"):
-		format = "%sp%s"
-	case strings.HasPrefix(deviceName, "mmcblk"):
-		format = "%sP%s"
-	default:
-		format = "%s%s"
-	}
-	return fmt.Sprintf(format, deviceName, partitionNumber)
-}
-
-func partitionForDevice(device, partitionNumber string) string {
-	return "/dev/" + partitionNameForDeviceName(stripDev(device), partitionNumber)
-}
-
 func (o *ops) calculateFreePercent(device string) (int64, error) {
 	type node struct {
 		Name     string

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -139,6 +139,23 @@ var _ = Describe("Set Boot Order", func() {
 			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m1).Times(1).Return("", errors.New("Bootlist is not exist."))
 			m2 := MatcherContainsStringElements{[]string{"test", "-d", "/sys/firmware/efi"}, true}
 			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m2).Times(1)
+			// Mock the lsblk call for getPartitionPathFromLsblk in findEfiDirectory
+			lsblkOutput := `{
+				"blockdevices": [
+					{
+						"name": "sda",
+						"size": 100000000000,
+						"children": [
+							{"name": "sda1", "size": 1048576},
+							{"name": "sda2", "size": 133169152},
+							{"name": "sda3", "size": 402653184},
+							{"name": "sda4", "size": 3272588800}
+						]
+					}
+				]
+			}`
+			mLsblk := MatcherContainsStringElements{[]string{"lsblk", "--bytes", "--json", "/dev/sda"}, true}
+			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), mLsblk).Times(1).Return(lsblkOutput, nil)
 			m3 := MatcherContainsStringElements{[]string{"efibootmgr", "/dev/sda", "Red Hat Enterprise Linux"}, true}
 			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m3).Times(1).Return("", nil)
 			m4 := MatcherContainsStringElements{[]string{"efibootmgr", "-l"}, true}


### PR DESCRIPTION
## Summary
Improve partition detection by querying `lsblk` directly for the device and using its JSON to resolve the EFI partition path, eliminating brittle string concatenation.

## Problem
`findEfiDirectory` previously constructed the EFI partition path via naive string concatenation (e.g., `device + "2"`), which fails for device name patterns like `nvme` (`/dev/nvme0n1p2`) and `dm-*`.

## Changes
- EFI path resolution: In src/ops/ops.go, `findEfiDirectory` now uses `o.getPartitionPathFromLsblk(device, "2")` to obtain the correct partition path from `lsblk`.
- `lsblk` invocation: Replace `lsblk -b -J` with `lsblk --bytes --json <device>` and rely on the scoped output instead of manual filtering.
- Linter cleanup: Remove redundant slice `nil` check (S1009) in `src/ops/ops.go`.
- Tests: Update mocks and expectations in `src/ops/ops_test.go` to reflect the new `lsblk` arguments and single-device behavior.

## Validation
`go test ./...` passes locally.
Manually verified EFI partition resolution for `sda`, `nvme0n1`, and `dm-*` style names.