### PR TITLE
OCPBUGS-96696: Wait for all nodes to join before exiting for ABI

### DIFF
--- a/src/main/assisted-installer-controller/assisted_installer_main.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main.go
@@ -164,7 +164,7 @@ func main() {
 			wg.Add(1)
 			go assistedController.PostInstallConfigsK8sClient(mainContext, &wg, bootstrapKubeconfigForSNO)
 
-			waitForInstallationAgentBasedInstaller(kc, logger, false)
+			waitForInstallationAgentBasedInstaller(mainContext, kc, logger, false, 0)
 			return
 		}
 		// With the agent-based installer, assisted-service runs on the bootstrap node.
@@ -234,7 +234,7 @@ func main() {
 	// monitoring installation by cluster status
 	switch invoker {
 	case common.InvokerAgent:
-		waitForInstallationAgentBasedInstaller(kc, logger, removeUninitializedTaint)
+		waitForInstallationAgentBasedInstaller(mainContext, kc, logger, removeUninitializedTaint, Options.ControllerConfig.ControlPlaneCount)
 	default:
 		waitForInstallation(client, logger, assistedController)
 	}
@@ -289,7 +289,16 @@ func waitForInstallation(client inventory_client.InventoryClient, log logrus.Fie
 // the inventory client because assisted-service is deployed on the bootstrap node
 // and when the bootstrap node reboots to join the cluster, assisted-service becomes
 // unavailable.
-func waitForInstallationAgentBasedInstaller(kubeClient k8s_client.K8SClient, log logrus.FieldLogger, removeUninitializedTaint bool) {
+//
+// When expectedNodes > 0, the function waits not only for ClusterVersion Available=True
+// but also for all expected nodes to join the cluster. This prevents the controller
+// from exiting before the rendezvous (bootstrap) node has rebooted and joined,
+// which is necessary because the controller's ApproveCsrs goroutine must keep
+// running to approve the rendezvous node's kubelet CSRs.
+func waitForInstallationAgentBasedInstaller(ctx context.Context, kubeClient k8s_client.K8SClient, log logrus.FieldLogger, removeUninitializedTaint bool, expectedNodes int) {
+	clusterVersionAvailable := false
+	ticker := time.NewTicker(waitForInstallationInterval)
+	defer ticker.Stop()
 	for {
 		if removeUninitializedTaint {
 			// After the boostrap node has rebooted, assisted-service becomes unavailable
@@ -310,19 +319,43 @@ func waitForInstallationAgentBasedInstaller(kubeClient k8s_client.K8SClient, log
 				}
 			}
 		}
-		clusterVersion, err := kubeClient.GetClusterVersion()
-		if err != nil {
-			log.WithError(err).Error("Failed to get cluster version from k8s client")
-		}
-		for _, condition := range clusterVersion.Status.Conditions {
-			if condition.Type == "Available" && condition.Status == "True" {
-				// cluster install is complete, we can exit
-				log.Info("ClusterVersion Available=True")
-				return
+		if !clusterVersionAvailable {
+			clusterVersion, err := kubeClient.GetClusterVersion()
+			if err != nil {
+				log.WithError(err).Error("Failed to get cluster version from k8s client")
+			} else {
+				for _, condition := range clusterVersion.Status.Conditions {
+					if condition.Type == "Available" && condition.Status == "True" {
+						clusterVersionAvailable = true
+						log.Info("ClusterVersion Available=True")
+						break
+					}
+				}
 			}
 		}
-		log.Info("ClusterVersion Available!=True, sleeping 30s")
-		time.Sleep(30 * time.Second)
+		if clusterVersionAvailable {
+			if expectedNodes <= 0 {
+				return
+			}
+			nodes, err := kubeClient.ListNodesByRole("master")
+			if err != nil {
+				log.WithError(err).Errorf("Failed to list control-plane nodes while waiting for all nodes to join")
+			} else if len(nodes.Items) >= expectedNodes {
+				log.Infof("All expected control-plane nodes have joined the cluster (%d/%d)", len(nodes.Items), expectedNodes)
+				return
+			} else {
+				log.Infof("Waiting for all control-plane nodes to join the cluster (%d/%d)", len(nodes.Items), expectedNodes)
+			}
+		}
+		if !clusterVersionAvailable {
+			log.Infof("ClusterVersion Available!=True, sleeping %s", waitForInstallationInterval)
+		}
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled, exiting waitForInstallationAgentBasedInstaller")
+			return
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/src/main/assisted-installer-controller/assisted_installer_main_test.go
+++ b/src/main/assisted-installer-controller/assisted_installer_main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -157,10 +158,11 @@ var _ = Describe("installer HostRoleMaster role", func() {
 
 var _ = Describe("installer HostRoleMaster role agent-based installation", func() {
 	var (
-		l             = logrus.New()
-		ctrl          *gomock.Controller
-		mockk8sclient *k8s_client.MockK8SClient
-		kubeNamesIds  map[string]string
+		l                                = logrus.New()
+		ctrl                             *gomock.Controller
+		mockk8sclient                    *k8s_client.MockK8SClient
+		kubeNamesIds                     map[string]string
+		savedWaitForInstallationInterval time.Duration
 	)
 
 	l.SetOutput(io.Discard)
@@ -168,8 +170,11 @@ var _ = Describe("installer HostRoleMaster role agent-based installation", func(
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockk8sclient = k8s_client.NewMockK8SClient(ctrl)
+		savedWaitForInstallationInterval = waitForInstallationInterval
+		waitForInstallationInterval = 10 * time.Millisecond
 	})
 	AfterEach(func() {
+		waitForInstallationInterval = savedWaitForInstallationInterval
 		ctrl.Finish()
 	})
 
@@ -198,7 +203,35 @@ var _ = Describe("installer HostRoleMaster role agent-based installation", func(
 		mockk8sclient.EXPECT().UntaintNode(gomock.Any()).Return(nil).Times(1)
 		mockk8sclient.EXPECT().GetPods(gomock.Any(), gomock.Any(), "").Return([]v1.Pod{}, nil).AnyTimes()
 		mockk8sclient.EXPECT().GetClusterVersion().Return(availableClusterVersionCondition, nil).Times(1)
-		waitForInstallationAgentBasedInstaller(mockk8sclient, l, true)
+		waitForInstallationAgentBasedInstaller(context.Background(), mockk8sclient, l, true, 0)
+	})
+
+	It("waits for all expected nodes to join after ClusterVersion is available", func() {
+		partialNodes := GetKubeNodes(map[string]string{
+			"master-1": "6d6f00e8-70dd-48a5-859a-0f1459485ad1",
+			"master-2": "6d6f00e8-70dd-48a5-859a-0f1459485ad2",
+		})
+		allNodes := GetKubeNodes(map[string]string{
+			"master-0": "6d6f00e8-70dd-48a5-859a-0f1459485ad0",
+			"master-1": "6d6f00e8-70dd-48a5-859a-0f1459485ad1",
+			"master-2": "6d6f00e8-70dd-48a5-859a-0f1459485ad2",
+		})
+
+		mockk8sclient.EXPECT().GetClusterVersion().Return(availableClusterVersionCondition, nil).Times(1)
+		// First call returns only 2 of 3 expected control-plane nodes
+		mockk8sclient.EXPECT().ListNodesByRole("master").Return(partialNodes, nil).Times(1)
+		// Second call returns all 3 control-plane nodes
+		mockk8sclient.EXPECT().ListNodesByRole("master").Return(allNodes, nil).Times(1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		waitForInstallationAgentBasedInstaller(ctx, mockk8sclient, l, false, 3)
+	})
+
+	It("exits immediately when expectedNodes is 0 and ClusterVersion is available", func() {
+		mockk8sclient.EXPECT().GetClusterVersion().Return(availableClusterVersionCondition, nil).Times(1)
+		// ListNodes should not be called when expectedNodes is 0
+		waitForInstallationAgentBasedInstaller(context.Background(), mockk8sclient, l, false, 0)
 	})
 })
 


### PR DESCRIPTION
Fixes the problem with ABI when installing a multi-node cluster. In this case the bootstrap (rendezvous) node is the last to reboot and join the cluster. The waitForInstallationAgentBasedInstaller() function exits as soon as ClusterVersion Available=True, which can happen with N-1 nodes. This cancels the mainContext, stopping the ApproveCsrs goroutine before it can approve the rendezvous node's kubelet CSRs, therefore leaving master-0 permanently unable to join the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent-based installation monitoring to use context-aware polling that stops on cancellation or timeout.
  * Now waits for cluster availability before proceeding, and—when configured—also waits for the expected control-plane node count.
  * For single-node/SNO scenarios, skips node-count checks when no nodes are expected.

* **Tests**
  * Expanded agent-based installer waiting coverage with context usage and interval tuning to verify partial-to-complete node readiness and immediate exit when no node count is expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->