### PR TITLE
MGMT-22042: add cve-automation github app to owners_aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,7 @@ aliases:
     - danmanor
     - giladravid16
     - pastequo
+    - cve-automation
   emeritus_approvers:
     - empovit
     - celebdor


### PR DESCRIPTION
This is required to allow auto merge on cve-automation pull requests