### PR TITLE
MGMT-22042: add cve-automation github app to owners_aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,3 +9,4 @@ aliases:
     - rccrdpccl
     - adriengentil
     - danmanor
+    - cve-automation


### PR DESCRIPTION
This is required to allow auto merge on cve-automation pull requests