### PR TITLE
[release-ocm-2.14] ACM-32566: CVE-2026-34986 Bump github.com/go-jose/go-jose/v3 to v3.0.5 using replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -202,3 +202,5 @@ replace (
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.13.0
 	github.com/sigstore/fulcio => github.com/sigstore/fulcio v1.8.3
 )
+
+replace github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5

--- a/go.sum
+++ b/go.sum
@@ -2099,9 +2099,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gormigrate/gormigrate/v2 v2.1.2/go.mod h1:9nHVX6z3FCMCQPA7PThGcA55t22yKQfK/Dnsf5i7hUo=
 github.com/go-ini/ini v1.66.6/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
-github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
-github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.0.4/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1183,3 +1183,4 @@ sigs.k8s.io/yaml
 # github.com/containerd/containerd => github.com/containerd/containerd v1.7.29
 # github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.13.0
 # github.com/sigstore/fulcio => github.com/sigstore/fulcio v1.8.3
+# github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5


### PR DESCRIPTION
Bump `github.com/go-jose/go-jose/v3` to `v3.0.5` to fix `CVE-2026-34986` using a replace directive

## Strategy Selection

### Strategies Not Applicable

- **Direct dependency version bump**
  Not applicable: dependency is indirect. Direct version bumps only work for explicitly required modules.

- **Direct dependency major version upgrade**
  Not applicable: dependency is indirect. Major version upgrades only apply to direct dependencies.

- **Indirect dependency fix via parent update**
  Exception: Could not get module github.com/go-jose/go-jose/v3 info at /tmp/jj-repos/patch/cache/assisted-service/ws-6f3eeb26-beea9266: go: github.com/openshift/assisted-service/api@v0.0.0 (replaced by ./api): parsing api/go.mod: /tmp/jj-repos/patch/cache/assisted-service/ws-6f3eeb26-beea9266/api/go.mod:13:2: require github.com/openshift/hive/apis: version "aa1db747a6ba" invalid: must be of the form v1.2.3


- **Indirect to direct dependency conversion**
  Attempted to pin github.com/go-jose/go-jose/v3 to a fixed version, but Go reverted it to indirect at v3.0.4. No other module requires this version directly, so the explicit requirement was automatically removed by Go's module resolution.

### ✓ Successful Strategy: Replace directive workaround
Added replace directive to override module resolution. Used as last resort when standard updates fail.

http://issues.redhat.com/browse/ACM-32566
http://issues.redhat.com/browse/ACM-32567