### PR TITLE
[release-ocm-2.15] ACM-32545: CVE-2026-34986 Bump github.com/go-jose/go-jose/v3 to v3.0.5 using replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -201,3 +201,5 @@ replace (
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201022175424-d30c7a274820
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201016155852-4090a6970205
 )
+
+replace github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5

--- a/go.sum
+++ b/go.sum
@@ -2026,8 +2026,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-gormigrate/gormigrate/v2 v2.1.2/go.mod h1:9nHVX6z3FCMCQPA7PThGcA55t22yKQfK/Dnsf5i7hUo=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ini/ini v1.66.6/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
-github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1177,3 +1177,4 @@ sigs.k8s.io/yaml/goyaml.v2
 # sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.5
 # sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201022175424-d30c7a274820
 # sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201016155852-4090a6970205
+# github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5


### PR DESCRIPTION
Bump `github.com/go-jose/go-jose/v3` to `v3.0.5` to fix `CVE-2026-34986` using a replace directive

## Strategy Selection

### Strategies Not Applicable

- **Direct dependency version bump**
  Not applicable: dependency is indirect. Direct version bumps only work for explicitly required modules.

- **Direct dependency major version upgrade**
  Not applicable: dependency is indirect. Major version upgrades only apply to direct dependencies.

- **Indirect dependency fix via parent update**
  Exception: Could not get module github.com/go-jose/go-jose/v3 info at /tmp/jj-repos/patch/cache/assisted-service/ws-6f3eeb26-cfdaed06: go: github.com/openshift/assisted-service/api@v0.0.0 (replaced by ./api): parsing api/go.mod: /tmp/jj-repos/patch/cache/assisted-service/ws-6f3eeb26-cfdaed06/api/go.mod:13:2: require github.com/openshift/hive/apis: version "aa1db747a6ba" invalid: must be of the form v1.2.3


- **Indirect to direct dependency conversion**
  Attempted to pin github.com/go-jose/go-jose/v3 to a fixed version, but Go reverted it to indirect at v3.0.3. No other module requires this version directly, so the explicit requirement was automatically removed by Go's module resolution.

### ✓ Successful Strategy: Replace directive workaround
Added replace directive to override module resolution. Used as last resort when standard updates fail.

http://issues.redhat.com/browse/ACM-32545
http://issues.redhat.com/browse/ACM-32546