### PR TITLE
MGMT-21454: update Go to 1.24 and adapt unit-tests

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 ENV GOFLAGS=""
 

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
This commit updates the assisted-installer project to use Go 1.24 and fixes compatibility issues that arose from the Go version update.

Context:
• This PR resolves the failed Renovate PR attempt that automatically tried to update to Go 1.24 
• The automated update failed due to unit test failures caused by TLS certificate validation changes 
• Manual intervention was required to fix the test compatibility issues before the Go version update

What was changed:
• Updated Dockerfiles (excluding OCP-specific ones) to use Go 1.24 toolset instead of Go 1.21 
• Modified unit tests in src/ops/ops_test.go to handle TLS certificate validation changes

Why these changes were needed:
• Go 1.24 introduced stricter TLS security defaults and certificate validation 
• The previous test approach used static certificates that were no longer accepted 
• Dynamic certificate extraction ensures tests use valid, server-generated certificates