### PR TITLE
KONFLUX-6210: fix and set name and cpe label for assisted-installer-ds-main

### DIFF
--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -29,7 +29,8 @@ COPY --from=builder /app/deploy/assisted-installer-controller /assisted-installe
 ENTRYPOINT ["/installer"]
 
 LABEL com.redhat.component="assisted-installer-container" \
-      name="assisted-installer" \
+      name="rhai/assisted-installer-rhel9" \
+      cpe="cpe:/a:redhat:assisted_installer:2.38::el9" \
       version="${version}" \
       upstream-ref="${version}" \
       upstream-url="https://github.com/openshift/assisted-installer" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
