### PR TITLE
NO-ISSUE: Update github.com/openshift/hive/apis digest to 6c66e20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/openshift-online/ocm-sdk-go v0.1.467 // indirect
 	github.com/openshift/assisted-service/api v0.0.0 // indirect
-	github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57 // indirect
+	github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3404,8 +3404,8 @@ github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b2
 github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581 h1:YWomd7tA7icznvjpDrSJ8Ksfd0xPWG4E0nEBhvABjSA=
 github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 github.com/openshift/hive/apis v0.0.0-20231220215202-ad99b9e52d27/go.mod h1:RRH8lt09SAiPECNdsbh7Gun0lkcRWi1nYKq6tDp5WxQ=
-github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57 h1:Jk9HVqFTkNNxCB4gaCMaDH4bAYsPuFTwbiPGJy2bKg4=
-github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57/go.mod h1:20tnfMYPSXqVDypUaO2vmxOtFzWj5l2KdZ+zYENpycI=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 h1:R8iA8JQ4k+2dNgseiFoLe3UkokexpUQTNHHb05UIuR4=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
 github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b/go.mod h1:G9yHOogitMOA0R5UWFmFup00E6nik8Sns/tCYYBU7jE=
 github.com/openshift/installer v0.16.1/go.mod h1:VWGgpJgF8DGCKQjbccnigglhZnHtRLCZ6cxqkXN4Ck0=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=

--- a/vendor/github.com/openshift/hive/apis/hive/v1/syncidentityprovider_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/syncidentityprovider_types.go
@@ -19,7 +19,7 @@ type SyncIdentityProviderCommonSpec struct {
 type SelectorSyncIdentityProviderSpec struct {
 	SyncIdentityProviderCommonSpec `json:",inline"`
 
-	// ClusterDeploymentSelector is a LabelSelector indicating which clusters the SelectorIdentityProvider
+	// ClusterDeploymentSelector is a LabelSelector indicating which clusters the SelectorSyncIdentityProvider
 	// applies to in any namespace.
 	// +optional
 	ClusterDeploymentSelector metav1.LabelSelector `json:"clusterDeploymentSelector,omitempty"`
@@ -32,12 +32,12 @@ type SyncIdentityProviderSpec struct {
 	SyncIdentityProviderCommonSpec `json:",inline"`
 
 	// ClusterDeploymentRefs is the list of LocalObjectReference indicating which clusters the
-	// SyncSet applies to in the SyncSet's namespace.
+	// SyncIdentityProvider applies to in the SyncIdentityProvider's namespace.
 	// +required
 	ClusterDeploymentRefs []corev1.LocalObjectReference `json:"clusterDeploymentRefs"`
 }
 
-// IdentityProviderStatus defines the observed state of SyncSet
+// IdentityProviderStatus defines the observed state of the SyncIdentityProvider
 type IdentityProviderStatus struct {
 }
 
@@ -45,7 +45,7 @@ type IdentityProviderStatus struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// SelectorSyncIdentityProvider is the Schema for the SelectorSyncSet API
+// SelectorSyncIdentityProvider is the Schema for the SelectorSyncIdentityProvider API
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
 type SelectorSyncIdentityProvider struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -531,7 +531,7 @@ github.com/openshift/client-go/operator/clientset/versioned
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alpha1
-# github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57
+# github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 ## explicit; go 1.24.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
Update github.com/openshift/hive/apis with proper Go pseudo-version.

See [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.