### PR TITLE
Freshen up dry run mode for the installer/controller

### DIFF
--- a/src/assisted_installer_controller/assisted_installer_controller.go
+++ b/src/assisted_installer_controller/assisted_installer_controller.go
@@ -94,10 +94,10 @@ type ControllerConfig struct {
 	ControlPlaneCount       int    `envconfig:"CONTROL_PLANE_COUNT" required:"false" default:"3"`
 	WaitForClusterVersion   bool   `envconfig:"CHECK_CLUSTER_VERSION" required:"false" default:"false"`
 	MustGatherImage         string `envconfig:"MUST_GATHER_IMAGE" required:"false" default:""`
+	NotifyNumReboots        bool   `envconfig:"NOTIFY_NUM_REBOOTS" default:"false"`
 	DryRunEnabled           bool   `envconfig:"DRY_ENABLE" required:"false" default:"false"`
 	DryFakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH" required:"false" default:""`
 	DryRunClusterHostsPath  string `envconfig:"DRY_CLUSTER_HOSTS_PATH"`
-	NotifyNumReboots        bool   `envconfig:"NOTIFY_NUM_REBOOTS" default:"false"`
 	// DryRunClusterHostsPath gets read parsed into ParsedClusterHosts by DryParseClusterHosts
 	ParsedClusterHosts config.DryClusterHosts
 }

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -220,6 +220,12 @@ func (i *installer) waitForWorkers(ctx context.Context) error {
 		i.log.Error(err)
 		return err
 	}
+
+	if i.DryRunEnabled {
+		// In dry run mode we assume we're not ABI
+		return nil
+	}
+
 	if invoker := common.GetInvoker(kc, i.log); invoker != common.InvokerAgent {
 		return nil
 	}
@@ -399,6 +405,10 @@ func (i *installer) writeImageToDisk(ignitionPath string) error {
 }
 
 func (i *installer) skipMcoReboot(ignitionPath string) {
+	if i.DryRunEnabled {
+		return
+	}
+
 	var mc *mcfgv1.MachineConfig
 	mc, err := i.getEncapsulatedMC(ignitionPath)
 	if err != nil {
@@ -447,9 +457,11 @@ func (i *installer) startBootstrap() error {
 	}
 
 	// reload systemd configurations from filesystem and regenerate dependency trees
-	err = i.ops.SystemctlAction("daemon-reload")
-	if err != nil {
-		return err
+	if !i.DryRunEnabled {
+		err = i.ops.SystemctlAction("daemon-reload")
+		if err != nil {
+			return err
+		}
 	}
 
 	/* in case hostname is illegal (localhost, contains capital letters, etc.), we need to set hostname to
@@ -466,7 +478,7 @@ func (i *installer) startBootstrap() error {
 	// restart NetworkManager to trigger NetworkManager/dispatcher.d/30-local-dns-prepender
 	// we don't do it on SNO because the "local-dns-prepender" is not even
 	// available on none-platform
-	if i.ControlPlaneCount != 1 {
+	if i.ControlPlaneCount != 1 && !i.DryRunEnabled {
 		err = i.ops.SystemctlAction("restart", "NetworkManager.service")
 		if err != nil {
 			i.log.Error(err)
@@ -482,7 +494,7 @@ func (i *installer) startBootstrap() error {
 	// If we're in a pure RHEL/CentOS environment, we need to overlay the node image
 	// first to have access to e.g. oc, kubelet, cri-o, etc...
 	// https://github.com/openshift/enhancements/pull/1637
-	if !i.ops.FileExists(openshiftClientBin) {
+	if !i.ops.FileExists(openshiftClientBin) && !i.DryRunEnabled {
 		err = i.ops.SystemctlAction("start", "--no-block", nodeImagePullService, nodeImageOverlayService)
 		if err != nil {
 			return err
@@ -504,6 +516,9 @@ func (i *installer) startBootstrap() error {
 	}
 
 	servicesToStart := []string{"bootkube.service", "approve-csr.service", "progress.service"}
+	if i.DryRunEnabled {
+		servicesToStart = []string{}
+	}
 	for _, service := range servicesToStart {
 		err = i.ops.SystemctlAction("start", service)
 		if err != nil {
@@ -614,9 +629,12 @@ func (i *installer) waitForControlPlane(ctx context.Context) error {
 	}
 
 	i.waitForBootkube(ctx)
-	if err = i.waitForETCDBootstrap(ctx); err != nil {
-		i.log.Error(err)
-		return err
+
+	if !i.DryRunEnabled {
+		if err = i.waitForETCDBootstrap(ctx); err != nil {
+			i.log.Error(err)
+			return err
+		}
 	}
 
 	// waiting for controller pod to be running

--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -98,7 +98,8 @@ func main() {
 		mockController := gomock.NewController(logger)
 		kc = k8s_client.NewMockK8SClient(mockController)
 		mock, _ := kc.(*k8s_client.MockK8SClient)
-		drymock.PrepareControllerDryMock(mock, logger, o, Options.ControllerConfig.ParsedClusterHosts)
+		drymock.PrepareControllerDryMock(mock, logger, o, Options.ControllerConfig.ParsedClusterHosts,
+			Options.ControllerConfig.ControlPlaneCount)
 	}
 
 	err = kc.SetProxyEnvVars()

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -268,6 +268,14 @@ func (o *ops) configureFirstBootIgnition(liveLogger io.Writer, ignitionPath stri
 }
 
 func (o *ops) WriteImageToExistingRoot(liveLogger io.Writer, ignitionPath string, installerArgs []string) error {
+	if o.installerConfig.DryRunEnabled {
+		// In dry run, we use an executable called dry-installer rather than ostree.
+		// This executable is expected to pretend to be doing coreos-installer stuff and print fake
+		// progress. It's up to the dry-mode user to make sure such executable is available in PATH
+		_, err := o.ExecPrivilegeCommand(liveLogger, dryRunCoreosInstallerExecutable)
+		return err
+	}
+
 	if err := o.remountFilesystems(liveLogger); err != nil {
 		return err
 	}


### PR DESCRIPTION
The installer/controller dry run mode has not been kept up to date with
recent changes. This commit updates the dry run mode to skip actions
that would modify the system, such as writing to disk or starting
services when in dry run mode.

This will avoid damaging the host system when testing the installer in
dry run mode (used by https://github.com/openshift-assisted/assisted-swarm)