### PR TITLE
[release-ocm-2.9] - CVE-2025-47907: Upgrade golang to 1.24.6

### DIFF
--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 
 # Workaround for creating build folder
 USER root

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS golang
 
 ENV GOFLAGS=""
 

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod


### PR DESCRIPTION
Security fix for CVE-2025-47907:
Upgrading golang to 1.24.6