### PR TITLE
MGMT-21454: Align with ART for OCP 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/Dockerfile.assisted-installer-controller.ocp
+++ b/Dockerfile.assisted-installer-controller.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"
@@ -6,7 +6,7 @@ ENV GOFLAGS="-mod=vendor"
 COPY . .
 RUN make controller
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 
 LABEL io.openshift.release.operator=true
 

--- a/Dockerfile.assisted-installer.ocp
+++ b/Dockerfile.assisted-installer.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"
@@ -7,7 +7,7 @@ COPY . .
 
 RUN make installer
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 
 LABEL io.openshift.release.operator=true
 


### PR DESCRIPTION
Bot PRs to bump images to Go 1.24 and OCP 4.20 failed. 
This manual PR applies those changes to resolve the issue.