### PR TITLE
[release-ocm-2.12] - ACM-24330,ACM-24325: CVE-2025-47907 Upgrade golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,57 +15,63 @@ run:
   # include test files or not, default is true
   tests: true
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - build
-    - client
-    - docs
-    - models
-    - restapi
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
 issues:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  exclude-dirs:
+    - build
+    - client
+    - docs
+    - models
+    - restapi
+
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - G107
+    - G115  # Integer overflow conversion
+    - G402  # support scality DisableSSL
+    - G401  # Use of weak cryptographic primitive
+    - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
+    - '"ok" shadows declaration'
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - gosec
-    - megacheck
     - unconvert
     - goimports
+    - copyloopvar
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
+
     settings:
       printf:
         funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-l
+          - Infof
+          - Warnf
+          - Errorf
+          - Fatalf

--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0 && \ 
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8 && \ 
   go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
   go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
   go install go.uber.org/mock/mockgen@v0.4.0 && \

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller.ocp
+++ b/Dockerfile.assisted-installer-controller.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer.ocp
+++ b/Dockerfile.assisted-installer.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/src/assisted_installer_controller/assisted_installer_controller_test.go
+++ b/src/assisted_installer_controller/assisted_installer_controller_test.go
@@ -355,7 +355,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			listNodes()
 
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
 			Expect(exit).Should(Equal(false))
@@ -494,7 +495,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess(done, hosts)
 			configuringSuccess()
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			exit := assistedController.waitAndUpdateNodesStatus(false)
 			Expect(exit).Should(Equal(false))
