### PR TITLE
[release-ocm-2.14] - ACM-24326,ACM-24321: CVE-2025-47907 Upgrade golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,57 +15,63 @@ run:
   # include test files or not, default is true
   tests: true
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - build
-    - client
-    - docs
-    - models
-    - restapi
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
 issues:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  exclude-dirs:
+    - build
+    - client
+    - docs
+    - models
+    - restapi
+
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - G107
+    - G115  # Integer overflow conversion
+    - G402  # support scality DisableSSL
+    - G401  # Use of weak cryptographic primitive
+    - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
+    - '"ok" shadows declaration'
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - gosec
-    - megacheck
     - unconvert
     - goimports
+    - copyloopvar
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
+
     settings:
       printf:
         funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-l
+          - Infof
+          - Warnf
+          - Errorf
+          - Fatalf

--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0 && \ 
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8 && \ 
   go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
   go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
   go install go.uber.org/mock/mockgen@v0.4.0 && \

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller.ocp
+++ b/Dockerfile.assisted-installer-controller.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer.ocp
+++ b/Dockerfile.assisted-installer.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -355,7 +355,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			listNodes()
 
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
 			Expect(exit).Should(Equal(false))
@@ -494,7 +495,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess(done, hosts)
 			configuringSuccess()
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
 			Expect(exit).Should(Equal(false))
@@ -549,7 +551,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("WaitAndUpdateNodesStatus one by one", func() {
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			listNodesOneByOne := func() {
 				kubeNameIdsToReturn := make(map[string]string)
@@ -591,7 +594,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	Context("UpdateStatusFails and then succeeds", func() {
 		It("UpdateStatus fails and then succeeds, list nodes failed ", func() {
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			updateProgressSuccessFailureTest := func(stages []models.HostStage, inventoryNamesIds map[string]inventory_client.HostData) {
 				var hostIds []string
@@ -642,7 +646,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			mockk8sclient.EXPECT().ListCsrs().Return(nil, fmt.Errorf("no matter what")).AnyTimes()
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 
 			go assistedController.WaitAndUpdateNodesStatus(context.TODO(), &wg, false)

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -1020,7 +1020,7 @@ func (i *installer) checkHostname() error {
 	data := fmt.Sprintf("random-hostname-%s", uuid.New().String())
 	i.log.Infof("Hostname [%s] is invalid, generated random hostname [%s]", hostname, data)
 	if err := i.ops.CreateRandomHostname(data); err != nil {
-		i.log.Errorf("Failed to generate random hostname", err)
+		i.log.Errorf("Failed to generate random hostname, err %s", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Jira Tickets
- https://issues.redhat.com/browse/ACM-24326
- https://issues.redhat.com/browse/ACM-24321

##
Update go version to 1.24 to address cve CVE-2025-47907

##
This PR updates tests to be compatible with Go 1.24 and golangci-lint 1.64.8.
                                                                                                                                                                                       
**TLS test changes (`ops_test.go`)**: Go 1.24 now [enforces a minimum 1024-bit RSA key size](https://tip.golang.org/doc/go1.24#crypto/rsa) for all TLS operations. The old `ghttp.NewTLSServer()` implementation generates certificates that are too weak and fail the new requirement. We've switched to using `httptest.NewTLSServer()` directly, which generates proper 2048-bit certificates. Since these certificates are dynamically generated per test, we had to change the function signatures from `withCert bool` to `ca []byte` to pass the actual certificate bytes through the test helpers.

**Loop variable changes (`assisted_installer_controller_test.go`)**: golangci-lint 1.64.8 includes the [copyloopvar](https://golangci-lint.run/usage/linters/#copyloopvar) linter which catches a common Go gotcha where loop variables are captured by reference in closures. The fix is simple - copy `value.Host` to a local variable before passing its fields to gomock expectations. This ensures each iteration uses the correct host data.
