### PR TITLE
KONFLUX-6210: fix and set name and cpe label for assisted-installer-acm-ds-2-14

### DIFF
--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -34,6 +34,7 @@ ENTRYPOINT ["/installer"]
 LABEL com.redhat.component="multicluster-engine-assisted-installer-container" \
       name="multicluster-engine/assisted-installer-rhel9" \
       version="${version}" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       upstream-ref="${version}" \
       upstream-url="https://github.com/openshift/assisted-installer" \
       summary="OpenShift Assisted Installer" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