@@ -549,7 +551,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("WaitAndUpdateNodesStatus one by one", func() {
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			listNodesOneByOne := func() {
 				kubeNameIdsToReturn := make(map[string]string)
@@ -591,7 +594,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 	Context("UpdateStatusFails and then succeeds", func() {
 		It("UpdateStatus fails and then succeeds, list nodes failed ", func() {
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 			updateProgressSuccessFailureTest := func(stages []models.HostStage, inventoryNamesIds map[string]inventory_client.HostData) {
 				var hostIds []string
@@ -642,7 +646,8 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 			mockk8sclient.EXPECT().ListCsrs().Return(nil, fmt.Errorf("no matter what")).AnyTimes()
 			for name, value := range inventoryNamesIds {
-				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, value.Host.ID, &value.Host.InfraEnvID, gomock.Any()).Times(1)
+				host := value.Host
+				mockRebootsNotifier.EXPECT().Start(gomock.Any(), name, host.ID, &host.InfraEnvID, gomock.Any()).Times(1)
 			}
 
 			go assistedController.WaitAndUpdateNodesStatus(context.TODO(), &wg, false)

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -890,7 +890,7 @@ func (i *installer) checkHostname() error {
 	data := fmt.Sprintf("random-hostname-%s", uuid.New().String())
 	i.log.Infof("Hostname [%s] is invalid, generated random hostname [%s]", hostname, data)
 	if err := i.ops.CreateRandomHostname(data); err != nil {
-		i.log.Errorf("Failed to generate random hostname", err)
+		i.log.Errorf("Failed to generate random hostname, err %s", err)
 		return err
 	}
 	return nil

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -5,10 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 
@@ -187,7 +189,17 @@ grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
 5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
 WkBKOclmOV2xlTVuPw==
 -----END CERTIFICATE-----`)
-	buildPointerIgnition := func(source string, withCert bool) types.Config {
+
+	newTLSTestServer := func(handler http.HandlerFunc) (*httptest.Server, []byte) {
+		ts := httptest.NewTLSServer(handler)
+		caPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: ts.Certificate().Raw,
+		})
+		return ts, caPEM
+	}
+
+	buildPointerIgnition := func(source string, ca []byte) types.Config {
 		ret := types.Config{}
 		ret.Ignition.Version = "3.2.0"
 		ret.Ignition.Config.Merge = append(ret.Ignition.Config.Merge,
@@ -195,20 +207,20 @@ WkBKOclmOV2xlTVuPw==
 				Source: swag.String(source),
 			})
 
-		if !withCert {
+		if len(ca) == 0 {
 			return ret
 		}
 
 		ret.Ignition.Security.TLS.CertificateAuthorities = append(ret.Ignition.Security.TLS.CertificateAuthorities,
 			types.Resource{
-				Source: swag.String(dataurl.EncodeBytes(localhostCert)),
+				Source: swag.String(dataurl.EncodeBytes(ca)),
 			})
 
 		return ret
 	}
 
-	buildPointerIgnitionFile := func(source string, withCert bool) string {
-		cfg := buildPointerIgnition(source, withCert)
+	buildPointerIgnitionFile := func(source string, ca []byte) string {
+		cfg := buildPointerIgnition(source, ca)
 		b, err := json.Marshal(&cfg)
 		Expect(err).ToNot(HaveOccurred())
 		f, err := os.CreateTemp("", "ign")
@@ -220,7 +232,7 @@ WkBKOclmOV2xlTVuPw==
 	}
 	Context("get pointed ignition", func() {
 		checkSource := func(source string) {
-			ignitionPath := buildPointerIgnitionFile(source, true)
+			ignitionPath := buildPointerIgnitionFile(source, localhostCert)
 			defer func() {
 				_ = os.RemoveAll(ignitionPath)
 			}()
@@ -272,8 +284,8 @@ WkBKOclmOV2xlTVuPw==
 			Expect(err).ToNot(HaveOccurred())
 			return string(b)
 		}
-		checkMcsIgnition := func(source string, withCert bool, shouldSucceed bool) {
-			ignitionPath := buildPointerIgnitionFile(source, withCert)
+		checkMcsIgnition := func(source string, ca []byte, shouldSucceed bool) {
+			ignitionPath := buildPointerIgnitionFile(source, ca)
 			defer func() {
 				_ = os.RemoveAll(ignitionPath)
 			}()
@@ -304,27 +316,25 @@ WkBKOclmOV2xlTVuPw==
 			}
 		})
 		It("from bootstrap - non existant URL", func() {
-			checkMcsIgnition("https://127.0.0.1:44", true, false)
+			checkMcsIgnition("https://127.0.0.1:44", localhostCert, false)
 		})
 		It("from bootstrap - success", func() {
-			s := ghttp.NewTLSServer()
-			s.RouteToHandler("GET", "/",
-				func(w http.ResponseWriter, req *http.Request) {
-					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
-					Expect(err).ToNot(HaveOccurred())
-				})
-			checkMcsIgnition(s.URL(), true, true)
-			s.Close()
+			ts, caPEM := newTLSTestServer(func(w http.ResponseWriter, req *http.Request) {
+				_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			defer ts.Close()
+
+			checkMcsIgnition(ts.URL, caPEM, true)
 		})
 		It("from bootstrap - empty response", func() {
-			s := ghttp.NewTLSServer()
-			s.RouteToHandler("GET", "/",
-				func(w http.ResponseWriter, req *http.Request) {
-					_, err := io.WriteString(w, "")
-					Expect(err).ToNot(HaveOccurred())
-				})
-			checkMcsIgnition(s.URL(), true, false)
-			s.Close()
+			ts, caPEM := newTLSTestServer(func(w http.ResponseWriter, req *http.Request) {
+				_, err := io.WriteString(w, "")
+				Expect(err).ToNot(HaveOccurred())
+			})
+			defer ts.Close()
+
+			checkMcsIgnition(ts.URL, caPEM, false)
 		})
 		It("from bootstrap - with http no cert should succeed", func() {
 			s := ghttp.NewServer()
@@ -333,7 +343,7 @@ WkBKOclmOV2xlTVuPw==
 					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
 					Expect(err).ToNot(HaveOccurred())
 				})
-			checkMcsIgnition(s.URL(), false, true)
+			checkMcsIgnition(s.URL(), nil, true)
 			s.Close()
 		})
 		It("from bootstrap - with http with cert should succeed", func() {
@@ -343,31 +353,29 @@ WkBKOclmOV2xlTVuPw==
 					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
 					Expect(err).ToNot(HaveOccurred())
 				})
-			checkMcsIgnition(s.URL(), true, true)
+			checkMcsIgnition(s.URL(), localhostCert, true)
 			s.Close()
 		})
 		It("from bootstrap - with https with cert should succeed", func() {
-			s := ghttp.NewTLSServer()
-			s.RouteToHandler("GET", "/",
-				func(w http.ResponseWriter, req *http.Request) {
-					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
-					Expect(err).ToNot(HaveOccurred())
-				})
-			checkMcsIgnition(s.URL(), true, true)
-			s.Close()
+			ts, caPEM := newTLSTestServer(func(w http.ResponseWriter, req *http.Request) {
+				_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			defer ts.Close()
+
+			checkMcsIgnition(ts.URL, caPEM, true)
 		})
 		It("from bootstrap - with https no cert should fail", func() {
-			s := ghttp.NewTLSServer()
-			s.RouteToHandler("GET", "/",
-				func(w http.ResponseWriter, req *http.Request) {
-					_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
-					Expect(err).ToNot(HaveOccurred())
-				})
-			checkMcsIgnition(s.URL(), false, false)
-			s.Close()
+			ts, _ := newTLSTestServer(func(w http.ResponseWriter, req *http.Request) {
+				_, err := io.WriteString(w, buildMcsIgnition(osImageURL, kernelArguments))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			defer ts.Close()
+
+			checkMcsIgnition(ts.URL, nil, false)
 		})
 		It("embedded - success", func() {
-			checkMcsIgnition(dataurl.EncodeBytes(compress([]byte(buildMcsIgnition(osImageURL, kernelArguments)))), true, true)
+			checkMcsIgnition(dataurl.EncodeBytes(compress([]byte(buildMcsIgnition(osImageURL, kernelArguments)))), localhostCert, true)
 		})
 	})
 })


### PR DESCRIPTION
## Jira Tickets
- https://issues.redhat.com/browse/ACM-24330
- https://issues.redhat.com/browse/ACM-24325

##
Update go version to 1.24 to address cve CVE-2025-47907

##
This PR updates tests to be compatible with Go 1.24 and golangci-lint 1.64.8.
                                                                                                                                                                                       
**TLS test changes (`ops_test.go`)**: Go 1.24 now [enforces a minimum 1024-bit RSA key size](https://tip.golang.org/doc/go1.24#crypto/rsa) for all TLS operations. The old `ghttp.NewTLSServer()` implementation generates certificates that are too weak and fail the new requirement. We've switched to using `httptest.NewTLSServer()` directly, which generates proper 2048-bit certificates. Since these certificates are dynamically generated per test, we had to change the function signatures from `withCert bool` to `ca []byte` to pass the actual certificate bytes through the test helpers.

**Loop variable changes (`assisted_installer_controller_test.go`)**: golangci-lint 1.64.8 includes the [copyloopvar](https://golangci-lint.run/usage/linters/#copyloopvar) linter which catches a common Go gotcha where loop variables are captured by reference in closures. The fix is simple - copy `value.Host` to a local variable before passing its fields to gomock expectations. This ensures each iteration uses the correct host data.
