### PR TITLE
ACM-38238: Assisted-installer repos: Set Up Set up Renovate configuration to automatically create Hive API Synchronization PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,11 +10,29 @@
     "enabledManagers": [
         "custom.regex",
         "tekton",
-        "rpm-lockfile"
+        "rpm-lockfile",
+        "gomod"
     ],
     "tekton": {
         "fileMatch": [
             "^.tekton/*"
+        ]
+    },
+    "gomod": {
+        "postUpdateOptions": [
+            "gomodUpdateImportPaths",
+            "gomodTidy"
+        ],
+        "packageRules": [
+            {
+                "matchManagers": [
+                    "gomod"
+                ],
+                "matchDepTypes": [
+                    "indirect"
+                ],
+                "enabled": false
+            }
         ]
     },
     "customManagers": [
@@ -167,6 +185,26 @@
             "matchManagers": [
                 "rpm-lockfile"
             ]
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "github.com/openshift/hive/apis"
+            ],
+            "groupName": "Hive API Synchronization",
+            "addLabels": [
+                "hive-api",
+                "api-sync"
+            ],
+            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
Set up Renovate configuration to automatically create Hive API Synchronization PRs.

Adds gomod to enabledManagers with postUpdateOptions (gomodUpdateImportPaths, gomodTidy), disables all gomod updates via packageRules, and enables only github.com/openshift/hive/apis.

Re-applies changes that were reverted by ACM-33186. Renovate issue is now resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation to support Go module management.
  * Disabled indirect and general Go module updates while enabling targeted synchronization for the Hive API module.
  * Added dedicated labeling and grouping for Hive API dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->