### PR TITLE
MGMT-21724: Update Renovate for legacy EL8 Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,18 @@
             ],
             "depNameTemplate": "registry.access.redhat.com/ubi9/go-toolset",
             "datasourceTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.assisted-installer-controller-mce$",
+                "^Dockerfile.assisted-installer-mce$"
+            ],
+            "matchStrings": [
+                "FROM --platform=\\$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:(?<currentValue>.*?) AS builder\\n"
+            ],
+            "depNameTemplate": "registry.access.redhat.com/ubi8/go-toolset",
+            "datasourceTemplate": "docker"
         }
     ],
 
@@ -54,13 +66,19 @@
             "groupName": "Go Builder",
             "addLabels": ["golang"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "allowedVersions": "/^[0-9]+\\.[0-9]+$/"
         },
         {
             "matchUpdateTypes": ["major"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "enabled": false
         },
         {


### PR DESCRIPTION
Adds a regex manager for ubi8/go-toolset in the two *-mce Dockerfiles so release-ocm-2.11 also receives automatic go-toolset bumps. No behavioural change for ubi9 images.