### PR TITLE
[release-ocm-2.13] - CVE-2025-47907: Upgrade golang to 1.24.6

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS golang
 
 ENV GOFLAGS=""
 

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Security fix for CVE-2025-47907:
Upgrading golang to 1.24.6