### PR TITLE
MGMT-24453: upgrade to golang 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.21
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
         - G115
         - G402
         - G602
+        - G118
   exclusions:
     generated: lax
     presets:

--- a/Dockerfile.assisted-installer
+++ b/Dockerfile.assisted-installer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-build
+++ b/Dockerfile.assisted-installer-build
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0 && \
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.4 && \
   go install golang.org/x/tools/cmd/goimports@v0.34.0 && \
   go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
   go install go.uber.org/mock/mockgen@v0.4.0 && \

--- a/Dockerfile.assisted-installer-controller
+++ b/Dockerfile.assisted-installer-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETPLATFORM
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/openshift/assisted-installer

--- a/Dockerfile.assisted-installer-controller-downstream
+++ b/Dockerfile.assisted-installer-controller-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller-mce
+++ b/Dockerfile.assisted-installer-controller-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-controller.ocp
+++ b/Dockerfile.assisted-installer-controller.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/Dockerfile.assisted-installer-downstream
+++ b/Dockerfile.assisted-installer-downstream
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer-mce
+++ b/Dockerfile.assisted-installer-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-installer.ocp
+++ b/Dockerfile.assisted-installer.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer
 ENV GOFLAGS="-mod=vendor"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-installer
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2
- Bump golangci-lint from v2.8.0 to v2.11.4

https://redhat.atlassian.net/browse/MGMT-24453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain from version 1.25 to 1.26 across all build systems and CI pipelines.
  * Updated build container images and associated linting tools to support the new Go version.
  * Refined code quality checks with updated linter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->