### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for assisted-installer-controller-ds-main

### DIFF
--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -27,8 +27,9 @@ COPY --from=builder /app/assisted-installer-controller /assisted-installer-contr
 ENTRYPOINT ["/assisted-installer-controller"]
 
 LABEL com.redhat.component="assisted-installer-controller" \
-      name="assisted-installer-controller" \
+      name="rhai/assisted-installer-controller-rhel9" \
       version="${version}" \
+      cpe="cpe:/a:redhat:assisted_installer:2.38::el9" \
       upstream-ref="${version}" \
       upstream-url="https://github.com/openshift/assisted-installer" \
       summary="OpenShift Assisted Installer Controller" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
